### PR TITLE
DM-41630: Require setting the namespace prefix for labs

### DIFF
--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
@@ -42,28 +41,6 @@ __all__ = [
     "PVCVolumeSource",
     "UserHomeDirectorySchema",
 ]
-
-
-def _get_namespace_prefix() -> str:
-    """Determine the prefix to use for namespaces for lab environments.
-
-    Use the namespace of the running pod as the prefix if we can determine
-    what it is, otherwise falls back on ``userlabs``.
-
-    Returns
-    -------
-    str
-        Namespace prefix to use for namespaces for lab environments.
-    """
-    if prefix := os.getenv("USER_NAMESPACE_PREFIX"):
-        return prefix
-
-    # Kubernetes puts the running pod namespace here.
-    path = Path("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-    if path.exists():
-        return path.read_text().strip()
-    else:
-        return "userlabs"
 
 
 class ContainerImage(BaseModel):
@@ -572,11 +549,11 @@ class LabConfig(BaseModel):
     )
 
     namespace_prefix: str = Field(
-        default_factory=_get_namespace_prefix,
+        ...,
         title="Namespace prefix for lab environments",
         description=(
             "The namespace for the user's lab will start with this string,"
-            " a hyphen (`-`), and the user's username."
+            " a hyphen (`-`), and the user's username"
         ),
     )
 

--- a/controller/tests/data/cycle/input/config.yaml
+++ b/controller/tests/data/cycle/input/config.yaml
@@ -1,6 +1,7 @@
 logLevel: DEBUG
 profile: development
 lab:
+  namespacePrefix: userlabs
   sizes:
     small:
       cpu: 1.0

--- a/controller/tests/data/extra-annotations/input/config.yaml
+++ b/controller/tests/data/extra-annotations/input/config.yaml
@@ -1,6 +1,7 @@
 logLevel: DEBUG
 profile: development
 lab:
+  namespacePrefix: userlabs
   spawnTimeout: 10
   extraAnnotations:
     k8s.v1.cni.cncf.io/networks: "kube-system/dds"

--- a/controller/tests/data/fileserver/input/config.yaml
+++ b/controller/tests/data/fileserver/input/config.yaml
@@ -1,6 +1,7 @@
 logLevel: DEBUG
 profile: development
 lab:
+  namespacePrefix: userlabs
   sizes:
     small:
       cpu: 1.0

--- a/controller/tests/data/gar-cycle/input/config.yaml
+++ b/controller/tests/data/gar-cycle/input/config.yaml
@@ -1,6 +1,7 @@
 logLevel: DEBUG
 profile: development
 lab:
+  namespacePrefix: userlabs
   sizes:
     small:
       cpu: 1.0

--- a/controller/tests/data/gar/input/config.yaml
+++ b/controller/tests/data/gar/input/config.yaml
@@ -1,6 +1,7 @@
 logLevel: DEBUG
 profile: development
 lab:
+  namespacePrefix: userlabs
   sizes:
     small:
       cpu: 1.0

--- a/controller/tests/data/homedir-schema/input/config.yaml
+++ b/controller/tests/data/homedir-schema/input/config.yaml
@@ -7,6 +7,7 @@ lab:
   homedirPrefix: "/u/home/"
   homedirSchema: initialThenUsername
   homedirSuffix: "/jhome/"
+  namespacePrefix: userlabs
   files:
     /etc/passwd:
       modify: true

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -2,6 +2,7 @@ logLevel: DEBUG
 profile: development
 lab:
   application: "nublado-users"
+  namespacePrefix: userlabs
   spawnTimeout: 10
   env:
     API_ROUTE: /api


### PR DESCRIPTION
Rather than using a complicated default of an environment variable we don't use and the namespace in which the controller is running, require the namespace prefix be explicitly configured. Explicit configuration is often better than obscure defaults.