### PR TITLE
[DM-21332] Allow for number of images to be 0

### DIFF
--- a/jupyterhub/sample_configs/20-spawner.py
+++ b/jupyterhub/sample_configs/20-spawner.py
@@ -63,10 +63,10 @@ class LSSTSpawner(namespacedkubespawner.NamespacedKubeSpawner):
         owner = os.getenv("LAB_REPO_OWNER") or "lsstsqre"
         name = os.getenv("LAB_REPO_NAME") or "sciplat-lab"
         host = os.getenv("LAB_REPO_HOST") or "hub.docker.com"
-        experimentals = int(os.getenv("PREPULLER_EXPERIMENTALS") or 0)
-        dailies = int(os.getenv("PREPULLER_DAILIES") or 3)
-        weeklies = int(os.getenv("PREPULLER_WEEKLIES") or 2)
-        releases = int(os.getenv("PREPULLER_RELEASES") or 1)
+        experimentals = int(os.getenv("PREPULLER_EXPERIMENTALS", 0))
+        dailies = int(os.getenv("PREPULLER_DAILIES", 3))
+        weeklies = int(os.getenv("PREPULLER_WEEKLIES", 2))
+        releases = int(os.getenv("PREPULLER_RELEASES", 1))
         cachefile = os.getenv("HOME") + "/repo-cache.json"
         debug = False
         if os.getenv("DEBUG"):


### PR DESCRIPTION
Since 0 evaluates to false, if you pass it in, then it uses the
or.  Instead, use the second parameter of os.getenv, which is
what to return if the environment variable isn't set.