### PR TITLE
DM-41630: Diagnose invalid lab size on creation

### DIFF
--- a/controller/src/controller/exceptions.py
+++ b/controller/src/controller/exceptions.py
@@ -8,6 +8,7 @@ from fastapi import status
 from kubernetes_asyncio.client import ApiException
 from pydantic import ValidationError
 from safir.fastapi import ClientRequestError
+from safir.models import ErrorLocation
 from safir.slack.blockkit import (
     SlackCodeBlock,
     SlackException,
@@ -17,12 +18,15 @@ from safir.slack.blockkit import (
     SlackWebException,
 )
 
+from .models.v1.lab import LabSize
+
 __all__ = [
     "DockerRegistryError",
     "DuplicateObjectError",
     "GafaelfawrParseError",
     "GafaelfawrWebError",
     "InvalidDockerReferenceError",
+    "InvalidLabSizeError",
     "InvalidTokenError",
     "KubernetesError",
     "LabDeletionError",
@@ -50,6 +54,16 @@ class InvalidDockerReferenceError(ClientRequestError):
     """
 
     error = "invalid_docker_reference"
+
+
+class InvalidLabSizeError(ClientRequestError):
+    """The provided lab size is not one of the configured sizes."""
+
+    error = "invalid_lab_size"
+
+    def __init__(self, size: LabSize) -> None:
+        msg = f'Invalid lab size "{size.value}"'
+        super().__init__(msg, ErrorLocation.body, ["options", "size"])
 
 
 class InvalidTokenError(ClientRequestError):

--- a/controller/tests/handlers/labs_test.py
+++ b/controller/tests/handlers/labs_test.py
@@ -610,6 +610,26 @@ async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
         ]
     }
 
+    # Test requesting a lab size that doesn't exist.
+    r = await client.post(
+        f"/nublado/spawner/v1/labs/{user.username}/create",
+        json={
+            "options": {"image_tag": "recommended", "size": "gargantuan"},
+            "env": lab.env,
+        },
+        headers=user.to_headers(),
+    )
+    assert r.status_code == 422
+    assert r.json() == {
+        "detail": [
+            {
+                "loc": ["body", "options", "size"],
+                "msg": 'Invalid lab size "gargantuan"',
+                "type": "invalid_lab_size",
+            }
+        ]
+    }
+
 
 @pytest.mark.asyncio
 async def test_spawn_errors(


### PR DESCRIPTION
The model checking ensured that the requested lab size was a valid member of the enum, but not that it was one of the configured sizes. This could have resulted in a run-time KeyError if the user sent an invalid size. Catch this error explicitly and return a 422 error instead.