### PR TITLE
DM-41630: Remove unnecessary delay in prepuller pods

### DIFF
--- a/controller/src/controller/services/builder/prepuller.py
+++ b/controller/src/controller/services/builder/prepuller.py
@@ -63,7 +63,7 @@ class PrepullerBuilder:
                 containers=[
                     V1Container(
                         name="prepull",
-                        command=["/bin/sleep", "5"],
+                        command=["/bin/true"],
                         image=image.reference_with_digest,
                         working_dir="/tmp",
                     )

--- a/controller/tests/data/standard/output/prepull-conflict-objects.json
+++ b/controller/tests/data/standard/output/prepull-conflict-objects.json
@@ -23,8 +23,7 @@
       "containers": [
         {
           "command": [
-            "/bin/sleep",
-            "5"
+            "/bin/true"
           ],
           "image": "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234",
           "name": "prepull",

--- a/controller/tests/data/standard/output/prepull-objects.json
+++ b/controller/tests/data/standard/output/prepull-objects.json
@@ -23,8 +23,7 @@
       "containers": [
         {
           "command": [
-            "/bin/sleep",
-            "5"
+            "/bin/true"
           ],
           "image": "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234",
           "name": "prepull",


### PR DESCRIPTION
Rather than sleeping five seconds after starting a prepuller container, allow it to exit immediately so that prepullers can complete somewhat faster.