### PR TITLE
DM-41613: Harden lab spawning against event watch errors

### DIFF
--- a/controller/src/controller/exceptions.py
+++ b/controller/src/controller/exceptions.py
@@ -303,7 +303,11 @@ class KubernetesError(SlackException):
                 obj = f"{kind}{self.name}"
             message.blocks.append(SlackTextBlock(heading="Object", text=obj))
         elif self.kind:
-            block = SlackTextBlock(heading="Object", text=self.kind)
+            if self.namespace:
+                obj = f"{self.kind} in namespace {self.namespace}"
+            else:
+                obj = self.kind
+            block = SlackTextBlock(heading="Object", text=obj)
             message.blocks.append(block)
         if self.body:
             code = SlackCodeBlock(heading="Error", code=self.body)


### PR DESCRIPTION
We saw one production exception indicating the Kubernetes API returned a 410 error on an event watch during lab startup, even though no resourceVersion was specified. Various things on-line indicate that this is known and expected for long-lasting watches, although this particular watch shouldn't have lasted long enough to trigger it.

Nonetheless, the correct behavior appears to be to retry all 410 errors even if no resourceVersion was set. Do that, but add a one second delay so that we don't spam the Kubernetes API with requests if all requests are returning 410.

Improve exception reporting when a namespace and object type are set but no object name, which is common with watches.

The pod event watch is purely informational, but we were aborting the spawn if the event watch died with an error. Swallow that error, log it, report it to Slack, but then let the event watch quietly die and continue waiting for the lab to spawn.