### PR TITLE
DM-41630: Add request timeouts to all Kubernetes calls

### DIFF
--- a/controller/src/controller/constants.py
+++ b/controller/src/controller/constants.py
@@ -12,6 +12,7 @@ __all__ = [
     "FILE_SERVER_REFRESH_INTERVAL",
     "IMAGE_REFRESH_INTERVAL",
     "KUBERNETES_DELETE_TIMEOUT",
+    "KUBERNETES_REQUEST_TIMEOUT",
     "LAB_COMMAND",
     "LAB_STATE_REFRESH_INTERVAL",
     "LIMIT_TO_REQUEST_RATIO",
@@ -63,6 +64,14 @@ In some cases, if a Kubernetes object the controller is trying to create
 already exists, it deletes that object and then retries the creation. This
 controls how long it waits for the object to go away after deletion before it
 gives up.
+"""
+
+KUBERNETES_REQUEST_TIMEOUT = timedelta(seconds=30)
+"""How long to wait for any given Kubernetes API call.
+
+This timeout is currently applied to each Kubernetes API call in isolation,
+just to impose an upper limit on how long we'll wait of the control plane is
+nonresponsive.
 """
 
 LAB_COMMAND = "/opt/lsst/software/jupyterlab/runlab.sh"

--- a/controller/src/controller/storage/kubernetes/creator.py
+++ b/controller/src/controller/storage/kubernetes/creator.py
@@ -28,6 +28,7 @@ from kubernetes_asyncio.client import (
 )
 from structlog.stdlib import BoundLogger
 
+from ...constants import KUBERNETES_REQUEST_TIMEOUT
 from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import KubernetesModel
 
@@ -103,7 +104,11 @@ class KubernetesObjectCreator(Generic[T]):
         msg = f"Creating {self._kind}"
         self._logger.debug(msg, name=body.metadata.name, namespace=namespace)
         try:
-            await self._create(namespace, body)
+            await self._create(
+                namespace,
+                body,
+                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
+            )
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error creating object",
@@ -134,7 +139,11 @@ class KubernetesObjectCreator(Generic[T]):
             Raised for exceptions from the Kubernetes API server.
         """
         try:
-            return await self._read(name, namespace)
+            return await self._read(
+                name,
+                namespace,
+                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
+            )
         except ApiException as e:
             if e.status == 404:
                 return None

--- a/controller/src/controller/storage/kubernetes/custom.py
+++ b/controller/src/controller/storage/kubernetes/custom.py
@@ -10,7 +10,7 @@ from kubernetes_asyncio import client
 from kubernetes_asyncio.client import ApiClient, ApiException
 from structlog.stdlib import BoundLogger
 
-from ...constants import KUBERNETES_DELETE_TIMEOUT
+from ...constants import KUBERNETES_DELETE_TIMEOUT, KUBERNETES_REQUEST_TIMEOUT
 from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import PropagationPolicy, WatchEventType
 from .watcher import KubernetesWatcher
@@ -135,7 +135,12 @@ class CustomStorage:
         self._logger.debug(msg, name=name, namespace=namespace)
         try:
             await self._api.delete_namespaced_custom_object(
-                self._group, self._version, namespace, self._plural, name
+                self._group,
+                self._version,
+                namespace,
+                self._plural,
+                name,
+                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
             )
         except ApiException as e:
             if e.status == 404:
@@ -170,7 +175,11 @@ class CustomStorage:
         """
         try:
             objs = await self._api.list_namespaced_custom_object(
-                self._group, self._version, namespace, self._plural
+                self._group,
+                self._version,
+                namespace,
+                self._plural,
+                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
             )
         except ApiException as e:
             raise KubernetesError.from_exception(
@@ -203,7 +212,12 @@ class CustomStorage:
         """
         try:
             return await self._api.get_namespaced_custom_object(
-                self._group, self._version, namespace, self._plural, name
+                self._group,
+                self._version,
+                namespace,
+                self._plural,
+                name,
+                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
             )
         except ApiException as e:
             if e.status == 404:
@@ -294,7 +308,12 @@ class CustomStorage:
         name = body["metadata"]["name"]
         try:
             await self._api.create_namespaced_custom_object(
-                self._group, self._version, namespace, self._plural, body
+                self._group,
+                self._version,
+                namespace,
+                self._plural,
+                body,
+                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
             )
         except ApiException as e:
             raise KubernetesError.from_exception(

--- a/controller/src/controller/storage/kubernetes/deleter.py
+++ b/controller/src/controller/storage/kubernetes/deleter.py
@@ -24,7 +24,7 @@ from kubernetes_asyncio.client import (
 )
 from structlog.stdlib import BoundLogger
 
-from ...constants import KUBERNETES_DELETE_TIMEOUT
+from ...constants import KUBERNETES_DELETE_TIMEOUT, KUBERNETES_REQUEST_TIMEOUT
 from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import (
     KubernetesModel,
@@ -177,7 +177,9 @@ class KubernetesObjectDeleter(KubernetesObjectCreator, Generic[T]):
         KubernetesError
             Raised for exceptions from the Kubernetes API server.
         """
-        extra_args: dict[str, str | int] = {}
+        extra_args: dict[str, str | int] = {
+            "_request_timeout": int(KUBERNETES_REQUEST_TIMEOUT.total_seconds())
+        }
         body = None
         if propagation_policy:
             extra_args["propagation_policy"] = propagation_policy.value
@@ -233,7 +235,9 @@ class KubernetesObjectDeleter(KubernetesObjectCreator, Generic[T]):
         KubernetesError
             Raised for exceptions from the Kubernetes API server.
         """
-        extra_args = {}
+        extra_args: dict[str, str | int] = {
+            "_request_timeout": int(KUBERNETES_REQUEST_TIMEOUT.total_seconds())
+        }
         if label_selector:
             extra_args["label_selector"] = label_selector
         try:
@@ -244,7 +248,6 @@ class KubernetesObjectDeleter(KubernetesObjectCreator, Generic[T]):
                 e,
                 kind=self._kind,
                 namespace=namespace,
-                **extra_args,
             ) from e
         return objs.items
 

--- a/controller/src/controller/storage/kubernetes/node.py
+++ b/controller/src/controller/storage/kubernetes/node.py
@@ -6,6 +6,7 @@ from kubernetes_asyncio import client
 from kubernetes_asyncio.client import ApiClient, ApiException
 from structlog.stdlib import BoundLogger
 
+from ...constants import KUBERNETES_REQUEST_TIMEOUT
 from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import KubernetesNodeImage
 
@@ -36,8 +37,9 @@ class NodeStorage:
             Map of nodes to lists of all cached images on that node.
         """
         self._logger.debug("Getting node image data")
+        timeout = KUBERNETES_REQUEST_TIMEOUT.total_seconds()
         try:
-            nodes = await self._api.list_node()
+            nodes = await self._api.list_node(_request_timeout=timeout)
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error reading node information", e, kind="Node"


### PR DESCRIPTION
The default request timeout in kubernetes_asyncio if none is given is five minutes, which is rather long. We were already setting request timeouts for any watches. Set a shorter request timeout of one minute for other operations so that we don't wait too long if the Kubernetes control plane is not responding.

This timeout is currently hard-coded, but this change makes it possible to make it configurable in the future.