### PR TITLE
DM-41630: Improve description of fileserver.enabled config

### DIFF
--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -395,8 +395,14 @@ class FileserverConfig(CamelCaseModel):
     """Configuration for user file servers."""
 
     enabled: bool = Field(
-        False, title="Whether to enable fileserver capability"
+        False,
+        title="Whether file servers are enabled",
+        description=(
+            "If set to false, file servers will be disabled and the routes"
+            " to create or manage file servers will return 404 errors"
+        ),
     )
+
     namespace: str = Field(
         "",
         title="Namespace for user fileservers",


### PR DESCRIPTION
Expand the description of the configuration option that determines whether the file server is enabled.