### PR TITLE
DM-41708: Use GafaelfawrUserInfo for file server creation

### DIFF
--- a/controller/src/controller/handlers/files.py
+++ b/controller/src/controller/handlers/files.py
@@ -32,7 +32,7 @@ from ..dependencies.config import config_dependency
 from ..dependencies.context import RequestContext, context_dependency
 from ..dependencies.user import user_dependency
 from ..exceptions import NotConfiguredError
-from ..models.v1.lab import UserInfo
+from ..models.domain.gafaelfawr import GafaelfawrUser
 from ..templates import templates
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
@@ -50,7 +50,7 @@ __all__ = ["router"]
 async def route_user(
     context: Annotated[RequestContext, Depends(context_dependency)],
     config: Annotated[Config, Depends(config_dependency)],
-    user: Annotated[UserInfo, Depends(user_dependency)],
+    user: Annotated[GafaelfawrUser, Depends(user_dependency)],
 ) -> Response:
     context.rebind_logger(user=user.username)
     if not config.fileserver.enabled:

--- a/controller/src/controller/services/builder/fileserver.py
+++ b/controller/src/controller/services/builder/fileserver.py
@@ -30,7 +30,7 @@ from ...models.domain.fileserver import (
     FileserverObjects,
     FileserverStateObjects,
 )
-from ...models.v1.lab import UserInfo
+from ...models.domain.gafaelfawr import GafaelfawrUserInfo
 from ...storage.kubernetes.ingress import ingress_has_ip_address
 from .volumes import VolumeBuilder
 
@@ -64,7 +64,7 @@ class FileserverBuilder:
         self._logger = logger
         self._volume_builder = VolumeBuilder()
 
-    def build(self, user: UserInfo) -> FileserverObjects:
+    def build(self, user: GafaelfawrUserInfo) -> FileserverObjects:
         """Construct the objects that make up a user's fileserver.
 
         Parameters
@@ -209,7 +209,7 @@ class FileserverBuilder:
             },
         }
 
-    def _build_job(self, user: UserInfo) -> V1Job:
+    def _build_job(self, user: GafaelfawrUserInfo) -> V1Job:
         """Construct the job for a fileserver."""
         volume_data = self._volume_builder.build_mounted_volumes(
             user.username, self._volumes, prefix="/mnt"

--- a/controller/src/controller/services/fileserver.py
+++ b/controller/src/controller/services/fileserver.py
@@ -19,8 +19,8 @@ from ..exceptions import (
     MissingObjectError,
     UnknownUserError,
 )
+from ..models.domain.gafaelfawr import GafaelfawrUserInfo
 from ..models.domain.kubernetes import PodPhase
-from ..models.v1.lab import UserInfo
 from ..storage.kubernetes.fileserver import FileserverStorage
 from .builder.fileserver import FileserverBuilder
 
@@ -83,7 +83,7 @@ class FileserverManager:
         # Mapping of usernames to internal state.
         self._servers: dict[str, _State] = {}
 
-    async def create(self, user: UserInfo) -> None:
+    async def create(self, user: GafaelfawrUserInfo) -> None:
         """Ensure a file server exists for the given user.
 
         If the user doesn't have a fileserver, create it.  If the user already
@@ -201,7 +201,7 @@ class FileserverManager:
         self._scheduler = None
 
     async def _create_file_server(
-        self, user: UserInfo, timeout: timedelta
+        self, user: GafaelfawrUserInfo, timeout: timedelta
     ) -> None:
         """Create a fileserver for the given user.
 


### PR DESCRIPTION
The file server was taking a UserInfo parameter, but we were actually passing in a GafaelfawrUser model. This happened to work because the fields had the same name, but it was incorrect. Switch all of the types to GafaelfawrUserInfo instead.