### PR TITLE
DM-41630: Move domain images for spawner form construction

### DIFF
--- a/controller/src/controller/models/domain/image.py
+++ b/controller/src/controller/models/domain/image.py
@@ -1,4 +1,4 @@
-"""Internal models for spawner form construction."""
+"""Internal models returned by image service methods."""
 
 from __future__ import annotations
 

--- a/controller/src/controller/services/image.py
+++ b/controller/src/controller/services/image.py
@@ -12,7 +12,7 @@ from structlog.stdlib import BoundLogger
 from ..constants import IMAGE_REFRESH_INTERVAL
 from ..exceptions import UnknownDockerImageError
 from ..models.domain.docker import DockerReference
-from ..models.domain.form import MenuImage, MenuImages
+from ..models.domain.image import MenuImage, MenuImages
 from ..models.domain.kubernetes import KubernetesNodeImage
 from ..models.domain.rspimage import RSPImage, RSPImageCollection
 from ..models.domain.rsptag import RSPImageType

--- a/controller/src/controller/services/source/base.py
+++ b/controller/src/controller/services/source/base.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from structlog.stdlib import BoundLogger
 
 from ...models.domain.docker import DockerReference
-from ...models.domain.form import MenuImage
+from ...models.domain.image import MenuImage
 from ...models.domain.kubernetes import KubernetesNodeImage
 from ...models.domain.rspimage import RSPImage, RSPImageCollection
 from ...models.v1.prepuller import PrepulledImage

--- a/controller/src/controller/services/source/docker.py
+++ b/controller/src/controller/services/source/docker.py
@@ -9,7 +9,7 @@ from structlog.stdlib import BoundLogger
 
 from ...exceptions import InvalidDockerReferenceError, UnknownDockerImageError
 from ...models.domain.docker import DockerReference
-from ...models.domain.form import MenuImage
+from ...models.domain.image import MenuImage
 from ...models.domain.kubernetes import KubernetesNodeImage
 from ...models.domain.rspimage import RSPImage, RSPImageCollection
 from ...models.domain.rsptag import RSPImageTagCollection

--- a/controller/src/controller/services/source/gar.py
+++ b/controller/src/controller/services/source/gar.py
@@ -8,7 +8,7 @@ from structlog.stdlib import BoundLogger
 
 from ...exceptions import InvalidDockerReferenceError, UnknownDockerImageError
 from ...models.domain.docker import DockerReference
-from ...models.domain.form import MenuImage
+from ...models.domain.image import MenuImage
 from ...models.domain.kubernetes import KubernetesNodeImage
 from ...models.domain.rspimage import RSPImage, RSPImageCollection
 from ...models.v1.prepuller import PrepulledImage


### PR DESCRIPTION
There is no longer a separate FormService, so putting the models returned by the image service in controller.models.domain.form felt weird. Rename that module to controller.models.domain.image since it is used by the image service.