### PR TITLE
DM-41630: Fix file server path_prefix

### DIFF
--- a/controller/src/controller/handlers/fileserver.py
+++ b/controller/src/controller/handlers/fileserver.py
@@ -53,7 +53,7 @@ __all__ = ["router", "user_router"]
 
 
 @user_router.get(
-    "/files",
+    "",
     summary="Allow user to access files, spawning new fileserver if needed.",
     responses={403: {"description": "Forbidden", "model": ErrorModel}},
     response_class=HTMLResponse,

--- a/controller/src/controller/services/builder/fileserver.py
+++ b/controller/src/controller/services/builder/fileserver.py
@@ -178,7 +178,7 @@ class FileserverBuilder:
         host = urlparse(self._base_url).hostname
         metadata = self._build_metadata(username).to_dict(serialize=True)
         path = {
-            "path": f"/files/{username}",
+            "path": f"{self._config.path_prefix}/{username}",
             "pathType": "Prefix",
             "backend": {
                 "service": {
@@ -214,7 +214,7 @@ class FileserverBuilder:
         volume_data = self._volume_builder.build_mounted_volumes(
             user.username, self._volumes, prefix="/mnt"
         )
-        url = f"{self._config.path_prefix}/files/{user.username}"
+        url = f"{self._config.path_prefix}/{user.username}"
         resources = self._config.resources
         timeout = str(int(self._config.idle_timeout.total_seconds()))
 

--- a/controller/src/controller/templates/fileserver.html.jinja
+++ b/controller/src/controller/templates/fileserver.html.jinja
@@ -6,7 +6,7 @@ User Fileserver Created
 </head>
 </body>
 <h1>
-Your <a href="{{ base_url }}{{ path_prefix }}/files/{{ username }}">fileserver</a> is ready.
+Your <a href="{{ base_url }}{{ path_prefix }}/{{ username }}">fileserver</a> is ready.
 <h1>
 
 <h2>
@@ -14,7 +14,7 @@ Access Token
 </h2>
 
 <p> If you do not have an access token, go to <a
-href="{{ base_url }}/auth/tokens/">the Gafaelfawr tokens page</a> and press
+href="{{ base_url }}/auth/tokens">the Gafaelfawr tokens page</a> and press
 the "Create Token" button.  </p>
 
 <p>
@@ -46,7 +46,7 @@ almost any Unix-like system and will work.
 
 <p>
 Connect to
-<a href="{{ base_url }}{{ path_prefix }}/files/{{ username }}">{{ base_url }}{{ path_prefix }}/files/{{ username }}</a>
+<a href="{{ base_url }}{{ path_prefix }}/{{ username }}">{{ base_url }}{{ path_prefix }}/{{ username }}</a>
 with your WebDAV client (for Konqueror, use "webdav" or "webdavs" rather
 than "http" or "https" as the protocol).  Use the token you acquired
 earlier as the password.  You can use any string for your username
@@ -57,7 +57,7 @@ would be both accurate and traditional.
 <p>
 If you make no requests in {{ timeout | format_timedelta }}, the fileserver will shut
 down.  If that occurs, simply go back to
-<a href="{{ base_url }}{{ path_prefix }}/files">{{ base_url }}{{ path_prefix }}/files</a>
+<a href="{{ base_url }}{{ path_prefix }}">{{ base_url }}{{ path_prefix }}</a>
 and a new fileserver will be created for you.
 </p>
 </body>

--- a/controller/tests/data/fileserver/output/fileserver.html
+++ b/controller/tests/data/fileserver/output/fileserver.html
@@ -14,7 +14,7 @@ Access Token
 </h2>
 
 <p> If you do not have an access token, go to <a
-href="http://127.0.0.1:8080/auth/tokens/">the Gafaelfawr tokens page</a> and press
+href="http://127.0.0.1:8080/auth/tokens">the Gafaelfawr tokens page</a> and press
 the "Create Token" button.  </p>
 
 <p>


### PR DESCRIPTION
The file server was always appending /files to path_prefix, which somewhat defeats the point of having a path prefix. Move /files to be the default value of path_prefix and stop appending /files.

Fix the creation of the per-user file server ingress to correctly honor path_prefix.