### PR TITLE
[DM-21348] Turn on NFSv4 for fileserver

### DIFF
--- a/fileserver/exports
+++ b/fileserver/exports
@@ -1,7 +1,7 @@
-/exports/         *(ro,fsid=0)
-/exports/home     *(rw,insecure,no_root_squash)
-/exports/scratch  *(rw,insecure,no_root_squash)
-/exports/project  *(rw,insecure,no_root_squash)
-/exports/datasets *(ro,insecure)
-/exports/software *(ro,insecure)
+/exports/         *(rw,fsid=0,sec=sys,no_root_squash)
+/exports/home     *(rw,insecure,sec=sys,no_root_squash)
+/exports/scratch  *(rw,insecure,sec=sys,no_root_squash)
+/exports/project  *(rw,insecure,sec=sys,no_root_squash)
+/exports/datasets *(ro,insecure,sec=sys)
+/exports/software *(ro,insecure,sec=sys)
 

--- a/fileserver/run_nfs.sh
+++ b/fileserver/run_nfs.sh
@@ -60,12 +60,12 @@ function start()
 
     mount -t nfsd nfds /proc/fs/nfsd
 
-    # -V 3: enable NFSv3
-    /usr/sbin/rpc.mountd -N 2 -V 3
+    # -N 2 -V 3 -V 4: enable NFSv3, NFSv4, disable v2
+    /usr/sbin/rpc.mountd -N 2 -V 3 -V 4
 
     /usr/sbin/exportfs -r
     # -G 10 to reduce grace time to 10 seconds (the lowest allowed)
-    /usr/sbin/rpc.nfsd -G 10 -N 2 -V 3
+    /usr/sbin/rpc.nfsd -G 10 -N 2 -V 3 -V 4
     /usr/sbin/rpc.statd --no-notify
     echo "NFS started"
 }


### PR DESCRIPTION
This allows us to run a fileserver that supports NFSv4.

The exports file is particularly important.  The first line, with
fsid=0 is important, since it is the root of what is exported.
If this isn't rw, then nothing under it can be rw.  If this isn't
no_root_squash, then everything under it can't be no_root_squash,
even if explicitly saying otherwise.  sec=sys tells NFS to not
try to map the account names to their UIDs (which NFSv4 supports,
to allow for the same user with different UIDs on the server
and client to work seamlessly).  Since the fileserver doesn't
have these accounts, this won't work.  We just want to trust the
uid like NFSv3, which is done by sec=sys.  This also must be on
the /exports otherwise it doesn't seem to be respected.

When mounting this on NFSv4, you would mount /home, not /exports/home,
which is different than v3, just to make it a little more confusing.