### PR TITLE
DM-41630: Standardize base_url handling in controller

### DIFF
--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -126,7 +126,6 @@ class ProcessContext:
             )
             fileserver_manager = FileserverManager(
                 config=config.fileserver,
-                base_url=config.base_url,
                 fileserver_builder=fileserver_builder,
                 fileserver_storage=FileserverStorage(
                     kubernetes_client, logger
@@ -141,11 +140,6 @@ class ProcessContext:
             source=source,
             node_storage=NodeStorage(kubernetes_client, logger),
             slack_client=slack_client,
-            logger=logger,
-        )
-        lab_builder = LabBuilder(
-            config=config.lab,
-            instance_url=config.base_url,
             logger=logger,
         )
         return cls(
@@ -166,8 +160,8 @@ class ProcessContext:
             ),
             lab_manager=LabManager(
                 config=config.lab,
-                lab_builder=lab_builder,
                 image_service=image_service,
+                lab_builder=LabBuilder(config.lab, config.base_url, logger),
                 metadata_storage=metadata_storage,
                 lab_storage=LabStorage(kubernetes_client, logger),
                 slack_client=slack_client,
@@ -317,19 +311,23 @@ class Factory:
     def create_lab_builder(self) -> LabBuilder:
         """Create builder service for user labs.
 
+        Only used by the test suite.
+
         Returns
         -------
         LabBuilder
             Newly-created lab builder.
         """
         return LabBuilder(
-            config=self._context.config.lab,
-            instance_url=self._context.config.base_url,
-            logger=self._logger,
+            self._context.config.lab,
+            self._context.config.base_url,
+            self._logger,
         )
 
     def create_lab_storage(self) -> LabStorage:
         """Create Kubernetes storage object for user labs.
+
+        Only used by the test suite.
 
         Returns
         -------

--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -84,23 +84,19 @@ class LabBuilder:
     ----------
     config
         Lab configuration.
-    instance_url
+    base_url
         Base URL for this Notebook Aspect instance.
     logger
         Logger to use.
     """
 
     def __init__(
-        self,
-        *,
-        config: LabConfig,
-        instance_url: str,
-        logger: BoundLogger,
+        self, config: LabConfig, base_url: str, logger: BoundLogger
     ) -> None:
         self._config = config
-        self._instance_url = instance_url
-        self._volume_builder = VolumeBuilder()
+        self._base_url = base_url
         self._logger = logger
+        self._volume_builder = VolumeBuilder()
 
     def build_internal_url(self, username: str, env: dict[str, str]) -> str:
         """Determine the URL of a newly-spawned lab.
@@ -348,8 +344,8 @@ class LabBuilder:
                 "CPU_LIMIT": str(resources.limits.cpu),
                 "MEM_GUARANTEE": str(resources.requests.memory),
                 "MEM_LIMIT": str(resources.limits.memory),
-                # Get global instance URL.
-                "EXTERNAL_INSTANCE_URL": self._instance_url,
+                # Used by code running in the lab to find other services.
+                "EXTERNAL_INSTANCE_URL": self._base_url,
             }
         )
 

--- a/controller/src/controller/services/fileserver.py
+++ b/controller/src/controller/services/fileserver.py
@@ -55,9 +55,6 @@ class FileserverManager:
     config
         Configuration for file servers. File servers are guaranteed to be
         enabled by `~controller.factory.ProcessContext`.
-    base_url
-        Base URL for this Phalanx installation, used in the template presented
-        to the user after a file server has been created.
     fileserver_builder
         Builder that constructs file server Kubernetes objects.
     fileserver_storage
@@ -70,14 +67,12 @@ class FileserverManager:
         self,
         *,
         config: FileserverConfig,
-        base_url: str,
         fileserver_builder: FileserverBuilder,
         fileserver_storage: FileserverStorage,
         slack_client: SlackWebhookClient | None,
         logger: BoundLogger,
     ) -> None:
         self._config = config
-        self._base_url = base_url
         self._builder = fileserver_builder
         self._storage = fileserver_storage
         self._slack = slack_client

--- a/controller/src/controller/services/lab.py
+++ b/controller/src/controller/services/lab.py
@@ -133,11 +133,11 @@ class LabManager:
     ----------
     config
         Configuration for user labs.
-    lab_builder
-        Builder for Kubernetes lab objects.
     image_service
         Tracks all available images and resolves the parameters of a request
         for a new lab to a specific Docker image.
+    lab_builder
+        Builder for Kubernetes lab objects.
     metadata_storage
         Storage for metadata about the running controller.
     lab_storage
@@ -152,16 +152,16 @@ class LabManager:
         self,
         *,
         config: LabConfig,
-        lab_builder: LabBuilder,
         image_service: ImageService,
+        lab_builder: LabBuilder,
         metadata_storage: MetadataStorage,
         lab_storage: LabStorage,
         slack_client: SlackWebhookClient | None,
         logger: BoundLogger,
     ) -> None:
         self._config = config
-        self._builder = lab_builder
         self._image_service = image_service
+        self._builder = lab_builder
         self._metadata = metadata_storage
         self._storage = lab_storage
         self._slack = slack_client


### PR DESCRIPTION
Always use base_url, not instance_url, for that configuration setting. Remove it from FileserverManager, which no longer needs it.