### PR TITLE
DM-41630: Clean up formatting of spawner form

### DIFF
--- a/controller/src/controller/templates/spawner.html.jinja
+++ b/controller/src/controller/templates/spawner.html.jinja
@@ -1,18 +1,18 @@
 <script>
 function selectDropdown() {
-    document.getElementById('{{ dropdown_sentinel }}').checked = true;
+  document.getElementById('{{ dropdown_sentinel }}').checked = true;
 }
 </script>
 <style>
-    td {
-        border: 1px solid black;
-        padding: 2%;
-        vertical-align: top;
-    }
-    .radio label,
-    .checkbox label {
-        padding-left: 0px;
-    }
+  td {
+    border: 1px solid black;
+    padding: 2%;
+    vertical-align: top;
+  }
+  .radio label,
+  .checkbox label {
+    padding-left: 0px;
+  }
 </style>
 <table width="100%">
 <tr>
@@ -22,39 +22,31 @@ function selectDropdown() {
 <tr>
 <td width="50%">
   <div class="radio radio-inline">
-{% for i in cached_images -%}
-    <input type="radio" name="image_list"
-     id="image{{ loop.index }}" value="{{ i.reference }}"
-     {% if loop.first %} checked {%- endif -%}
-    >
+{%- for i in cached_images %}
+    <input type="radio" name="image_list" id="image{{ loop.index }}" value="{{ i.reference }}"{% if loop.first %} checked{% endif %}>
     <label for="image{{ loop.index }}">{{ i.name }}</label><br />
-{% endfor %}
-    <input type="radio" name="image_list"
-        id="{{ dropdown_sentinel }}"
-        value="{{ dropdown_sentinel }}"
-        {% if not cached_images %} checked {%- endif -%}
-    >
+{%- endfor %}
+
+    <input type="radio" name="image_list" id="{{ dropdown_sentinel }}" value="{{ dropdown_sentinel }}"{% if not cached_images %} checked{% endif %}>
     <label for="{{ dropdown_sentinel }}">
       Select uncached image (slower start):
     </label><br />
+
     <select name="image_dropdown" onchange="selectDropdown()">
-{% for i in all_images -%}
-        <option value="{{ i.reference }}">{{ i.name }}</option>
-{% endfor %}
+{%- for i in all_images %}
+      <option value="{{ i.reference }}">{{ i.name }}</option>
+{%- endfor %}
     </select>
   </div>
 </td>
 <td width="50%">
   <div class="radio radio-inline">
-{% for key, value in sizes.items() -%}
-    <input type="radio" name="size"
-     id="{{ key.value }}" value="{{ key.value }}"
-     {% if loop.first %} checked {%- endif -%}
-    >
+{%- for key, value in sizes.items() %}
+    <input type="radio" name="size" id="{{ key.value }}" value="{{ key.value }}"{% if loop.first %} checked{% endif %}>
     <label for="{{ key.value }}">
       {{ key.value.title() }} ({{ value }})
     </label><br />
-{% endfor %}
+{%- endfor %}
   </div>
   <br />
   <br />

--- a/controller/tests/data/standard/output/lab-form.html
+++ b/controller/tests/data/standard/output/lab-form.html
@@ -1,18 +1,18 @@
 <script>
 function selectDropdown() {
-    document.getElementById('use_image_from_dropdown').checked = true;
+  document.getElementById('use_image_from_dropdown').checked = true;
 }
 </script>
 <style>
-    td {
-        border: 1px solid black;
-        padding: 2%;
-        vertical-align: top;
-    }
-    .radio label,
-    .checkbox label {
-        padding-left: 0px;
-    }
+  td {
+    border: 1px solid black;
+    padding: 2%;
+    vertical-align: top;
+  }
+  .radio label,
+  .checkbox label {
+    padding-left: 0px;
+  }
 </style>
 <table width="100%">
 <tr>
@@ -22,49 +22,37 @@ function selectDropdown() {
 <tr>
 <td width="50%">
   <div class="radio radio-inline">
-<input type="radio" name="image_list"
-     id="image1" value="lighthouse.ceres/library/sketchbook:recommended@sha256:5678"
-      checked>
+    <input type="radio" name="image_list" id="image1" value="lighthouse.ceres/library/sketchbook:recommended@sha256:5678" checked>
     <label for="image1">Recommended (Weekly 2077_43)</label><br />
 
-    <input type="radio" name="image_list"
-        id="use_image_from_dropdown"
-        value="use_image_from_dropdown"
-        >
+    <input type="radio" name="image_list" id="use_image_from_dropdown" value="use_image_from_dropdown">
     <label for="use_image_from_dropdown">
       Select uncached image (slower start):
     </label><br />
-    <select name="image_dropdown" onchange="selectDropdown()">
-<option value="lighthouse.ceres/library/sketchbook:recommended@sha256:5678">Recommended (Weekly 2077_43)</option>
-<option value="lighthouse.ceres/library/sketchbook:w_2077_43@sha256:5678">Weekly 2077_43</option>
-<option value="lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234">Daily 2077_10_23</option>
-<option value="lighthouse.ceres/library/sketchbook:latest_weekly">latest_weekly</option>
-<option value="lighthouse.ceres/library/sketchbook:latest_daily">latest_daily</option>
 
+    <select name="image_dropdown" onchange="selectDropdown()">
+      <option value="lighthouse.ceres/library/sketchbook:recommended@sha256:5678">Recommended (Weekly 2077_43)</option>
+      <option value="lighthouse.ceres/library/sketchbook:w_2077_43@sha256:5678">Weekly 2077_43</option>
+      <option value="lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234">Daily 2077_10_23</option>
+      <option value="lighthouse.ceres/library/sketchbook:latest_weekly">latest_weekly</option>
+      <option value="lighthouse.ceres/library/sketchbook:latest_daily">latest_daily</option>
     </select>
   </div>
 </td>
 <td width="50%">
   <div class="radio radio-inline">
-<input type="radio" name="size"
-     id="small" value="small"
-      checked>
+    <input type="radio" name="size" id="small" value="small" checked>
     <label for="small">
       Small (1.0 CPU, 3Gi RAM)
     </label><br />
-<input type="radio" name="size"
-     id="medium" value="medium"
-     >
+    <input type="radio" name="size" id="medium" value="medium">
     <label for="medium">
       Medium (2.0 CPU, 6Gi RAM)
     </label><br />
-<input type="radio" name="size"
-     id="large" value="large"
-     >
+    <input type="radio" name="size" id="large" value="large">
     <label for="large">
       Large (4.0 CPU, 12Gi RAM)
     </label><br />
-
   </div>
   <br />
   <br />


### PR DESCRIPTION
Be more careful about whitespace management in the spawner form and put selections on single lines to make the output a bit more readable by humans and with fewer stray stranded angle brackets.