### PR TITLE
DM-41630: Add .conda to documentation of reset_env

### DIFF
--- a/controller/src/controller/models/v1/lab.py
+++ b/controller/src/controller/models/v1/lab.py
@@ -197,9 +197,9 @@ class UserOptions(BaseModel):
         description=(
             "If true, set the `RESET_USER_ENV` environment variable when"
             " spawning the lab, which tells the lab to move aside the user"
-            " environment directories (`.cache`, `.jupyter`, `.local`). This"
-            " can be used to recover from user configuration errors that"
-            " break lab startup."
+            " environment directories (`.cache`, `.conda`, `.jupyter`,"
+            " `.local`). This can be used to recover from user configuration"
+            " errors that break lab startup."
         ),
         examples=[True],
     )


### PR DESCRIPTION
In the API documentation for lab creation, document that reset_env also moves aside the .conda directory.