### PR TITLE
DM-41630: Reorganize file server routes

### DIFF
--- a/controller/src/controller/handlers/files.py
+++ b/controller/src/controller/handlers/files.py
@@ -1,0 +1,86 @@
+"""Route handler for user file server creation.
+
+This router manages the route used by the user to create file servers. Unlike
+the administrative routes (in `controller.handlers.fileserver`), this route is
+not mounted under the general path prefix for the controller. It is instead
+mounted under the ``fileserver.path_prefix`` setting in the Nublado controller
+configuration. Normally, this is ``/files``.
+
+All requests for this route **and anything under this route** are directed to
+this route by the Kubernetes ``Ingress``. Specifically, this means that both
+``/files`` and :samp:`/files/{username}` (assuming the default path prefix)
+are sent to this route if there is no more specific ingress.
+
+When the user file server is created, it gets an accompanying ``Ingress``
+resource specific to that user (:samp:`/files/{username}`). Since that match
+is longer than the ``/files`` match in the general ``Ingress``, traffic for
+that user is then sent to their file server instead of to this route. When
+that file server times out and is deleted, the ``Ingress`` is also deleted,
+and the catch-all ``Ingress`` once again sends the user to this route, where a
+new file server will be spawned.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import HTMLResponse, Response
+from safir.models import ErrorModel
+from safir.slack.webhook import SlackRouteErrorHandler
+
+from ..config import Config
+from ..dependencies.config import config_dependency
+from ..dependencies.context import RequestContext, context_dependency
+from ..dependencies.user import user_dependency
+from ..exceptions import NotConfiguredError
+from ..models.v1.lab import UserInfo
+from ..templates import templates
+
+router = APIRouter(route_class=SlackRouteErrorHandler)
+"""Router to mount into the application."""
+
+__all__ = ["router"]
+
+
+@router.get(
+    "",
+    summary="Create file server for user",
+    responses={403: {"description": "Forbidden", "model": ErrorModel}},
+    response_class=HTMLResponse,
+)
+async def route_user(
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    config: Annotated[Config, Depends(config_dependency)],
+    user: Annotated[UserInfo, Depends(user_dependency)],
+) -> Response:
+    context.rebind_logger(user=user.username)
+    if not config.fileserver.enabled:
+        raise NotConfiguredError("Fileserver is disabled in configuration")
+
+    # Spawn the file server if necessary.
+    try:
+        await context.fileserver_manager.create(user)
+    except Exception as e:
+        # The exception (other than timeout errors) was already reported to
+        # Slack at the service layer, so convert it to a standard error
+        # message instead of letting it propagate as an uncaught exception.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=[
+                {
+                    "msg": f"Failed to create file server: {e!s}",
+                    "type": "file_server_create_failed",
+                }
+            ],
+        ) from e
+
+    # Construct and return the instructions page.
+    return templates.TemplateResponse(
+        "fileserver.html.jinja",
+        {
+            "request": context.request,
+            "username": user.username,
+            "base_url": config.base_url,
+            "path_prefix": config.fileserver.path_prefix,
+            "timeout": config.fileserver.idle_timeout,
+        },
+    )

--- a/controller/src/controller/handlers/fileserver.py
+++ b/controller/src/controller/handlers/fileserver.py
@@ -1,106 +1,23 @@
-"""Rounte handlers for user file servers."""
+"""Route handlers for administrative control of user file servers.
+
+This does not include the route normally used by users to spawn a file server.
+That route uses a separate path prefix and is defined in a different router in
+`controller.handlers.files`.
+"""
 
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import HTMLResponse, Response
 from safir.models import ErrorModel
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from ..config import Config
-from ..dependencies.config import config_dependency
 from ..dependencies.context import RequestContext, context_dependency
-from ..dependencies.user import user_dependency
-from ..exceptions import NotConfiguredError, UnknownUserError
-from ..models.v1.lab import UserInfo
-from ..templates import templates
+from ..exceptions import UnknownUserError
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
-user_router = APIRouter(route_class=SlackRouteErrorHandler)
 """Router to mount into the application."""
 
-__all__ = ["router", "user_router"]
-
-# This router does not go under the safir path prefix, but under its own,
-# which by default is "" -- that is, user files are typically accessed as
-# <base-url>/files
-#
-# Note that we don't care what's after /files.
-#
-# That's because the requesting user is identified by the header,
-# and if there is already a more specific ingress path, then that
-# ingress will handle the request and we will never see it.  That will be
-# the case if the user already has a running fileserver, since
-# /files/<username> will already be a (basic-auth) ingress for WebDAV.
-#
-# So either the user went to just "/files", in which case we figure
-# out whether they need an ingress, and create it (and the backing
-# fileserver) if so, or they went to "/files/<themselves>" but there
-# is no ingress and backing fileserver, so we need to create it, or
-# they went to "/files/<someone-else>" and there is no ingress for
-# <someone-else>.  In the last case, we do exactly the same thing as
-# for "/files": determine whether they themselves have a fileserver'
-# and create it if it doesn't exist.
-#
-# In all these cases, we provide documentation of how to use the created
-# fileserver.  This should eventually move into SquareOne and be nicely
-# styled.
-#
-# Finally, if they go to "/files/<someone-else>" and there already
-# is an ingress (that is, someone-else already has a running fileserver)
-# then the user request will go there (and we will never see the request).
-# In that case, it's not our problem; in any event, they won't have a token
-# that lets them authenticate to WebDAV behind that ingress, so they can't
-# do anything nefarious.
-
-
-@user_router.get(
-    "",
-    summary="Allow user to access files, spawning new fileserver if needed.",
-    responses={403: {"description": "Forbidden", "model": ErrorModel}},
-    response_class=HTMLResponse,
-)
-async def route_user(
-    context: Annotated[RequestContext, Depends(context_dependency)],
-    config: Annotated[Config, Depends(config_dependency)],
-    user: Annotated[UserInfo, Depends(user_dependency)],
-) -> Response:
-    context.rebind_logger(user=user.username)
-    if not config.fileserver.enabled:
-        raise NotConfiguredError("Fileserver is disabled in configuration")
-
-    # Spawn the file server if necessary.
-    try:
-        await context.fileserver_manager.create(user)
-    except Exception as e:
-        # The exception (other than timeout errors) was already reported to
-        # Slack at the service layer, so convert it to a standard error
-        # message instead of letting it propagate as an uncaught exception.
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=[
-                {
-                    "msg": f"Failed to create file server: {e!s}",
-                    "type": "file_server_create_failed",
-                }
-            ],
-        ) from e
-
-    # Construct and return the instructions page.
-    return templates.TemplateResponse(
-        "fileserver.html.jinja",
-        {
-            "request": context.request,
-            "username": user.username,
-            "base_url": config.base_url,
-            "path_prefix": config.fileserver.path_prefix,
-            "timeout": config.fileserver.idle_timeout,
-        },
-    )
-
-
-# The remaining endpoints are for administrative functions and can be
-# tucked under the safir path prefix
+__all__ = ["router"]
 
 
 @router.get(

--- a/controller/src/controller/main.py
+++ b/controller/src/controller/main.py
@@ -18,7 +18,15 @@ from sse_starlette.sse import AppStatus
 
 from .dependencies.config import config_dependency
 from .dependencies.context import context_dependency
-from .handlers import fileserver, form, index, labs, prepuller, user_status
+from .handlers import (
+    files,
+    fileserver,
+    form,
+    index,
+    labs,
+    prepuller,
+    user_status,
+)
 
 __all__ = ["create_app"]
 
@@ -70,17 +78,18 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    # Attach the routers.
+    # Attach the main controller routers.
     app.include_router(index.internal_router)
     app.include_router(index.external_router, prefix=config.path_prefix)
     app.include_router(form.router, prefix=config.path_prefix)
     app.include_router(labs.router, prefix=config.path_prefix)
     app.include_router(prepuller.router, prefix=config.path_prefix)
     app.include_router(user_status.router, prefix=config.path_prefix)
-    app.include_router(
-        fileserver.user_router, prefix=config.fileserver.path_prefix
-    )
     app.include_router(fileserver.router, prefix=config.path_prefix)
+    app.include_router(fileserver.router, prefix=config.path_prefix)
+
+    # Attach the separate router for user file server creation.
+    app.include_router(files.router, prefix=config.fileserver.path_prefix)
 
     # Register middleware.
     app.add_middleware(XForwardedMiddleware)

--- a/controller/tests/handlers/files_test.py
+++ b/controller/tests/handlers/files_test.py
@@ -22,7 +22,7 @@ from ..support.fileserver import (
 
 
 @pytest.mark.asyncio
-async def test_fileserver(
+async def test_create_delete(
     client: AsyncClient,
     user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,


### PR DESCRIPTION
Separate the route for the user /files handler into a separate module so that we aren't juggling two routers in the same handler module. Move the long comment explaining how this handler works into the module documentation.