### PR TITLE
DM-41630: Allow use of SI units for file server resources

### DIFF
--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -7,7 +7,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Literal, Self
 
-import bitmath
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
@@ -21,6 +20,7 @@ from .constants import (
 from .models.domain.kubernetes import PullPolicy, VolumeAccessMode
 from .models.v1.lab import LabResources, LabSize, ResourceQuantity
 from .models.v1.prepuller_config import PrepullerConfig
+from .units import memory_to_bytes
 
 __all__ = [
     "BaseVolumeSource",
@@ -207,10 +207,7 @@ class LabSizeDefinition(BaseModel):
     @property
     def memory_bytes(self) -> int:
         """Amount of memory in bytes."""
-        memory = self.memory
-        if not memory.endswith("B"):
-            memory += "B"
-        return int(bitmath.parse_string(memory).bytes)
+        return memory_to_bytes(self.memory)
 
     def to_lab_resources(self) -> LabResources:
         """Convert to the equivalent lab resources model."""

--- a/controller/src/controller/units.py
+++ b/controller/src/controller/units.py
@@ -1,0 +1,28 @@
+"""Unit conversions for the Nublado controller."""
+
+from __future__ import annotations
+
+import bitmath
+
+__all__ = ["memory_to_bytes"]
+
+
+def memory_to_bytes(memory: str) -> int:
+    """Convert a string representatio of memory to a number of bytes.
+
+    Parameters
+    ----------
+    memory
+        Amount of memory as a string.
+
+    Returns
+    -------
+    int
+        Equivalent number of bytes.
+
+    Raises
+    ------
+    ValueError
+        Raised if the input string is not a valid byte specification.
+    """
+    return int(bitmath.parse_string_unsafe(memory).bytes)

--- a/controller/tests/models/v1/lab_test.py
+++ b/controller/tests/models/v1/lab_test.py
@@ -6,7 +6,20 @@ import pytest
 from pydantic import ValidationError
 
 from controller.constants import DROPDOWN_SENTINEL_VALUE
-from controller.models.v1.lab import ImageClass, LabSize, UserOptions
+from controller.models.v1.lab import (
+    ImageClass,
+    LabSize,
+    ResourceQuantity,
+    UserOptions,
+)
+
+
+def test_resource_quantity() -> None:
+    quantity = ResourceQuantity.model_validate({"cpu": 0.4, "memory": "1Gi"})
+    assert quantity.memory == 1024 * 1024 * 1024
+
+    with pytest.raises(ValidationError):
+        ResourceQuantity.model_validate({"cpu": 1.0, "memory": "24D"})
 
 
 def test_user_options() -> None:

--- a/controller/tests/units_test.py
+++ b/controller/tests/units_test.py
@@ -1,0 +1,15 @@
+"""Test unit conversions."""
+
+from __future__ import annotations
+
+from controller.units import memory_to_bytes
+
+
+def test_memory_to_bytes() -> None:
+    assert memory_to_bytes("123456789") == 123456789
+    assert memory_to_bytes("12K") == 12 * 1000
+    assert memory_to_bytes("12Ki") == 12 * 1024
+    assert memory_to_bytes("12M") == 12 * 1000 * 1000
+    assert memory_to_bytes("12Mi") == 12 * 1024 * 1024
+    assert memory_to_bytes("12MiB") == 12 * 1024 * 1024
+    assert memory_to_bytes("1Gi") == 1024 * 1024 * 1024


### PR DESCRIPTION
The resource constraints on the file server reused the existing ResourceQuantity model, which meant that memory limits and requests had to be specified in bytes. Lift the bitmath utility function into a new module for unit conversions and use it for both lab sizes and for validation of ResourceQuantity, allowing use of SI and NIST suffixes.

Switch to using bitmath's parse_string_unsafe, which handles the lack of a B suffix, supports K instead of k, and otherwise more closely matches the resource language used by Kubernetes.