### PR TITLE
DM-41595: Use ruff format instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/psf/black
-    rev: 23.10.1
-    hooks:
-      - id: black
-        args: [--config, pyproject.toml]
+      - id: ruff-format
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,23 @@ ignore = [
     "TID252",  # if we're going to use relative imports, use them always
     "TRY003",  # good general advice but lint is way too aggressive
     "TRY301",  # sometimes raising exceptions inside try is the best flow
+
+    # The following settings should be disabled when using ruff format
+    # per https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
 ]
 select = ["ALL"]
 target-version = "py311"
@@ -126,7 +143,6 @@ known-first-party = [
     "rubin.nublado.spawner",
     "tests",
 ]
-split-on-trailing-comma = false
 
 [tool.ruff.flake8-bugbear]
 extend-immutable-calls = [


### PR DESCRIPTION
Ruff can now also do formatting, so use it and reduce the number of linter programs we use. Disable the Ruff warnings that the Ruff documentation says should be disabled when using ruff format.

We unfortunately still have to use black via blacken-docs for formatting examples in documentation. A native Ruff replacement is still some time off.