### PR TITLE
DM-41630: Move Docker credentials configuration

### DIFF
--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -16,7 +16,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
 
 from .constants import (
-    DOCKER_SECRETS_PATH,
     LIMIT_TO_REQUEST_RATIO,
     METADATA_PATH,
 )
@@ -740,10 +739,6 @@ class Config(BaseSettings):
     )
 
     lab: LabConfig = Field(..., title="User lab configuration")
-
-    docker_secrets_path: Path = Field(
-        DOCKER_SECRETS_PATH, title="Path to Docker API credentials"
-    )
 
     model_config = SettingsConfigDict(
         alias_generator=to_camel, extra="forbid", populate_by_name=True

--- a/controller/src/controller/constants.py
+++ b/controller/src/controller/constants.py
@@ -6,7 +6,7 @@ from pathlib import Path
 __all__ = [
     "ARGO_CD_ANNOTATIONS",
     "CONFIGURATION_PATH",
-    "DOCKER_SECRETS_PATH",
+    "DOCKER_CREDENTIALS_PATH",
     "DROPDOWN_SENTINEL_VALUE",
     "GROUPNAME_REGEX",
     "FILE_SERVER_REFRESH_INTERVAL",
@@ -39,7 +39,7 @@ should not manage them.
 CONFIGURATION_PATH = Path("/etc/nublado/config.yaml")
 """Default path to controller configuration."""
 
-DOCKER_SECRETS_PATH = Path("/etc/secrets/.dockerconfigjson")
+DOCKER_CREDENTIALS_PATH = Path("/etc/secrets/.dockerconfigjson")
 """Default path to the Docker API secrets."""
 
 DROPDOWN_SENTINEL_VALUE = "use_image_from_dropdown"

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -101,7 +101,7 @@ class ProcessContext:
         match config.images.source:
             case DockerSourceConfig():
                 docker_client = DockerStorageClient(
-                    credentials_path=config.docker_secrets_path,
+                    credentials_path=config.images.source.credentials_path,
                     http_client=http_client,
                     logger=logger,
                 )
@@ -282,13 +282,23 @@ class Factory:
     def create_docker_storage(self) -> DockerStorageClient:
         """Create a Docker storage client.
 
+        Only used by the test suite.
+
         Returns
         -------
         DockerStorageClient
             Newly-created Docker storage client.
+
+        Raises
+        ------
+        NotConfiguredError
+            Raised if the image source is not configured to use Docker.
         """
+        if self._context.config.images.source.type != "docker":
+            raise NotConfiguredError("Docker image source not configured")
+        credentials_path = self._context.config.images.source.credentials_path
         return DockerStorageClient(
-            credentials_path=self._context.config.docker_secrets_path,
+            credentials_path=credentials_path,
             http_client=self._context.http_client,
             logger=self._logger,
         )

--- a/controller/src/controller/models/v1/prepuller_config.py
+++ b/controller/src/controller/models/v1/prepuller_config.py
@@ -7,10 +7,13 @@ so it is defined in a separate model that can be included by both.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
+
+from ...constants import DOCKER_CREDENTIALS_PATH
 
 __all__ = [
     "DockerSourceConfig",
@@ -42,6 +45,18 @@ class DockerSourceConfig(BaseModel):
             " This is sometimes called the image name."
         ),
         examples=["library/sketchbook"],
+    )
+
+    credentials_path: Path = Field(
+        DOCKER_CREDENTIALS_PATH,
+        title="Path to Docker API credentials",
+        description=(
+            "Path to a file containing a JSON-encoded dictionary of Docker"
+            " credentials for various registries, in the same format as"
+            " the Docker configuration file and the value of a Kubernetes"
+            " pull secret"
+        ),
+        exclude=True,
     )
 
     model_config = ConfigDict(

--- a/controller/tests/conftest.py
+++ b/controller/tests/conftest.py
@@ -93,7 +93,7 @@ def mock_docker(
         respx_mock,
         host=config.images.source.registry,
         repository=config.images.source.repository,
-        credentials_path=config.docker_secrets_path,
+        credentials_path=config.images.source.credentials_path,
         tags=tags,
         require_bearer=True,
     )

--- a/controller/tests/storage/docker_test.py
+++ b/controller/tests/storage/docker_test.py
@@ -30,7 +30,7 @@ async def test_api(
         respx_mock,
         host=config.images.source.registry,
         repository=config.images.source.repository,
-        credentials_path=config.docker_secrets_path,
+        credentials_path=config.images.source.credentials_path,
         tags=tags,
     )
     docker = factory.create_docker_storage()
@@ -51,7 +51,7 @@ async def test_bearer_auth(
         respx_mock,
         host=config.images.source.registry,
         repository=config.images.source.repository,
-        credentials_path=config.docker_secrets_path,
+        credentials_path=config.images.source.credentials_path,
         tags=tags,
         require_bearer=True,
     )

--- a/controller/tests/support/config.py
+++ b/controller/tests/support/config.py
@@ -10,6 +10,7 @@ from safir.testing.kubernetes import MockKubernetesApi
 from controller.config import Config
 from controller.dependencies.config import config_dependency
 from controller.dependencies.context import context_dependency
+from controller.models.v1.prepuller_config import DockerSourceConfig
 
 __all__ = ["configure"]
 
@@ -42,14 +43,16 @@ async def configure(
 
     # Adjust the configuration to point to external objects if they're present
     # in the configuration directory.
-    if (config_path / "docker-creds.json").exists():
-        config.docker_secrets_path = config_path / "docker-creds.json"
-    else:
-        config.docker_secrets_path = base_path / "docker-creds.json"
     if (config_path / "metadata").exists():
         config.metadata_path = config_path / "metadata"
     else:
         config.metadata_path = base_path / "metadata"
+    if isinstance(config.images.source, DockerSourceConfig):
+        if (config_path / "docker-creds.json").exists():
+            credentials_path = config_path / "docker-creds.json"
+        else:
+            credentials_path = base_path / "docker-creds.json"
+        config.images.source.credentials_path = credentials_path
 
     # If the new configuration enables fileservers, create the namespace for
     # the fileserver pods. Existence of the fileserver namespace is checked


### PR DESCRIPTION
The path to a Docker credentials file was configured at the top level of the Nublado controller configuration, but this file is only used if the prepuller is configured with a Docker image source. Move this setting into the Docker image source model, but mark it as not exported since we don't want to return this field when queried for prepuller status via the API.