### PR TITLE
DM-41708: Fix nox -s test with specific files

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -199,7 +199,7 @@ def test(session: nox.Session) -> None:
             "--cov=controller",
             "--cov-branch",
             "--cov-report=",
-            *session.posargs,
+            *(a.removeprefix("controller/") for a in session.posargs),
         )
 
 


### PR DESCRIPTION
When refactoring the test support to further separate JupyterHub from the Nublado controller, the support for running specific tests was accidentally removed. Re-add that.