### PR TITLE
DM-41630: Fix Nublado Docker image build issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,7 +166,7 @@ jobs:
       - uses: lsst-sqre/build-and-push-to-ghcr@v1
         id: build-hub
         with:
-          dockerfile: Dockerfile.controller
+          dockerfile: Dockerfile.hub
           image: ${{ github.repository }}-jupyterhub
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -47,7 +47,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . /workdir
 WORKDIR /workdir
-RUN pip install --no-cache-dir controller
+RUN pip install --no-cache-dir ./controller
 
 FROM base-image AS runtime-image
 

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -35,7 +35,7 @@ FROM dependencies-image as runtime-image
 # Install the extra JupyterHub modules.
 COPY . /app
 WORKDIR /app
-RUN pip install --no-cache-dir ./authenticator ./spawner
+RUN pip install --no-deps --no-cache-dir ./authenticator ./spawner
 
 # Create a non-root user to run JupyterHub. Upstream uses 768 as the UID
 # and GID. This value must be kept in sync with the Phalanx nublado

--- a/controller/scripts/start.sh
+++ b/controller/scripts/start.sh
@@ -4,5 +4,4 @@
 
 set -eu
 
-uvicorn --factory jupyterlabcontroller.main:create_app \
-    --host 0.0.0.0 --port 8080
+uvicorn --factory controller.main:create_app --host 0.0.0.0 --port 8080


### PR DESCRIPTION
Fix various Docker build issues with the new vertical monorepo setup:

- Fix the start command for the Nublado controller to use the correct Python module name
- Use the correct Dockerfile when building the JupyterHub image
- Install the correct controller package and not some random package named controller from PyPI
- Do not install dependencies for JupyterHub modules, since for some reason that downgrades JupyterHub