### PR TITLE
DM-41630: Rename configuration_dependency

### DIFF
--- a/controller/src/controller/dependencies/config.py
+++ b/controller/src/controller/dependencies/config.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from ..config import Config
 from ..constants import CONFIGURATION_PATH
 
+__all__ = [
+    "ConfigDependency",
+    "config_dependency",
+]
+
 
 class ConfigDependency:
     """Dependency to manage a cached Nublado controller configuration.
@@ -51,4 +56,4 @@ class ConfigDependency:
         self._config = Config.from_file(path)
 
 
-configuration_dependency = ConfigDependency()
+config_dependency = ConfigDependency()

--- a/controller/src/controller/handlers/fileserver.py
+++ b/controller/src/controller/handlers/fileserver.py
@@ -7,7 +7,7 @@ from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..config import Config
 from ..constants import FILESERVER_TEMPLATE
-from ..dependencies.config import configuration_dependency
+from ..dependencies.config import config_dependency
 from ..dependencies.context import RequestContext, context_dependency
 from ..dependencies.user import user_dependency
 from ..exceptions import UnknownUserError
@@ -61,7 +61,7 @@ __all__ = ["router", "user_router"]
 )
 async def route_user(
     context: RequestContext = Depends(context_dependency),
-    config: Config = Depends(configuration_dependency),
+    config: Config = Depends(config_dependency),
     user: UserInfo = Depends(user_dependency),
 ) -> str:
     context.rebind_logger(user=user.username)

--- a/controller/src/controller/handlers/index.py
+++ b/controller/src/controller/handlers/index.py
@@ -5,7 +5,7 @@ from safir.metadata import Metadata, get_metadata
 from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..config import Config
-from ..dependencies.config import configuration_dependency
+from ..dependencies.config import config_dependency
 from ..models.index import Index
 
 internal_router = APIRouter(route_class=SlackRouteErrorHandler)
@@ -24,7 +24,7 @@ __all__ = ["external_router", "internal_router"]
     summary="Application metadata",
 )
 async def get_index(
-    config: Config = Depends(configuration_dependency),
+    config: Config = Depends(config_dependency),
 ) -> Index:
     metadata = get_metadata(
         package_name="controller",
@@ -46,7 +46,7 @@ async def get_index(
     summary="Application metadata (internal)",
 )
 async def get_internal_index(
-    config: Config = Depends(configuration_dependency),
+    config: Config = Depends(config_dependency),
 ) -> Metadata:
     return get_metadata(
         package_name="controller",

--- a/controller/src/controller/main.py
+++ b/controller/src/controller/main.py
@@ -16,7 +16,7 @@ from safir.middleware.x_forwarded import XForwardedMiddleware
 from safir.slack.webhook import SlackRouteErrorHandler
 from sse_starlette.sse import AppStatus
 
-from .dependencies.config import configuration_dependency
+from .dependencies.config import config_dependency
 from .dependencies.context import context_dependency
 from .handlers import fileserver, form, index, labs, prepuller, user_status
 
@@ -35,7 +35,7 @@ def create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await initialize_kubernetes()
-        config = configuration_dependency.config
+        config = config_dependency.config
         await context_dependency.initialize(config)
 
         yield
@@ -53,7 +53,7 @@ def create_app() -> FastAPI:
         AppStatus.should_exit_event = None
 
     # Configure logging.
-    config = configuration_dependency.config
+    config = config_dependency.config
     configure_logging(
         name="controller",
         profile=config.safir.profile,

--- a/controller/tests/support/config.py
+++ b/controller/tests/support/config.py
@@ -8,7 +8,7 @@ from kubernetes_asyncio.client import V1Namespace, V1ObjectMeta
 from safir.testing.kubernetes import MockKubernetesApi
 
 from controller.config import Config
-from controller.dependencies.config import configuration_dependency
+from controller.dependencies.config import config_dependency
 from controller.dependencies.context import context_dependency
 
 __all__ = ["configure"]
@@ -37,8 +37,8 @@ async def configure(
     """
     config_path = Path(__file__).parent.parent / "data" / directory / "input"
     base_path = Path(__file__).parent.parent / "data" / "base" / "input"
-    configuration_dependency.set_path(config_path / "config.yaml")
-    config = configuration_dependency.config
+    config_dependency.set_path(config_path / "config.yaml")
+    config = config_dependency.config
 
     # Adjust the configuration to point to external objects if they're present
     # in the configuration directory.
@@ -71,4 +71,4 @@ async def configure(
         await context_dependency.initialize(config)
 
     # Return the new configuration.
-    return configuration_dependency.config
+    return config_dependency.config


### PR DESCRIPTION
Rename configuration_dependency to config_dependency to parallel other packages and to match the name of the implementation class.