### PR TITLE
DM-41622: Add more timeouts on Kubernetes operations

### DIFF
--- a/controller/src/controller/storage/kubernetes/fileserver.py
+++ b/controller/src/controller/storage/kubernetes/fileserver.py
@@ -119,10 +119,13 @@ class FileserverStorage:
         ------
         KubernetesError
             Raised if there is some failure in a Kubernetes API call.
+        TimeoutError
+            Raised if the deletion of any individual object took longer than
+            the Kubernetes delete timeout.
         """
         await self._gafaelfawr.delete(name, namespace, wait=True)
         await self._ingress.wait_for_deletion(name, namespace)
-        await self._service.delete(name, namespace)
+        await self._service.delete(name, namespace, wait=True)
         await self._job.delete(name, namespace, wait=True)
 
     async def namespace_exists(self, name: str) -> bool:

--- a/controller/src/controller/storage/kubernetes/watcher.py
+++ b/controller/src/controller/storage/kubernetes/watcher.py
@@ -111,7 +111,8 @@ class KubernetesWatcher(Generic[T]):
     resource_version
         Resource version at which to start the watch.
     timeout
-        Timeout for the watch.
+        Timeout for the watch. This may be `None`, in which case the watch
+        continues until cancelled or until the iterator is no longer called.
     logger
         Logger to use.
 
@@ -135,7 +136,7 @@ class KubernetesWatcher(Generic[T]):
         plural: str | None = None,
         involved_object: str | None = None,
         resource_version: str | None = None,
-        timeout: timedelta | None = None,
+        timeout: timedelta | None,
         logger: BoundLogger,
     ) -> None:
         self._method = method


### PR DESCRIPTION
Force all Kubernetes watches to have timeouts or explicitly set timeout to None, and ensure the latter is only done for the background task waiting for file server pods to complete. Everythig else now has a timeout, although often this is KUBERNETES_DELETE_TIMEOUT for deletions and replacements.

Add explicit asyncio.timeout calls around watches rather than relying on the timeout handling of the underlying Kubernetes library, since it seems a little underdocumented. Make timeout arguments to more lower-level storage functions mandatory.

Add a timeout around the watch for pod events during spawn.