### PR TITLE
DM-41630: Further separate controller and hub testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,8 +60,7 @@ jobs:
 
   # The controller requires Python 3.11, but the modules we add to the Hub
   # have to run with Python 3.10 since that's what the JupyterHub image uses.
-  # Run a separate matrix to test those modules with only the versions of
-  # Python supported for the Hub but not supported for the controller.
+  # Run a separate matrix to test those modules.
   test-hub:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -70,6 +69,7 @@ jobs:
       matrix:
         python:
           - "3.10"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
           pip install --upgrade nox
 
       - name: Run nox
-        run: "nox -s test-hub"
+        run: "nox -s typing-hub test-hub"
 
   docs:
     runs-on: ubuntu-latest

--- a/controller/requirements/dev.in
+++ b/controller/requirements/dev.in
@@ -13,8 +13,6 @@
 asgi-lifespan
 coverage[toml]
 httpx-sse
-mypy
-pre-commit
 pytest
 pytest-asyncio
 pytest-cov

--- a/controller/requirements/dev.txt
+++ b/controller/requirements/dev.txt
@@ -47,10 +47,6 @@ certifi==2023.7.22 \
     #   httpcore
     #   httpx
     #   requests
-cfgv==3.4.0 \
-    --hash=sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9 \
-    --hash=sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560
-    # via pre-commit
 charset-normalizer==3.3.2 \
     --hash=sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027 \
     --hash=sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087 \
@@ -207,10 +203,6 @@ coverage[toml]==7.3.2 \
     # via
     #   -r controller/requirements/dev.in
     #   pytest-cov
-distlib==0.3.7 \
-    --hash=sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057 \
-    --hash=sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8
-    # via virtualenv
 documenteer[guide]==1.0.0a13 \
     --hash=sha256:3d2acd02110751166ea7e8dd7cebed723074afe4346079a816a3f9cd6297d24e \
     --hash=sha256:4dbac173d529d23127138fd45a187a426746ec5f11f94f0b8a02fe088a266381
@@ -229,10 +221,6 @@ docutils==0.20.1 \
     #   sphinx-jinja
     #   sphinx-prompt
     #   sphinxcontrib-bibtex
-filelock==3.13.1 \
-    --hash=sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e \
-    --hash=sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
-    # via virtualenv
 gitdb==4.0.11 \
     --hash=sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4 \
     --hash=sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
@@ -263,10 +251,6 @@ httpx-sse==0.3.1 \
     --hash=sha256:3bb3289b2867f50cbdb2fee3eeeefecb1e86653122e164faac0023f1ffc88aea \
     --hash=sha256:7376dd88732892f9b6b549ac0ad05a8e2341172fe7dcf9f8f9c8050934297316
     # via -r controller/requirements/dev.in
-identify==2.5.31 \
-    --hash=sha256:7736b3c7a28233637e3c36550646fc6389bedd74ae84cb788200cc8e2dd60b75 \
-    --hash=sha256:90199cb9e7bd3c5407a9b7e81b4abec4bb9d249991c79439ec8af740afc6293d
-    # via pre-commit
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
@@ -387,47 +371,10 @@ mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via markdown-it-py
-mypy==1.7.0 \
-    --hash=sha256:0e81ffd120ee24959b449b647c4b2fbfcf8acf3465e082b8d58fd6c4c2b27e46 \
-    --hash=sha256:185cff9b9a7fec1f9f7d8352dff8a4c713b2e3eea9c6c4b5ff7f0edf46b91e41 \
-    --hash=sha256:1e280b5697202efa698372d2f39e9a6713a0395a756b1c6bd48995f8d72690dc \
-    --hash=sha256:1fe46e96ae319df21359c8db77e1aecac8e5949da4773c0274c0ef3d8d1268a9 \
-    --hash=sha256:2b53655a295c1ed1af9e96b462a736bf083adba7b314ae775563e3fb4e6795f5 \
-    --hash=sha256:551d4a0cdcbd1d2cccdcc7cb516bb4ae888794929f5b040bb51aae1846062901 \
-    --hash=sha256:55d28d7963bef00c330cb6461db80b0b72afe2f3c4e2963c99517cf06454e665 \
-    --hash=sha256:5da84d7bf257fd8f66b4f759a904fd2c5a765f70d8b52dde62b521972a0a2357 \
-    --hash=sha256:6cb8d5f6d0fcd9e708bb190b224089e45902cacef6f6915481806b0c77f7786d \
-    --hash=sha256:7a7b1e399c47b18feb6f8ad4a3eef3813e28c1e871ea7d4ea5d444b2ac03c418 \
-    --hash=sha256:870bd1ffc8a5862e593185a4c169804f2744112b4a7c55b93eb50f48e7a77010 \
-    --hash=sha256:87c076c174e2c7ef8ab416c4e252d94c08cd4980a10967754f91571070bf5fbe \
-    --hash=sha256:96650d9a4c651bc2a4991cf46f100973f656d69edc7faf91844e87fe627f7e96 \
-    --hash=sha256:a3637c03f4025f6405737570d6cbfa4f1400eb3c649317634d273687a09ffc2f \
-    --hash=sha256:a79cdc12a02eb526d808a32a934c6fe6df07b05f3573d210e41808020aed8b5d \
-    --hash=sha256:b633f188fc5ae1b6edca39dae566974d7ef4e9aaaae00bc36efe1f855e5173ac \
-    --hash=sha256:bf7a2f0a6907f231d5e41adba1a82d7d88cf1f61a70335889412dec99feeb0f8 \
-    --hash=sha256:c1b06b4b109e342f7dccc9efda965fc3970a604db70f8560ddfdee7ef19afb05 \
-    --hash=sha256:cddee95dea7990e2215576fae95f6b78a8c12f4c089d7e4367564704e99118d3 \
-    --hash=sha256:d01921dbd691c4061a3e2ecdbfbfad029410c5c2b1ee88946bf45c62c6c91210 \
-    --hash=sha256:d0fa29919d2e720c8dbaf07d5578f93d7b313c3e9954c8ec05b6d83da592e5d9 \
-    --hash=sha256:d6ed9a3997b90c6f891138e3f83fb8f475c74db4ccaa942a1c7bf99e83a989a1 \
-    --hash=sha256:d93e76c2256aa50d9c82a88e2f569232e9862c9982095f6d54e13509f01222fc \
-    --hash=sha256:df67fbeb666ee8828f675fee724cc2cbd2e4828cc3df56703e02fe6a421b7401 \
-    --hash=sha256:f29386804c3577c83d76520abf18cfcd7d68264c7e431c5907d250ab502658ee \
-    --hash=sha256:f65f385a6f43211effe8c682e8ec3f55d79391f70a201575def73d08db68ead1 \
-    --hash=sha256:fc9fe455ad58a20ec68599139ed1113b21f977b536a91b42bef3ffed5cce7391
-    # via -r controller/requirements/dev.in
-mypy-extensions==1.0.0 \
-    --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
-    --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-    # via mypy
 myst-parser==2.0.0 \
     --hash=sha256:7c36344ae39c8e740dad7fdabf5aa6fc4897a813083c6cc9990044eb93656b14 \
     --hash=sha256:ea929a67a6a0b1683cdbe19b8d2e724cd7643f8aa3e7bb18dd65beac3483bead
     # via documenteer
-nodeenv==1.8.0 \
-    --hash=sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2 \
-    --hash=sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec
-    # via pre-commit
 packaging==23.2 \
     --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
     --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
@@ -436,18 +383,10 @@ packaging==23.2 \
     #   pytest
     #   pytest-sugar
     #   sphinx
-platformdirs==3.11.0 \
-    --hash=sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3 \
-    --hash=sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e
-    # via virtualenv
 pluggy==1.3.0 \
     --hash=sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12 \
     --hash=sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7
     # via pytest
-pre-commit==3.5.0 \
-    --hash=sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32 \
-    --hash=sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660
-    # via -r controller/requirements/dev.in
 pybtex==0.24.0 \
     --hash=sha256:818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755 \
     --hash=sha256:e1e0c8c69998452fea90e9179aa2a98ab103f3eed894405b7264e517cc2fcc0f
@@ -655,7 +594,6 @@ pyyaml==6.0.1 \
     #   -c controller/requirements/main.txt
     #   documenteer
     #   myst-parser
-    #   pre-commit
     #   pybtex
     #   sphinxcontrib-redoc
 referencing==0.30.2 \
@@ -913,7 +851,6 @@ typing-extensions==4.8.0 \
     --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
     # via
     #   -c controller/requirements/main.txt
-    #   mypy
     #   pydantic
     #   pydantic-core
 uc-micro-py==1.0.2 \
@@ -927,15 +864,3 @@ urllib3==2.1.0 \
     #   -c controller/requirements/main.txt
     #   documenteer
     #   requests
-virtualenv==20.24.6 \
-    --hash=sha256:02ece4f56fbf939dbbc33c0715159951d6bf14aaf5457b092e4548e1382455af \
-    --hash=sha256:520d056652454c5098a00c0f073611ccbea4c79089331f60bf9d7ba247bb7381
-    # via pre-commit
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==68.2.2 \
-    --hash=sha256:4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87 \
-    --hash=sha256:b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
-    # via
-    #   -c controller/requirements/main.txt
-    #   nodeenv

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -82,7 +82,12 @@ To run all Nublado tests, run:
    nox -s
 
 This tests the library in the same way that the CI workflow does.
-You may wish to run the individual environments (``lint``, ``typing``, ``test``, and ``docs``) when iterating on a specific change.
+You may wish to run the individual sessions (``lint``, ``typing``, ``typing-hub``, ``test``, ``test-hub``, and ``docs``) when iterating on a specific change.
+
+mypy and pytest tests are divided into two nox sessions: one for the Nublado controller (the default) and one for JupyterHub and its plugins.
+The JupyterHub plugins have to support different versions of Python and have different frozen dependencies, so must be tested separately.
+Use the ``typing-hub`` and ``test-hub`` sessions to do that.
+Since most code and thus most code changes is part of the controller, the ``typing`` and ``test`` sessions with no suffix test it.
 
 To see a listing of nox sessions:
 
@@ -90,7 +95,7 @@ To see a listing of nox sessions:
 
    nox --list
 
-To run a specific test or list of tests, you can add test file names (and any other pytest_ options) after ``--`` when executing the ``test`` nox session.
+To run a specific test or list of tests, you can add test file names (and any other pytest_ options) after ``--`` when executing the ``test`` or ``test-hub`` nox session.
 For example:
 
 .. prompt:: bash


### PR DESCRIPTION
Since the controller and hub use separate frozen dependencies, they should use entirely separate testing sessions for both mypy and pytest. Separate JupyterHub plugin type checking into typing-hub, and clean up the dependency installation.

Remove mypy and pre-commit from dev dependencies for the controller since they aren't used in controller tests. Their installation is properly handled by nox.

Improve the logic for deciding which tests to run when pytest is given arguments, although this is now mostly useful for the test-hub session.