### PR TITLE
[DM-21019] Make a helm chart for nublado

### DIFF
--- a/tools/helm-chart/.helmignore
+++ b/tools/helm-chart/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tools/helm-chart/Chart.yaml
+++ b/tools/helm-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: nublado
+version: 0.1.0

--- a/tools/helm-chart/static/configmap-resourcemap.json
+++ b/tools/helm-chart/static/configmap-resourcemap.json
@@ -1,0 +1,11 @@
+[
+  { "disabled": true,
+    "user": "Username for user with custom resources",
+    "group": "Groupname for group with custom resources",
+    "resources": {
+      "size_index": "integer representing which size container is default: 0 is smallest",
+      "mem_quota": "integer, namespace quota size in MB",
+      "cpu_quota": "integer, namespace quota CPU limit"
+    }
+  }
+]

--- a/tools/helm-chart/static/jupyterhub_config.d
+++ b/tools/helm-chart/static/jupyterhub_config.d
@@ -1,0 +1,1 @@
+../../../jupyterhub/jupyterhub_config/jupyterhub_config.d/

--- a/tools/helm-chart/static/jupyterhub_config.py
+++ b/tools/helm-chart/static/jupyterhub_config.py
@@ -1,0 +1,1 @@
+../../../jupyterhub/jupyterhub_config/jupyterhub_config.py

--- a/tools/helm-chart/templates/_helpers.tpl
+++ b/tools/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nublado.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nublado.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nublado.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nublado.labels" -}}
+app.kubernetes.io/name: {{ include "nublado.name" . }}
+helm.sh/chart: {{ include "nublado.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/tools/helm-chart/templates/fileserver/deployment.yml
+++ b/tools/helm-chart/templates/fileserver/deployment.yml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "nublado.fullname" . }}-fileserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: {{ template "nublado.fullname" . }}-fileserver
+    spec:
+      containers:
+        - name: {{ template "nublado.fullname" . }}-fileserver
+          imagePullPolicy: "Always"
+          image: "lsstsqre/sciplat-fileserver"
+          env:
+            - name: LOGLEVEL
+              value: INFO
+          ports:
+          - name: nfs
+            containerPort: 2049
+          - name: mountd
+            containerPort: 20048
+          - name: rpcbind
+            containerPort: 111              
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: storage
+              mountPath: /exports
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ template "nublado.fullname" . }}-physpvc

--- a/tools/helm-chart/templates/fileserver/mount.yml
+++ b/tools/helm-chart/templates/fileserver/mount.yml
@@ -1,0 +1,46 @@
+# Iterate over the list of mounts in the values
+# and make a document like this for each of them.
+# The reason for the template with the . is that
+# is the currently iterated item.
+{{ $volume_size := .Values.fileserver.shared_volume_size }}
+{{ $name := include "nublado.fullname" . }}
+{{ $namespace := .Release.Namespace }}
+{{- range .Values.fileserver.mounts }}
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  # PersistentVolumes are not namespaced, so you need to have an
+  #  identifier in the name
+  name: {{ $name }}-{{ . }}
+  # Needed (but dangerous) to keep the notebook from freezing.
+  annotations:
+    volume.beta.kubernetes.io/mount-options: "local_lock=all"
+spec:
+  capacity:
+    # Must be a little smaller than the actual PV.
+    storage: {{ $volume_size }}
+  accessModes:
+    - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: fast
+  nfs:
+    server: '{{ $name }}-fileserver.{{ $namespace }}.svc.cluster.local'
+    path: "/exports/{{ . }}"
+
+---
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ $name }}-{{ . }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: {{ $volume_size }}
+  storageClassName: fast
+
+---
+{{- end }}

--- a/tools/helm-chart/templates/fileserver/physpvc.template.yml
+++ b/tools/helm-chart/templates/fileserver/physpvc.template.yml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-physpvc
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{.Values.fileserver.shared_volume_size}}
+  storageClassName: fast
+

--- a/tools/helm-chart/templates/fileserver/service.yml
+++ b/tools/helm-chart/templates/fileserver/service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nublado.fullname" . }}-fileserver
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    name: {{ template "nublado.fullname" . }}-fileserver

--- a/tools/helm-chart/templates/fileserver/storageclass.yml
+++ b/tools/helm-chart/templates/fileserver/storageclass.yml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/tools/helm-chart/templates/jupyterhub/clusterrole.yml
+++ b/tools/helm-chart/templates/jupyterhub/clusterrole.yml
@@ -1,0 +1,12 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub
+rules:
+- apiGroups: [""]
+  resources: ["pods","events", "namespaces", "serviceaccounts",
+  "persistentvolumeclaims", "persistentvolumes", "resourcequotas"]
+  verbs: ["get", "list", "create", "watch", "delete"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "create", "delete"]

--- a/tools/helm-chart/templates/jupyterhub/clusterrolebinding.template.yml
+++ b/tools/helm-chart/templates/jupyterhub/clusterrolebinding.template.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nublado.fullname" . }}-hub
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "nublado.fullname" . }}-hub
+  apiGroup: rbac.authorization.k8s.io

--- a/tools/helm-chart/templates/jupyterhub/configmap-fs-mounts.yml
+++ b/tools/helm-chart/templates/jupyterhub/configmap-fs-mounts.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nublado.fullname" . }}-fs-mounts
+data:
+  mountpoints.json: |
+    [ 
+      {
+        "mountpoint": "/home",
+        "mode": "rw",
+        "kubernetes-volume": "{{ template "nublado.fullname" . }}-home"
+      },
+      { 
+        "mountpoint": "/datasets",
+        "kubernetes-volume": "{{ template "nublado.fullname" . }}-datasets"
+      },
+      { 
+        "mountpoint": "/software",
+        "kubernetes-volume": "{{ template "nublado.fullname" . }}-software"
+      },
+      { 
+        "mountpoint": "/project",
+        "mode": "rw",
+        "kubernetes-volume": "{{ template "nublado.fullname" . }}-project"
+      },
+      { 
+        "mountpoint": "/scratch",
+        "mode": "rw",
+        "kubernetes-volume": "{{ template "nublado.fullname" . }}-scratch"
+      }
+    ]

--- a/tools/helm-chart/templates/jupyterhub/configmap-hub-config.yml
+++ b/tools/helm-chart/templates/jupyterhub/configmap-hub-config.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub-config
+data:
+  {{ $root := . }}
+  jupyterhub_config.py: |-
+    {{ $root.Files.Get "static/jupyterhub_config.py" | trimSuffix "\n" | nindent 4 }}
+
+  {{- (.Files.Glob "static/jupyterhub_config.d/*").AsConfig | nindent 2 }}

--- a/tools/helm-chart/templates/jupyterhub/configmap-jwt-cert.yml
+++ b/tools/helm-chart/templates/jupyterhub/configmap-jwt-cert.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nublado.fullname" . }}-jwt-cert
+data:
+  signing-certificate.pem: |-
+    {{ .Files.Get "static/signing-certificate.pem" | b64enc }}

--- a/tools/helm-chart/templates/jupyterhub/configmap-resourcemap.yml
+++ b/tools/helm-chart/templates/jupyterhub/configmap-resourcemap.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nublado.fullname" . }}-resourcemap
+data:
+  resourcemap.json: |-
+    {{ .Files.Get "static/configmap-resourcemap.json" | b64enc }}

--- a/tools/helm-chart/templates/jupyterhub/dask/dask-role.template.yml
+++ b/tools/helm-chart/templates/jupyterhub/dask/dask-role.template.yml
@@ -1,0 +1,8 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-dask
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "create", "delete"]

--- a/tools/helm-chart/templates/jupyterhub/dask/dask-rolebinding.template.yml
+++ b/tools/helm-chart/templates/jupyterhub/dask/dask-rolebinding.template.yml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-dask
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nublado.fullname" . }}-dask
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ template "nublado.fullname" . }}-dask
+  apiGroup: ""
+

--- a/tools/helm-chart/templates/jupyterhub/dask/dask-serviceaccount.yml
+++ b/tools/helm-chart/templates/jupyterhub/dask/dask-serviceaccount.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "nublado.fullname" . }}-dask

--- a/tools/helm-chart/templates/jupyterhub/deployment.template.yml
+++ b/tools/helm-chart/templates/jupyterhub/deployment.template.yml
@@ -1,0 +1,269 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: {{ template "nublado.fullname" . }}-hub
+    spec:
+      serviceAccountName: {{ template "nublado.fullname" . }}-hub
+      securityContext:
+        runAsUser: {{ .Values.hub.uid }}
+        runAsGroup: {{ .Values.hub.gid }}
+        fsGroup: {{ .Values.hub.gid }}
+      containers:
+        - name: {{ template "nublado.fullname" . }}-hub
+          imagePullPolicy: "Always"
+          image: "lsstsqre/sciplat-hub"
+          resources:
+            limits:
+              memory: 2G
+              cpu: 2.0
+            requests:
+              memory: 1G
+              cpu: 0.8
+          ports:
+            - containerPort: 8081
+              name: api
+          env:
+            - name: LOGLEVEL
+              value: INFO
+            - name: FQDN
+              value: '{{.Values.fqdn}}'
+            # Set to non-empty value to enable debugging.
+            - name: DEBUG
+              value: '{{.Values.debug}}'
+            # One of "github", "cilogon", or "jwt"
+            - name: OAUTH_PROVIDER
+              value: '{{.Values.oauth_provider}}'
+            # If set, enables running lab containers with k8s privileges
+            #  to start/stop/list containers (to spawn dask worker pods)
+            - name: ALLOW_DASK_SPAWN
+              value: '{{.Values.dask.allow_spawn}}'
+            # If set, restricts lab or dask to run on containers with
+            #  labels 'jupyterlab: ok' or 'dask: ok'
+            - name: RESTRICT_LAB_NODES
+              value: '{{.Values.lab.restrict_nodes}}'
+            - name: RESTRICT_DASK_NODES
+              value: '{{.Values.dask.restrict_nodes}}'
+            # Maximum number of dask worker pods
+            - name: MAX_DASK_WORKERS
+              value: '{{.Values.dask.max_workers}}'
+            # Set to customize what repo and what images to scan.
+            - name: LAB_REPO_HOST
+              value: '{{.Values.lab.image.repo_host}}'
+            - name: LAB_REPO_OWNER
+              value: '{{.Values.lab.image.repo_owner}}'
+            - name: LAB_REPO_NAME
+              value: '{{.Values.lab.image.repo_name}}'
+            # Set if you want to change number of experimentals/dailies/
+            #  weeklies/releases prepulled and displayed in menu
+            #  (usually 0/3/2/1)
+            - name: PREPULLER_EXPERIMENTALS
+              value: '{{.Values.lab.image.experimentals}}'
+            - name: PREPULLER_DAILIES
+              value: '{{.Values.lab.image.dailies}}'
+            - name: PREPULLER_WEEKLIES
+              value: '{{.Values.lab.image.weeklies}}'
+            - name: PREPULLER_RELEASES
+              value: '{{.Values.lab.image.releases}}'
+            # Set if you do not want to scan a repository for images.
+            - name: LAB_IMAGE
+              value: '{{.Values.lab.image_name}}'
+            # Set if you want something other than 12 hours.  Setting to
+            # zero or a negative value disables.
+            - name: LAB_IDLE_TIMEOUT
+              value: '{{.Values.lab.idle_timeout}}'
+            - name: LAB_MEM_LIMIT
+              value: '{{.Values.lab.resources.mem_limit}}'
+            - name: LAB_CPU_LIMIT
+              value: '{{.Values.lab.resources.cpu_limit}}'
+            - name: LAB_MEM_GUARANTEE
+              value: '{{.Values.lab.resources.mem_guarantee}}'
+            - name: LAB_CPU_GUARANTEE
+              value: '{{.Values.lab.resources.cpu_guarantee}}'
+            - name: LAB_NODEJS_MAX_MEM
+              value: '{{.Values.lab.resources.nodejs_max_mem}}'
+            - name: TINY_CPU_MAX
+              value: '{{.Values.lab.resources.tiny_cpu_max}}'
+            - name: MB_PER_CPU
+              value: '{{.Values.lab.resources.mb_per_cpu}}'
+            - name: LAB_SIZE_RANGE
+              value: '{{.Values.lab.resources.size_range}}'
+            - name: JUPYTERLAB_CONFIG_DIR
+              value: '/opt/lsst/software/jupyterhub/config'
+            - name: HUB_ROUTE
+              value: '{{.Values.routes.hub}}'
+            - name: FIREFLY_ROUTE
+              value: '{{.Values.routes.firefly}}'
+            - name: JS9_ROUTE
+              value: '{{.Values.routes.js9}}'
+            - name: API_ROUTE
+              value: '{{.Values.routes.api}}'
+            - name: TAP_ROUTE
+              value: '{{.Values.routes.tap}}'
+            - name: SODA_ROUTE
+              value: '{{.Values.routes.soda}}'
+            - name: AUTO_REPO_URLS
+              value: '{{.Values.lab.repos}}'
+            - name: SIZE_INDEX
+              value: '{{.Values.lab.resources.size_index}}'
+            - name: EXTERNAL_FILESERVER_IP
+            {{ if .Values.routes.external.fileserver }}
+              value: '{{.Values.routes.external.fileserver }}'
+            {{ else }}
+              value: '{{ template "nublado.fullname" . }}-fileserver.{{.Release.Namespace}}.svc.cluster.local'
+            {{ end }}
+            - name: EXTERNAL_FIREFLY_URL
+              value: '{{.Values.routes.external.firefly}}'
+            - name: EXTERNAL_JS9_URL
+              value: '{{.Values.routes.external.js9}}'
+            - name: EXTERNAL_INSTANCE_URL
+              value: '{{.Values.routes.external.instance}}'
+            - name: EXTERNAL_API_URL
+              value: '{{.Values.routes.external.api}}'
+            - name: EXTERNAL_SODA_URL
+              value: '{{.Values.routes.external.soda}}'
+            - name: EXTERNAL_HUB_URL
+              value: '{{.Values.routes.external.hub}}'
+            - name: PROXY_SERVICE_HOST
+              value: '{{ template "nublado.fullname" . }}-proxy.{{.Release.Namespace}}'
+            - name: PROXY_SERVICE_PORT_API
+              value: '8081'
+            - name: HUB_SERVICE_HOST
+              value: '{{ template "nublado.fullname" . }}-hub.{{.Release.Namespace}}'
+            - name: PROXY_SERVICE_PORT_API
+              value: '8001'
+            - name: GITHUB_ORGANIZATION_WHITELIST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: github_organization_whitelist
+            - name: CILOGON_GROUP_WHITELIST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: cilogon_group_whitelist
+            - name: GITHUB_ORGANIZATION_DENYLIST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: github_organization_denylist
+                  optional: true
+            - name: CILOGON_GROUP_DENYLIST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: cilogon_group_denylist
+                  optional: true
+            - name: OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: oauth_client_id
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: oauth_secret
+            - name: OAUTH_CALLBACK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: oauth_callback_url
+            # You want this if you're using CILogon rather than GitHub
+            #  and not using 'cilogon.org'
+            # - name: CILOGON_HOST
+            #   value: 'test.cilogon.org'
+            # Use this to restrict the list of available ID Providers
+            #- name: CILOGON_IDP_SELECTION
+            #  value: 'https://idp.ncsa.illinois.edu/idp/shibboleth'
+            # Use this to set the CILogon skin
+            #- name: CILOGON_SKIN
+            #  value: 'LSST'
+            # This may contain credentials, so it should be a secret
+            - name: SESSION_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: session_db_url
+            # This is one or more 32-byte encryption keys (separated
+            # with ';') needed to persist auth_state.  They can be
+            # base64 or hex-encoded.  Two lets you do key rotation
+            - name: JUPYTERHUB_CRYPT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: jupyterhub_crypto_key
+            - name: CONFIGPROXY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: configproxy_auth_token
+          # If you use sqlite, you want this to persist sessions across
+          #  jupyterhub restarts.
+          volumeMounts:
+            - name: home-jovyan
+              mountPath: /home/jovyan
+            - name: hub-config
+              mountPath: /opt/lsst/software/jupyterhub/config
+            - name: fs-mounts
+              mountPath: /opt/lsst/software/jupyterhub/mounts
+            - name: resourcemap
+              mountPath: /opt/lsst/software/jupyterhub/resources
+            - name: jwt-cert
+              mountPath: /opt/jwt
+              readOnly: true
+      volumes:
+        - name: home-jovyan
+          persistentVolumeClaim:
+           claimName: {{ template "nublado.fullname" . }}-hub-physpvc
+        - name: hub-config
+          configMap:
+            name: {{ template "nublado.fullname" . }}-hub-config
+            #  Create with `kubectl create configmap hub-config \
+            #   --from-file=config/jupyterhub_config.py \
+            #   --from-file=config/jupyterhub_config.d`
+            #  It is sort of annoying that you still have to specify
+            #   each file in the directory.
+            items:
+            - key: jupyterhub_config.py
+              path: jupyterhub_config.py
+            - key: 00-preamble.py
+              path: jupyterhub_config.d/00-preamble.py
+            - key: 10-authenticator.py
+              path: jupyterhub_config.d/10-authenticator.py
+            - key: 20-spawner.py
+              path: jupyterhub_config.d/20-spawner.py
+            - key: 30-environment.py
+              path: jupyterhub_config.d/30-environment.py
+        - name: jwt-cert
+          configMap:
+              #  Create with `kubectl create configmap jwt-cert \
+              #   --from-file=config/signing-certificate.pem`
+            defaultMode: 420
+            items:
+            - key: signing-certificate.pem
+              path: signing-certificate.pem
+            name: {{ template "nublado.fullname" . }}-jwt-cert
+        - name: fs-mounts
+          configMap:
+              #  Create with `kubectl create configmap fs-mounts \
+              #   --from-file=config/mountpoints.json`
+            defaultMode: 420
+            items:
+            - key: mountpoints.json
+              path: mountpoints.json
+            name: {{ template "nublado.fullname" . }}-fs-mounts
+        - name: resourcemap
+          configMap:
+              #  Create with `kubectl create configmap resourcemap \
+              #   --from-file=config/resourcemap.json`
+            defaultMode: 420
+            items:
+            - key: resourcemap.json
+              path: resourcemap.json
+            name: {{ template "nublado.fullname" . }}-resourcemap

--- a/tools/helm-chart/templates/jupyterhub/physpvc.yml
+++ b/tools/helm-chart/templates/jupyterhub/physpvc.yml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+annotations:
+  pv.beta.kubernetes.io/gid: {{ .Values.hub.gid }}
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub-physpvc
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/tools/helm-chart/templates/jupyterhub/role.template.yml
+++ b/tools/helm-chart/templates/jupyterhub/role.template.yml
@@ -1,0 +1,8 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub
+rules:
+- apiGroups: [""]
+  resources: ["pods","events"]
+  verbs: ["get", "list", "create", "watch", "delete"]

--- a/tools/helm-chart/templates/jupyterhub/rolebinding.template.yml
+++ b/tools/helm-chart/templates/jupyterhub/rolebinding.template.yml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nublado.fullname" . }}-hub
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ template "nublado.fullname" . }}-hub
+  apiGroup: ""
+

--- a/tools/helm-chart/templates/jupyterhub/secrets.template.yml
+++ b/tools/helm-chart/templates/jupyterhub/secrets.template.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub
+type: Opaque
+stringData:
+  oauth_client_id: '{{ .Values.oauth_client_id}}'
+  oauth_secret: '{{.Values.oauth_secret}}'
+  oauth_callback_url: '{{.Values.scheme}}{{.Values.fqdn}}{{.Values.routes.hub}}/hub/oauth_callback'
+  github_organization_whitelist: '{{.Values.github_organization_whitelist}}'
+  github_organization_denylist: '{{.Values.github_organization_denylist}}'
+  cilogon_group_whitelist: '{{.Values.cilogon_group_whitelist}}'
+  cilogon_group_denylist: '{{.Values.cilogon_group_denylist}}'
+  session_db_url: '{{.Values.session_db_url}}'
+  {{- if .Values.hub.crypto_key }}
+  jupyterhub_crypto_key: '{{.Values.hub.crypto_key}}'
+  {{- else }}
+  jupyterhub_crypto_key: '{{ randAlphaNum 32 | b64enc }}'
+  {{- end }}
+
+  {{- if .Values.hub.proxy_auth_token }}
+  configproxy_auth_token: '{{.Values.hub.proxy_auth_token}}'
+  {{- else }}
+  configproxy_auth_token: '{{randAlphaNum 32 | b64enc }}:{{randAlphaNum 32 | b64enc }}'
+  {{- end }}

--- a/tools/helm-chart/templates/jupyterhub/service.yml
+++ b/tools/helm-chart/templates/jupyterhub/service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub
+  labels:
+    name: {{ template "nublado.fullname" . }}-hub
+spec:
+  type: NodePort
+  ports:
+  - name: api
+    port: 8081
+    targetPort: 8081
+    protocol: TCP
+  selector:
+    name: {{ template "nublado.fullname" . }}-hub

--- a/tools/helm-chart/templates/jupyterhub/serviceaccount.yml
+++ b/tools/helm-chart/templates/jupyterhub/serviceaccount.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "nublado.fullname" . }}-hub

--- a/tools/helm-chart/templates/jupyterhubproxy/deployment.template.yml
+++ b/tools/helm-chart/templates/jupyterhubproxy/deployment.template.yml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "nublado.fullname" . }}-proxy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: {{ template "nublado.fullname" . }}-proxy
+    spec:
+      serviceAccountName: {{ template "nublado.fullname" . }}-hub
+      containers:
+        - name: {{ template "nublado.fullname" . }}-hub
+          imagePullPolicy: "Always"
+          image: "jupyterhub/configurable-http-proxy"
+          command:
+            - configurable-http-proxy
+            - --ip=0.0.0.0
+            - --api-ip=0.0.0.0
+            - --api-port=8001
+            - --default-target=http://{{ template "nublado.fullname" . }}-hub:8081
+            - --error-target=http://{{ template "nublado.fullname" . }}-hub:8081/hub/error
+            - --port=8000
+          env:
+            - name: CONFIGPROXY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "nublado.fullname" . }}-hub
+                  key: configproxy_auth_token
+            - name: NODE_OPTIONS
+              value: "--max-http-header-size={{ .Values.proxy.max_http_header_size }}"
+              # This needs to be 16K or more for JWT.  Value is in bytes.
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 200m
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8001
+              name: api

--- a/tools/helm-chart/templates/jupyterhubproxy/ingress.template.yml
+++ b/tools/helm-chart/templates/jupyterhubproxy/ingress.template.yml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "nublado.fullname" . }}-proxy
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0m"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.routes.hub }}/$2
+    #
+    # If you're doing JWT auth, you also need:
+    #
+    # nginx.ingress.kubernetes.io/auth-url: https://{{ .Values.fqdn }}/auth\
+    #  ?capability=exec:notebook&reissue_token=true
+    #
+    # Also make sure that MAX_HTTP_HEADER_SIZE is set to at least 16384
+    # in the deployment configuration if you are doing JWT.
+    #
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Port 443;
+      proxy_set_header X-Forwarded-Path {{ .Values.routes.hub }};
+    #
+    # And for JWT, add:
+    #
+    # auth_request_set $auth_token $upstream_http_x_auth_request_token;
+    # proxy_set_header X-Portal-Authorization "Bearer $auth_token";
+    # error_page 403 = "https://{{ .Values.fqdn }}/oauth2/start?rd=$request_uri";
+    #
+spec:
+  rules:
+  - host: {{ .Values.fqdn }}
+    http:
+      paths:
+      - path: {{ .Values.routes.hub }}(/|$)(.*)
+        backend:
+          serviceName: {{ template "nublado.fullname" . }}-proxy
+          servicePort: 8000

--- a/tools/helm-chart/templates/jupyterhubproxy/service.yml
+++ b/tools/helm-chart/templates/jupyterhubproxy/service.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nublado.fullname" . }}-proxy
+  labels:
+    name: {{ template "nublado.fullname" . }}-proxy
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000
+    protocol: TCP
+  - name: api
+    port: 8001
+    targetPort: 8001
+    protocol: TCP
+  selector:
+    name: {{ template "nublado.fullname" . }}-proxy

--- a/tools/helm-chart/templates/prepuller/clusterrole.yml
+++ b/tools/helm-chart/templates/prepuller/clusterrole.yml
@@ -1,0 +1,9 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # Cluster roles not namespaced
+  name: {{ template "nublado.fullname" . }}-prepuller
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]

--- a/tools/helm-chart/templates/prepuller/clusterrolebinding.template.yml
+++ b/tools/helm-chart/templates/prepuller/clusterrolebinding.template.yml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-prepuller
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nublado.fullname" . }}-prepuller
+  namespace: {{ .Release.Namespace }}
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: {{ template "nublado.fullname" . }}-prepuller
+  apiGroup: ""
+

--- a/tools/helm-chart/templates/prepuller/cronjob.template.yml
+++ b/tools/helm-chart/templates/prepuller/cronjob.template.yml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "nublado.fullname" . }}-prepuller
+spec:
+  schedule: "{{.Values.prepuller.minute_to_run}} * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: "Never"
+          serviceAccountName: {{ template "nublado.fullname" . }}-prepuller
+          securityContext:
+            # Run as provisionator, not root.
+            runAsUser: {{ .Values.prepuller.uid }}
+            runAsGroup: {{ .Values.prepuller.gid }}
+          containers:
+            - name: {{ template "nublado.fullname" . }}-prepuller
+              imagePullPolicy: "Always"
+              image: "lsstsqre/prepuller"
+              env:
+              - name: DEBUG
+                value: "{{.Values.debug}}"
+              # image_list and no_scan can be used to completely replace
+              #  the prepull repository scan with a static list of images.
+              - name: PREPULLER_IMAGE_LIST
+                value: "{{.Values.lab.image_name}}"
+              - name: PREPULLER_NO_SCAN
+                value: "{{.Values.lab.image_name}}"
+              # Use the next three with your own image with an LSST/DM
+              #  dated tag format ( [d|w][YYYYMMDD] or r[MajMin])
+              - name: PREPULLER_REPO
+                value: "{{.Values.lab.image.repo_host}}"
+              - name: PREPULLER_OWNER
+                value: "{{.Values.lab.image.repo_owner}}"
+              - name: PREPULLER_IMAGE_NAME
+                value: "{{.Values.lab.image.image_name}}"
+              # Normally 0/3/2/1
+              - name: PREPULLER_EXPERIMENTALS
+                value: "{{.Values.lab.image.experimentals}}"
+              - name: PREPULLER_DAILIES
+                value: "{{.Values.lab.image.dailies}}"
+              - name: PREPULLER_WEEKLIES
+                value: "{{.Values.lab.image.weeklies}}"
+              - name: PREPULLER_RELEASES
+                value: "{{.Values.lab.image.releases}}"
+              # Probably won't need to change any of these.
+              - name: PREPULLER_INSECURE
+                value: ""
+              - name: PREPULLER_PORT
+                value: ""
+              - name: PREPULLER_SORT_FIELD
+                value: ""
+              - name: PREPULLER_COMMAND
+                value: ""
+              - name: PREPULLER_NAMESPACE
+                value: "{{.Release.Namespace}}"
+              - name: ALLOW_DASK_SPAWN
+                value: "{{.Values.dask.allow_spawn}}"
+              - name: RESTRICT_LAB_NODES
+                value: "{{.Values.lab.restrict_nodes}}"
+              - name: RESTRICT_DASK_NODES
+                value: "{{.Values.lab.restrict_dask}}"

--- a/tools/helm-chart/templates/prepuller/role.template.yml
+++ b/tools/helm-chart/templates/prepuller/role.template.yml
@@ -1,0 +1,9 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "nublado.fullname" . }}-prepuller
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "create", "update", "delete"]

--- a/tools/helm-chart/templates/prepuller/rolebinding.template.yml
+++ b/tools/helm-chart/templates/prepuller/rolebinding.template.yml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "nublado.fullname" . }}-prepuller
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nublado.fullname" . }}-prepuller
+  namespace: {{ .Release.Namespace }}
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ template "nublado.fullname" . }}-prepuller
+  apiGroup: ""

--- a/tools/helm-chart/templates/prepuller/serviceaccount.yml
+++ b/tools/helm-chart/templates/prepuller/serviceaccount.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "nublado.fullname" . }}-prepuller

--- a/tools/helm-chart/values.yaml
+++ b/tools/helm-chart/values.yaml
@@ -1,0 +1,108 @@
+# Default values for nublado.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Variables you absolutely need (with examples commented out):
+#fqdn: 'test.lsst.rocks'
+scheme: 'http://'
+
+# GitHub Application settings for OAuth apps
+# Get these from github.com OAuth settings by creating an app
+#oauth_client_id: 'f457c71304e31654c665'
+#oauth_secret: '2eb0f52c3a416f7286287e498599214d451fef2d'
+
+# Set up debugging, set to enable
+debug: 'true'
+
+# OAuth provider to use: 
+# One of "github", "cilogon", or "jwt"
+oauth_provider: 'github'
+
+# Allow and deny lists
+github_organization_whitelist: ''
+github_organization_denylist: ''
+cilogon_group_whitelist: ''
+cilogon_group_denylist: ''
+
+hub:
+  uid: 768
+  gid: 768
+  #proxy_auth_token: ''
+  #crypto_key: ''
+
+# Dask settings
+dask:
+  allow_spawn: 'true'
+  restrict_nodes: ''
+  max_workers: 25
+
+lab:
+  restrict_nodes: ''
+
+  # If you don't want to use the prepuller to scan for images, put in a full
+  # image here.
+  # image_name: 'lsstsqre/sciplat-lab:latest'
+  image_name: ''
+
+  # Configure the scanner to find images to put in the spawner
+  image:
+    repo_host: ''
+    repo_owner: 'lsstsqre'
+    repo_name: 'sciplat-lab'
+
+    # Number of images of each type to put in the spawner page
+    experimentals: 0
+    dailies: 3
+    weeklies: 2
+    releases: 1
+
+  resources:
+    cpu_limit: 1.0
+    mem_limit: '2048M'
+    cpu_guarantee: 0.02
+    mem_guarantee: '64K'
+    # what are these for?
+    #nodejs_max_mem: ''
+    #tiny_cpu_max: ''
+    #mb_per_cpu: ''
+    size_range: 4
+    size_index: 1
+
+  # How long to wait before reaping idle container (in seconds)
+  idle_timeout: 43200
+
+  repos: 'https://github.com/lsst-sqre/notebook-demo'
+
+proxy:
+  max_http_header_size: 16384
+
+routes:
+  hub: '/nb'
+  firefly: '/firefly'
+  js9: '/js9'
+  api: '/api'
+  tap: '/api/tap'
+  soda: '/api/soda'
+  
+  external:
+    fileserver: ''
+    firefly: ''
+    js9: ''
+    instance: ''
+    api: ''
+    soda: ''
+    hub: ''
+
+fileserver:
+  mounts:
+    - home
+    - datasets
+    - project
+    - scratch
+    - software
+  shared_volume_size: '10Gi'
+
+prepuller:
+  minute_to_run: 35
+  uid: 769
+  gid: 769


### PR DESCRIPTION
Starting from the current deployment tool, make a helm chart.
This gets rid of some of the things from the deployment scope,
such as DNS, TLS, nginx ingress, etc.  This is just to put it
into an existing cluster that has ingress already set up.