### PR TITLE
DM-41630: Separate NSS configuration from simple files

### DIFF
--- a/controller/tests/data/extra-annotations/input/config.yaml
+++ b/controller/tests/data/extra-annotations/input/config.yaml
@@ -5,15 +5,6 @@ lab:
   spawnTimeout: 10
   extraAnnotations:
     k8s.v1.cni.cncf.io/networks: "kube-system/dds"
-  files:
-    /etc/passwd:
-      modify: true
-      contents: |
-        root:x:0:0:root:/root:/bin/bash
-    /etc/group:
-      modify: true
-      contents: |
-        root:x:0:
   sizes:
     small:
       cpu: 1.0

--- a/controller/tests/data/homedir-schema/input/config.yaml
+++ b/controller/tests/data/homedir-schema/input/config.yaml
@@ -8,15 +8,6 @@ lab:
   homedirSchema: initialThenUsername
   homedirSuffix: "/jhome/"
   namespacePrefix: userlabs
-  files:
-    /etc/passwd:
-      modify: true
-      contents: |
-        root:x:0:0:root:/root:/bin/bash
-    /etc/group:
-      modify: true
-      contents: |
-        root:x:0:
   sizes:
     small:
       cpu: 1.0

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -42,88 +42,28 @@ lab:
     # Additionally, some environment variables will be set from the secrets
     # below.
   files:
-    /etc/passwd:
-      modify: true
-      contents: |
-        root:x:0:0:root:/root:/bin/bash
-        bin:x:1:1:bin:/bin:/sbin/nologin
-        daemon:x:2:2:daemon:/sbin:/sbin/nologin
-        adm:x:3:4:adm:/var/adm:/sbin/nologin
-        lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
-        sync:x:5:0:sync:/sbin:/bin/sync
-        shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
-        halt:x:7:0:halt:/sbin:/sbin/halt
-        mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
-        operator:x:11:0:operator:/root:/sbin/nologin
-        games:x:12:100:games:/usr/games:/sbin/nologin
-        ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
-        tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
-        dbus:x:81:81:System message bus:/:/sbin/nologin
-        nobody:x:99:99:Nobody:/:/sbin/nologin
-        systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin
-        lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
-    /etc/group:
-      modify: true
-      contents: |
-        root:x:0:
-        bin:x:1:
-        daemon:x:2:
-        sys:x:3:
-        adm:x:4:
-        tty:x:5:
-        disk:x:6:
-        lp:x:7:
-        mem:x:8:
-        kmem:x:9:
-        wheel:x:10:
-        cdrom:x:11:
-        mail:x:12:
-        man:x:15:
-        dialout:x:18:
-        floppy:x:19:
-        games:x:20:
-        utmp:x:22:
-        tape:x:33:
-        utempter:x:35:
-        video:x:39:
-        ftp:x:50:
-        lock:x:54:
-        tss:x:59:
-        audio:x:63:
-        dbus:x:81:
-        screen:x:84:
-        nobody:x:99:
-        users:x:100:
-        systemd-journal:x:190:
-        systemd-network:x:192:
-        cgred:x:997:
-        ssh_keys:x:998:
-        input:x:999:
-    /opt/lsst/software/jupyterlab/lsst_dask.yml:
-      contents: |
-        # No longer used, but preserves compatibility with runlab.sh
-        dask_worker.yml: |
-          enabled: false
-    /opt/lsst/software/jupyterlab/panda:
-      modify: false
-      contents: |
-        # Licensed under the Apache License, Version 2.0 (the "License");
-        # You may not use this file except in compliance with the License.
-        # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-        #
-        # Authors:
-        # - Wen Guan, <wen.guan@cern.ch>, 2020
-        [common]
-        # if logdir is configured, idds will write to idds.log in this directory.
-        # else idds will go to stdout/stderr.
-        # With supervisord, it's good to write to stdout/stderr, then supervisord can manage and rotate logs.
-        # logdir = /var/log/idds
-        loglevel = INFO
-        [rest]
-        host = https://iddsserver.cern.ch:443/idds
-        #url_prefix = /idds
-        #cacher_dir = /tmp
-        cacher_dir = /data/idds
+    /opt/lsst/software/jupyterlab/lsst_dask.yml: |
+      # No longer used, but preserves compatibility with runlab.sh
+      dask_worker.yml: |
+        enabled: false
+    /opt/lsst/software/jupyterlab/panda: |
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # You may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+      #
+      # Authors:
+      # - Wen Guan, <wen.guan@cern.ch>, 2020
+      [common]
+      # if logdir is configured, idds will write to idds.log in this directory.
+      # else idds will go to stdout/stderr.
+      # With supervisord, it's good to write to stdout/stderr, then supervisord can manage and rotate logs.
+      # logdir = /var/log/idds
+      loglevel = INFO
+      [rest]
+      host = https://iddsserver.cern.ch:443/idds
+      #url_prefix = /idds
+      #cacher_dir = /tmp
+      cacher_dir = /data/idds
   initContainers:
     - name: initdir
       image:
@@ -136,6 +76,60 @@ lab:
             type: nfs
             serverPath: /share1/home
             server: 10.87.86.26
+  nss:
+    basePasswd: |
+      root:x:0:0:root:/root:/bin/bash
+      bin:x:1:1:bin:/bin:/sbin/nologin
+      daemon:x:2:2:daemon:/sbin:/sbin/nologin
+      adm:x:3:4:adm:/var/adm:/sbin/nologin
+      lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+      sync:x:5:0:sync:/sbin:/bin/sync
+      shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+      halt:x:7:0:halt:/sbin:/sbin/halt
+      mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+      operator:x:11:0:operator:/root:/sbin/nologin
+      games:x:12:100:games:/usr/games:/sbin/nologin
+      ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+      tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
+      dbus:x:81:81:System message bus:/:/sbin/nologin
+      nobody:x:99:99:Nobody:/:/sbin/nologin
+      systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin
+      lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
+    baseGroup: |
+      root:x:0:
+      bin:x:1:
+      daemon:x:2:
+      sys:x:3:
+      adm:x:4:
+      tty:x:5:
+      disk:x:6:
+      lp:x:7:
+      mem:x:8:
+      kmem:x:9:
+      wheel:x:10:
+      cdrom:x:11:
+      mail:x:12:
+      man:x:15:
+      dialout:x:18:
+      floppy:x:19:
+      games:x:20:
+      utmp:x:22:
+      tape:x:33:
+      utempter:x:35:
+      video:x:39:
+      ftp:x:50:
+      lock:x:54:
+      tss:x:59:
+      audio:x:63:
+      dbus:x:81:
+      screen:x:84:
+      nobody:x:99:
+      users:x:100:
+      systemd-journal:x:190:
+      systemd-network:x:192:
+      cgred:x:997:
+      ssh_keys:x:998:
+      input:x:999:
   pullSecret: pull-secret
   secrets:
     - secretName: nublado-secret


### PR DESCRIPTION
Combining NSS base configuration (/etc/passwd and /etc/group) with simple files using an oddly-named modify boolean was confusing and required unnecessary config structure. Move the base /etc/passwd and /etc/group files into their own nss key and turn files into simple key/value pairs of file paths to file contents.

Diagnose attempts to define /etc/passwd and /etc/group via files and reject them when validating the configuration.

Create simple defaults for /etc/passwd and /etc/group containing only the root account, mostly to simplify test setup.