### PR TITLE
DM-41630: Use a list for lab sizes instead of a dict

### DIFF
--- a/controller/src/controller/handlers/form.py
+++ b/controller/src/controller/handlers/form.py
@@ -42,11 +42,11 @@ async def get_user_lab_form(
     # than the user's quota, if they have a quota.
     if user.quota and user.quota.notebook:
         quota = user.quota.notebook
-        sizes = {
-            k: v
-            for k, v in config.lab.sizes.items()
-            if v.memory_bytes <= quota.memory_bytes and v.cpu <= quota.cpu
-        }
+        sizes = [
+            s
+            for s in config.lab.sizes
+            if s.memory_bytes <= quota.memory_bytes and s.cpu <= quota.cpu
+        ]
         if not sizes:
             msg = "Insufficient quota to spawn smallest lab"
             raise InsufficientQuotaError(msg)

--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -326,7 +326,7 @@ class LabBuilder:
             env["RESET_USER_ENV"] = "TRUE"
 
         # Add standard environment variables.
-        size = self._config.sizes[lab.options.size]
+        size = self._config.get_size_definition(lab.options.size)
         resources = size.to_lab_resources()
         env.update(
             {
@@ -338,7 +338,7 @@ class LabBuilder:
                 "IMAGE_DESCRIPTION": image.display_name,
                 "IMAGE_DIGEST": image.digest,
                 # Container data for display frame.
-                "CONTAINER_SIZE": f"{lab.options.size.value.title()} ({size})",
+                "CONTAINER_SIZE": str(size),
                 # Normally set by JupyterHub so keep compatibility.
                 "CPU_GUARANTEE": str(resources.requests.cpu),
                 "CPU_LIMIT": str(resources.limits.cpu),
@@ -505,7 +505,8 @@ class LabBuilder:
         self, user: GafaelfawrUserInfo, lab: LabSpecification, image: RSPImage
     ) -> V1Pod:
         """Construct the user's lab pod."""
-        resources = self._config.sizes[lab.options.size].to_lab_resources()
+        size = self._config.get_size_definition(lab.options.size)
+        resources = size.to_lab_resources()
 
         # Construct the pull secrets.
         pull_secrets = None
@@ -925,8 +926,8 @@ class LabBuilder:
             not, returns ``LabSize.CUSTOM``.
         """
         limits = resources.limits
-        for size, definition in self._config.sizes.items():
+        for definition in self._config.sizes:
             memory = definition.memory_bytes
             if definition.cpu == limits.cpu and memory == limits.memory:
-                return size
+                return definition.size
         return LabSize.CUSTOM

--- a/controller/src/controller/services/lab.py
+++ b/controller/src/controller/services/lab.py
@@ -235,9 +235,10 @@ class LabManager:
             image = await self._image_service.image_for_tag_name(tag)
 
         # Determine the resources to assign to the lab.
-        if spec.options.size not in self._config.sizes:
-            raise InvalidLabSizeError(spec.options.size)
-        size = self._config.sizes[spec.options.size]
+        try:
+            size = self._config.get_size_definition(spec.options.size)
+        except KeyError as e:
+            raise InvalidLabSizeError(spec.options.size) from e
         if user.quota and user.quota.notebook:
             quota = user.quota.notebook
             if quota.memory_bytes < size.memory_bytes or quota.cpu < size.cpu:

--- a/controller/src/controller/templates/spawner.html.jinja
+++ b/controller/src/controller/templates/spawner.html.jinja
@@ -41,10 +41,10 @@ function selectDropdown() {
 </td>
 <td width="50%">
   <div class="radio radio-inline">
-{%- for key, value in sizes.items() %}
-    <input type="radio" name="size" id="{{ key.value }}" value="{{ key.value }}"{% if loop.first %} checked{% endif %}>
-    <label for="{{ key.value }}">
-      {{ key.value.title() }} ({{ value }})
+{%- for definition in sizes %}
+    <input type="radio" name="size" id="{{ definition.size.value }}" value="{{ definition.size.value }}"{% if loop.first %} checked{% endif %}>
+    <label for="{{ definition.size.value }}">
+      {{ definition }}
     </label><br />
 {%- endfor %}
   </div>

--- a/controller/tests/data/cycle/input/config.yaml
+++ b/controller/tests/data/cycle/input/config.yaml
@@ -3,7 +3,7 @@ profile: development
 lab:
   namespacePrefix: userlabs
   sizes:
-    small:
+    - size: small
       cpu: 1.0
       memory: 3Gi
 images:

--- a/controller/tests/data/extra-annotations/input/config.yaml
+++ b/controller/tests/data/extra-annotations/input/config.yaml
@@ -6,7 +6,7 @@ lab:
   extraAnnotations:
     k8s.v1.cni.cncf.io/networks: "kube-system/dds"
   sizes:
-    small:
+    - size: small
       cpu: 1.0
       memory: 3Gi
   volumes:

--- a/controller/tests/data/fileserver/input/config.yaml
+++ b/controller/tests/data/fileserver/input/config.yaml
@@ -3,7 +3,7 @@ profile: development
 lab:
   namespacePrefix: userlabs
   sizes:
-    small:
+    - size: small
       cpu: 1.0
       memory: 3Gi
   volumes:

--- a/controller/tests/data/gar-cycle/input/config.yaml
+++ b/controller/tests/data/gar-cycle/input/config.yaml
@@ -3,7 +3,7 @@ profile: development
 lab:
   namespacePrefix: userlabs
   sizes:
-    small:
+    - size: small
       cpu: 1.0
       memory: 3Gi
 images:

--- a/controller/tests/data/gar/input/config.yaml
+++ b/controller/tests/data/gar/input/config.yaml
@@ -3,7 +3,7 @@ profile: development
 lab:
   namespacePrefix: userlabs
   sizes:
-    small:
+    - size: small
       cpu: 1.0
       memory: 3Gi
 images:

--- a/controller/tests/data/homedir-schema/input/config.yaml
+++ b/controller/tests/data/homedir-schema/input/config.yaml
@@ -9,7 +9,7 @@ lab:
   homedirSuffix: "/jhome/"
   namespacePrefix: userlabs
   sizes:
-    small:
+    - size: small
       cpu: 1.0
       memory: 3Gi
   volumes:

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -139,16 +139,16 @@ lab:
     - secretName: extra-secret
       secretKey: db-password
   sizes:
-    small:
+    - size: small
       cpu: 1.0
       memory: 3Gi
-    medium:
+    - size: medium
       cpu: 2.0
       memory: 6Gi
-    large:
+    - size: large
       cpu: 9.0
       memory: 27Gi
-    huge:
+    - size: huge
       cpu: 12.0
       memory: 32Gi
   volumes:

--- a/controller/tests/handlers/labs_test.py
+++ b/controller/tests/handlers/labs_test.py
@@ -135,7 +135,8 @@ async def test_lab_start_stop(
     assert r.json() == [user.username]
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 200
-    expected_resources = config.lab.sizes[lab.options.size].to_lab_resources()
+    size = config.lab.get_size_definition(lab.options.size)
+    expected_resources = size.to_lab_resources()
     expected_options = lab.options.model_dump()
     expected_options["image_dropdown"] = expected_options["image_list"]
     expected_options["image_list"] = None

--- a/controller/tests/handlers/user_status_test.py
+++ b/controller/tests/handlers/user_status_test.py
@@ -60,7 +60,8 @@ async def test_user_status(
         "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 200
-    expected_resources = config.lab.sizes[lab.options.size].to_lab_resources()
+    size = config.lab.get_size_definition(lab.options.size)
+    expected_resources = size.to_lab_resources()
     expected = {
         "env": lab.env,
         "internal_url": "http://lab.userlabs-rachel:8888/nb/user/rachel/",

--- a/controller/tests/services/lab_test.py
+++ b/controller/tests/services/lab_test.py
@@ -65,7 +65,8 @@ async def create_lab(
     assert user.quota
     assert user.quota.notebook
     lab = read_input_lab_specification_json("base", "lab-specification.json")
-    resources = config.lab.sizes[lab.options.size].to_lab_resources()
+    size = config.lab.get_size_definition(lab.options.size)
+    resources = size.to_lab_resources()
     await factory.image_service.refresh()
     assert lab.options.image_list
     reference = DockerReference.from_str(lab.options.image_list)


### PR DESCRIPTION
Either Argo CD or Helm sorts the keys of a dict in a chart configuration before applying the chart, so using a dict for lab sizes does not preserve order. Change it to a list and add a helper function to retrieve the definition for a specific size.