### PR TITLE
DM-41630: Filter available labs by the user's quota

### DIFF
--- a/controller/src/controller/exceptions.py
+++ b/controller/src/controller/exceptions.py
@@ -25,6 +25,7 @@ __all__ = [
     "DuplicateObjectError",
     "GafaelfawrParseError",
     "GafaelfawrWebError",
+    "InsufficientQuotaError",
     "InvalidDockerReferenceError",
     "InvalidLabSizeError",
     "InvalidTokenError",
@@ -44,6 +45,13 @@ class FileserverCreationError(ClientRequestError):
 
     error = "fileserver_creation_failed"
     status_code = status.HTTP_400_BAD_REQUEST
+
+
+class InsufficientQuotaError(ClientRequestError):
+    """The user's quota is insufficient to satisfy this request."""
+
+    error = "insufficient_quota"
+    status_code = status.HTTP_403_FORBIDDEN
 
 
 class InvalidDockerReferenceError(ClientRequestError):

--- a/controller/src/controller/models/domain/gafaelfawr.py
+++ b/controller/src/controller/models/domain/gafaelfawr.py
@@ -49,6 +49,11 @@ class NotebookQuota(BaseModel):
         ..., title="Maximum memory use (GiB)", examples=[16.0]
     )
 
+    @property
+    def memory_bytes(self) -> int:
+        """Maximum memory use in bytes."""
+        return int(self.memory * 1024 * 1024 * 1024)
+
 
 class UserQuota(BaseModel):
     """Quota information for a user."""

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -146,8 +146,11 @@ lab:
       cpu: 2.0
       memory: 6Gi
     large:
-      cpu: 4.0
-      memory: 12Gi
+      cpu: 9.0
+      memory: 27Gi
+    huge:
+      cpu: 12.0
+      memory: 32Gi
   volumes:
     - containerPath: /home
       source:

--- a/controller/tests/data/standard/output/lab-form.html
+++ b/controller/tests/data/standard/output/lab-form.html
@@ -51,7 +51,7 @@ function selectDropdown() {
     </label><br />
     <input type="radio" name="size" id="large" value="large">
     <label for="large">
-      Large (4.0 CPU, 12Gi RAM)
+      Large (9.0 CPU, 27Gi RAM)
     </label><br />
   </div>
   <br />

--- a/controller/tests/handlers/form_test.py
+++ b/controller/tests/handlers/form_test.py
@@ -24,10 +24,10 @@ async def test_lab_form(client: AsyncClient, user: GafaelfawrUser) -> None:
 
 
 @pytest.mark.asyncio
-async def test_errors(client: AsyncClient) -> None:
+async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
     r = await client.get(
-        "/nublado/spawner/v1/lab-form/someuser",
-        headers={"X-Auth-Request-User": "otheruser"},
+        "/nublado/spawner/v1/lab-form/otheruser",
+        headers=user.to_headers(),
     )
     assert r.status_code == 403
     assert r.json() == {

--- a/controller/tests/handlers/labs_test.py
+++ b/controller/tests/handlers/labs_test.py
@@ -630,6 +630,26 @@ async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
         ]
     }
 
+    # Test requesting a lab size too large for the user's quota.
+    r = await client.post(
+        f"/nublado/spawner/v1/labs/{user.username}/create",
+        json={
+            "options": {"image_tag": "recommended", "size": "huge"},
+            "env": lab.env,
+        },
+        headers=user.to_headers(),
+    )
+    assert r.status_code == 403
+    assert r.json() == {
+        "detail": [
+            {
+                "loc": ["body", "options", "size"],
+                "msg": "Insufficient quota to spawn requested lab",
+                "type": "insufficient_quota",
+            }
+        ]
+    }
+
 
 @pytest.mark.asyncio
 async def test_spawn_errors(


### PR DESCRIPTION
Do not display lab sizes that are larger than the user's quota in the spawner menu, and reject attempts to create labs larger than the user's quota in the LabManager.