### PR TITLE
DM-41708: Separate volumes and volume mounts

### DIFF
--- a/controller/src/controller/constants.py
+++ b/controller/src/controller/constants.py
@@ -12,6 +12,7 @@ __all__ = [
     "FILE_SERVER_REFRESH_INTERVAL",
     "IMAGE_REFRESH_INTERVAL",
     "KUBERNETES_DELETE_TIMEOUT",
+    "KUBERNETES_NAME_PATTERN",
     "KUBERNETES_REQUEST_TIMEOUT",
     "LAB_COMMAND",
     "LAB_STATE_REFRESH_INTERVAL",
@@ -65,6 +66,9 @@ already exists, it deletes that object and then retries the creation. This
 controls how long it waits for the object to go away after deletion before it
 gives up.
 """
+
+KUBERNETES_NAME_PATTERN = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+"""Pattern matching valid Kubernetes names."""
 
 KUBERNETES_REQUEST_TIMEOUT = timedelta(seconds=30)
 """How long to wait for any given Kubernetes API call.

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -124,6 +124,7 @@ class ProcessContext:
                     config=config.fileserver,
                     base_url=config.base_url,
                     volumes=config.lab.volumes,
+                    volume_mounts=config.lab.volume_mounts,
                     logger=logger,
                 ),
                 fileserver_storage=FileserverStorage(

--- a/controller/src/controller/models/domain/fileserver.py
+++ b/controller/src/controller/models/domain/fileserver.py
@@ -3,7 +3,13 @@
 from dataclasses import dataclass
 from typing import Any
 
-from kubernetes_asyncio.client import V1Ingress, V1Job, V1Pod, V1Service
+from kubernetes_asyncio.client import (
+    V1Ingress,
+    V1Job,
+    V1PersistentVolumeClaim,
+    V1Pod,
+    V1Service,
+)
 
 __all__ = [
     "FileserverObjects",
@@ -14,6 +20,9 @@ __all__ = [
 @dataclass
 class FileserverObjects:
     """All of the Kubernetes objects making up a user's fileserver."""
+
+    pvcs: list[V1PersistentVolumeClaim]
+    """Persistent volume claims."""
 
     ingress: dict[str, Any]
     """``GafaelfawrIngress`` object for the fileserver."""

--- a/controller/src/controller/models/domain/kubernetes.py
+++ b/controller/src/controller/models/domain/kubernetes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Self
+from typing import Any, Self
 
 from kubernetes_asyncio.client import V1ContainerImage, V1ObjectMeta, V1Pod
 from typing_extensions import Protocol
@@ -31,6 +31,9 @@ class KubernetesModel(Protocol):
     """
 
     metadata: V1ObjectMeta
+
+    def to_dict(self, *, serialize: bool = False) -> dict[str, Any]:
+        ...
 
 
 class PodPhase(str, Enum):

--- a/controller/src/controller/services/builder/volumes.py
+++ b/controller/src/controller/services/builder/volumes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from kubernetes_asyncio.client import (
     V1HostPathVolumeSource,
     V1NFSVolumeSource,
@@ -12,11 +14,11 @@ from kubernetes_asyncio.client import (
 
 from ...config import (
     HostPathVolumeSource,
-    LabVolume,
     NFSVolumeSource,
     PVCVolumeSource,
+    VolumeConfig,
+    VolumeMountConfig,
 )
-from ...models.domain.volumes import MountedVolume
 
 __all__ = ["VolumeBuilder"]
 
@@ -28,82 +30,8 @@ class VolumeBuilder:
     labs and fileservers.
     """
 
-    def build_mounted_volumes(
-        self, username: str, volumes: list[LabVolume], prefix: str = ""
-    ) -> list[MountedVolume]:
-        """Construct volumes and mounts for volumes in the lab configuration.
-
-        Parameters
-        ----------
-        username
-            Name of user this lab is for, used to name the PVC objects.
-        volumes
-            Configured volumes.
-        prefix
-            Prefix to prepend to all mount paths, if given.
-
-        Returns
-        -------
-        list of MountedVolume
-            List of volumes and mounts.
-        """
-        volume_objects = self._build_volumes(username, volumes)
-        mounts = self._build_mounts(volumes, prefix)
-        return [
-            MountedVolume(volume=v, volume_mount=m)
-            for v, m in zip(volume_objects, mounts, strict=True)
-        ]
-
-    def _build_volume_name(self, volume: LabVolume) -> str:
-        """Construct the name of the volume resource."""
-        return volume.container_path.replace("/", "-")[1:].lower()
-
-    def _build_volumes(
-        self, username: str, volumes: list[LabVolume]
-    ) -> list[V1Volume]:
-        """Construct volumes and mounts for volumes in the lab configuration.
-
-        Parameters
-        ----------
-        username
-            Name of user this lab is for, used to name the PVC objects.
-        volumes
-            Configured volumes.
-
-        Returns
-        -------
-        list of kubernetes_asyncio.client.V1Volume
-            List of volumes and mounts.
-        """
-        results = []
-        pvc_count = 1
-        for spec in volumes:
-            name = self._build_volume_name(spec)
-            match spec.source:
-                case HostPathVolumeSource() as source:
-                    host_path = V1HostPathVolumeSource(path=source.path)
-                    volume = V1Volume(name=name, host_path=host_path)
-                case NFSVolumeSource() as source:
-                    volume = V1Volume(
-                        name=name,
-                        nfs=V1NFSVolumeSource(
-                            path=source.server_path,
-                            read_only=spec.read_only,
-                            server=source.server,
-                        ),
-                    )
-                case PVCVolumeSource():
-                    claim = V1PersistentVolumeClaimVolumeSource(
-                        claim_name=f"{username}-nb-pvc-{pvc_count}",
-                        read_only=spec.read_only,
-                    )
-                    volume = V1Volume(name=name, persistent_volume_claim=claim)
-                    pvc_count += 1
-            results.append(volume)
-        return results
-
-    def _build_mounts(
-        self, volumes: list[LabVolume], prefix: str = ""
+    def build_mounts(
+        self, mounts: Iterable[VolumeMountConfig], prefix: str = ""
     ) -> list[V1VolumeMount]:
         """Construct volume mounts for configured volumes.
 
@@ -121,10 +49,55 @@ class VolumeBuilder:
         """
         return [
             V1VolumeMount(
-                name=self._build_volume_name(v),
-                mount_path=prefix + v.container_path,
-                sub_path=v.sub_path,
-                read_only=v.read_only,
+                name=m.volume_name,
+                mount_path=prefix + m.container_path,
+                sub_path=m.sub_path,
+                read_only=m.read_only,
             )
-            for v in volumes
+            for m in mounts
         ]
+
+    def build_volumes(
+        self, volumes: Iterable[VolumeConfig], pvc_prefix: str
+    ) -> list[V1Volume]:
+        """Construct Kubernetes ``V1Volume`` objects for configured volumes.
+
+        Parameters
+        ----------
+        volumes
+            Configured volumes.
+        pvc_prefx
+            Prefix to add to the names of persistent volume claims. The name
+            of the claim will be followed by ``-pvc-`` and the name of the
+            volume.
+
+        Returns
+        -------
+        list of kubernetes_asyncio.client.V1Volume
+            List of Kubernetes ``V1Volume`` objects.
+        """
+        results = []
+        for spec in volumes:
+            match spec.source:
+                case HostPathVolumeSource() as source:
+                    host_path = V1HostPathVolumeSource(path=source.path)
+                    volume = V1Volume(name=spec.name, host_path=host_path)
+                case NFSVolumeSource() as source:
+                    volume = V1Volume(
+                        name=spec.name,
+                        nfs=V1NFSVolumeSource(
+                            path=source.server_path,
+                            read_only=source.read_only,
+                            server=source.server,
+                        ),
+                    )
+                case PVCVolumeSource() as source:
+                    claim = V1PersistentVolumeClaimVolumeSource(
+                        claim_name=f"{pvc_prefix}-pvc-{spec.name}",
+                        read_only=source.read_only,
+                    )
+                    volume = V1Volume(
+                        name=spec.name, persistent_volume_claim=claim
+                    )
+            results.append(volume)
+        return results

--- a/controller/src/controller/services/fileserver.py
+++ b/controller/src/controller/services/fileserver.py
@@ -244,7 +244,7 @@ class FileserverManager:
         name = self._builder.build_name(username)
         start = current_datetime(microseconds=True)
         try:
-            await self._storage.delete(name, self._config.namespace)
+            await self._storage.delete(name, self._config.namespace, username)
         except TimeoutError as e:
             now = current_datetime(microseconds=True)
             elapsed = (now - start).total_seconds()
@@ -303,7 +303,7 @@ class FileserverManager:
         observed = {k: v for k, v in observed.items() if k not in to_delete}
         for username in to_delete:
             name = self._builder.build_name(username)
-            await self._storage.delete(name, self._config.namespace)
+            await self._storage.delete(name, self._config.namespace, username)
 
         # Tidy up any no-longer-running users. They aren't running, but they
         # might have some objects remaining. This should only be possible if

--- a/controller/src/controller/storage/kubernetes/creator.py
+++ b/controller/src/controller/storage/kubernetes/creator.py
@@ -22,7 +22,6 @@ from kubernetes_asyncio.client import (
     ApiException,
     V1ConfigMap,
     V1NetworkPolicy,
-    V1PersistentVolumeClaim,
     V1ResourceQuota,
     V1Secret,
 )
@@ -39,7 +38,6 @@ __all__ = [
     "ConfigMapStorage",
     "KubernetesObjectCreator",
     "NetworkPolicyStorage",
-    "PersistentVolumeClaimStorage",
     "ResourceQuotaStorage",
     "SecretStorage",
     "T",
@@ -196,28 +194,6 @@ class NetworkPolicyStorage(KubernetesObjectCreator):
             read_method=api.read_namespaced_network_policy,
             object_type=V1NetworkPolicy,
             kind="NetworkPolicy",
-            logger=logger,
-        )
-
-
-class PersistentVolumeClaimStorage(KubernetesObjectCreator):
-    """Storage layer for ``PersistentVolumeClaim`` objects.
-
-    Parameters
-    ----------
-    api_client
-        Kubernetes API client.
-    logger
-        Logger to use.
-    """
-
-    def __init__(self, api_client: ApiClient, logger: BoundLogger) -> None:
-        api = client.CoreV1Api(api_client)
-        super().__init__(
-            create_method=api.create_namespaced_persistent_volume_claim,
-            read_method=api.read_namespaced_persistent_volume_claim,
-            object_type=V1PersistentVolumeClaim,
-            kind="PersistentVolumeClaim",
             logger=logger,
         )
 

--- a/controller/src/controller/storage/kubernetes/deleter.py
+++ b/controller/src/controller/storage/kubernetes/deleter.py
@@ -20,6 +20,7 @@ from kubernetes_asyncio.client import (
     ApiException,
     V1DeleteOptions,
     V1Job,
+    V1PersistentVolumeClaim,
     V1Service,
 )
 from structlog.stdlib import BoundLogger
@@ -39,6 +40,8 @@ T = TypeVar("T", bound=KubernetesModel)
 
 __all__ = [
     "KubernetesObjectDeleter",
+    "JobStorage",
+    "PersistentVolumeClaimStorage",
     "ServiceStorage",
     "T",
 ]
@@ -332,6 +335,30 @@ class JobStorage(KubernetesObjectDeleter):
             read_method=api.read_namespaced_job,
             object_type=V1Job,
             kind="Job",
+            logger=logger,
+        )
+
+
+class PersistentVolumeClaimStorage(KubernetesObjectDeleter):
+    """Storage layer for ``PersistentVolumeClaim`` objects.
+
+    Parameters
+    ----------
+    api_client
+        Kubernetes API client.
+    logger
+        Logger to use.
+    """
+
+    def __init__(self, api_client: ApiClient, logger: BoundLogger) -> None:
+        api = client.CoreV1Api(api_client)
+        super().__init__(
+            create_method=api.create_namespaced_persistent_volume_claim,
+            delete_method=api.delete_namespaced_persistent_volume_claim,
+            list_method=api.list_namespaced_persistent_volume_claim,
+            read_method=api.read_namespaced_persistent_volume_claim,
+            object_type=V1PersistentVolumeClaim,
+            kind="PersistentVolumeClaim",
             logger=logger,
         )
 

--- a/controller/src/controller/storage/kubernetes/lab.py
+++ b/controller/src/controller/storage/kubernetes/lab.py
@@ -15,11 +15,10 @@ from ...models.domain.lab import LabObjectNames, LabObjects, LabStateObjects
 from .creator import (
     ConfigMapStorage,
     NetworkPolicyStorage,
-    PersistentVolumeClaimStorage,
     ResourceQuotaStorage,
     SecretStorage,
 )
-from .deleter import ServiceStorage
+from .deleter import PersistentVolumeClaimStorage, ServiceStorage
 from .namespace import NamespaceStorage
 from .pod import PodStorage
 

--- a/controller/tests/data/extra-annotations/input/config.yaml
+++ b/controller/tests/data/extra-annotations/input/config.yaml
@@ -10,11 +10,14 @@ lab:
       cpu: 1.0
       memory: 3Gi
   volumes:
-    - containerPath: /home
+    - name: home
       source:
         type: nfs
         server: 10.13.105.122
         serverPath: /share1/home
+  volumeMounts:
+    - containerPath: /home
+      volumeName: home
 images:
   source:
     type: docker

--- a/controller/tests/data/fileserver/input/config.yaml
+++ b/controller/tests/data/fileserver/input/config.yaml
@@ -7,17 +7,16 @@ lab:
       cpu: 1.0
       memory: 3Gi
   volumes:
-    - containerPath: /home
+    - name: home
       source:
         type: nfs
         server: 10.13.105.122
         serverPath: /share1/home
-    - containerPath: /project
-      readOnly: true
+    - name: project
       source:
         type: hostPath
         path: /share1/project
-    - containerPath: /scratch
+    - name: scratch
       source:
         type: persistentVolumeClaim
         storageClassName: sdf-home
@@ -26,6 +25,14 @@ lab:
         resources:
           requests:
             storage: 1Gi
+  volumeMounts:
+    - containerPath: /home
+      volumeName: home
+    - containerPath: /project
+      readOnly: true
+      volumeName: project
+    - containerPath: /scratch
+      volumeName: scratch
 images:
   source:
     type: docker

--- a/controller/tests/data/fileserver/output/fileserver-objects.json
+++ b/controller/tests/data/fileserver/output/fileserver-objects.json
@@ -1,0 +1,359 @@
+[
+  {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "Ingress",
+    "metadata": {
+      "name": "rachel-fs",
+      "namespace": "fileservers"
+    },
+    "status": {
+      "loadBalancer": {
+        "ingress": [
+          {
+            "ip": "127.0.0.1"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": {
+      "annotations": {
+        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+        "argocd.argoproj.io/sync-options": "Prune=false"
+      },
+      "labels": {
+        "nublado.lsst.io/category": "fileserver",
+        "nublado.lsst.io/user": "rachel",
+        "argocd.argoproj.io/instance": "fileservers"
+      },
+      "name": "rachel-fs",
+      "namespace": "fileservers"
+    },
+    "spec": {
+      "template": {
+        "metadata": {
+          "labels": {
+            "nublado.lsst.io/category": "fileserver",
+            "nublado.lsst.io/user": "rachel"
+          },
+          "name": "rachel-fs"
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "WORBLEHAT_BASE_HREF",
+                  "value": "/files/rachel"
+                },
+                {
+                  "name": "WORBLEHAT_TIMEOUT",
+                  "value": "3600"
+                },
+                {
+                  "name": "WORBLEHAT_DIR",
+                  "value": "/mnt"
+                }
+              ],
+              "image": "ghcr.io/lsst-sqre/worblehat:1.0.0",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "fileserver",
+              "ports": [
+                {
+                  "containerPort": 8000,
+                  "name": "http"
+                }
+              ],
+              "securityContext": {
+                "allowPrivilegeEscalation": false,
+                "readOnlyRootFilesystem": true
+              },
+              "volumeMounts": [
+                {
+                  "mountPath": "/mnt/home",
+                  "name": "home",
+                  "readOnly": false
+                },
+                {
+                  "mountPath": "/mnt/project",
+                  "name": "project",
+                  "readOnly": true
+                },
+                {
+                  "mountPath": "/mnt/scratch",
+                  "name": "scratch",
+                  "readOnly": false
+                }
+              ]
+            }
+          ],
+          "restartPolicy": "Never",
+          "securityContext": {
+            "runAsGroup": 1101,
+            "runAsNonRoot": true,
+            "runAsUser": 1101,
+            "supplementalGroups": [
+              1101,
+              2028,
+              2001,
+              2021
+            ]
+          },
+          "volumes": [
+            {
+              "name": "home",
+              "nfs": {
+                "path": "/share1/home",
+                "readOnly": false,
+                "server": "10.13.105.122"
+              }
+            },
+            {
+              "hostPath": {
+                "path": "/share1/project"
+              },
+              "name": "project"
+            },
+            {
+              "name": "scratch",
+              "persistentVolumeClaim": {
+                "claimName": "rachel-fs-pvc-scratch",
+                "readOnly": false
+              }
+            }
+          ]
+        }
+      }
+    },
+    "status": {
+      "active": 1
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+      "name": "fileservers"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": {
+      "annotations": {
+        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+        "argocd.argoproj.io/sync-options": "Prune=false"
+      },
+      "labels": {
+        "nublado.lsst.io/category": "fileserver",
+        "nublado.lsst.io/user": "rachel",
+        "argocd.argoproj.io/instance": "fileservers"
+      },
+      "name": "rachel-fs-pvc-scratch",
+      "namespace": "fileservers"
+    },
+    "spec": {
+      "accessModes": [
+        "ReadWriteMany"
+      ],
+      "resources": {
+        "requests": {
+          "storage": "1Gi"
+        }
+      },
+      "storageClassName": "sdf-home"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "labels": {
+        "nublado.lsst.io/category": "fileserver",
+        "nublado.lsst.io/user": "rachel",
+        "job-name": "rachel-fs"
+      },
+      "name": "rachel-fs",
+      "namespace": "fileservers"
+    },
+    "spec": {
+      "containers": [
+        {
+          "env": [
+            {
+              "name": "WORBLEHAT_BASE_HREF",
+              "value": "/files/rachel"
+            },
+            {
+              "name": "WORBLEHAT_TIMEOUT",
+              "value": "3600"
+            },
+            {
+              "name": "WORBLEHAT_DIR",
+              "value": "/mnt"
+            }
+          ],
+          "image": "ghcr.io/lsst-sqre/worblehat:1.0.0",
+          "imagePullPolicy": "IfNotPresent",
+          "name": "fileserver",
+          "ports": [
+            {
+              "containerPort": 8000,
+              "name": "http"
+            }
+          ],
+          "securityContext": {
+            "allowPrivilegeEscalation": false,
+            "readOnlyRootFilesystem": true
+          },
+          "volumeMounts": [
+            {
+              "mountPath": "/mnt/home",
+              "name": "home",
+              "readOnly": false
+            },
+            {
+              "mountPath": "/mnt/project",
+              "name": "project",
+              "readOnly": true
+            },
+            {
+              "mountPath": "/mnt/scratch",
+              "name": "scratch",
+              "readOnly": false
+            }
+          ]
+        }
+      ],
+      "restartPolicy": "Never",
+      "securityContext": {
+        "runAsGroup": 1101,
+        "runAsNonRoot": true,
+        "runAsUser": 1101,
+        "supplementalGroups": [
+          1101,
+          2028,
+          2001,
+          2021
+        ]
+      },
+      "volumes": [
+        {
+          "name": "home",
+          "nfs": {
+            "path": "/share1/home",
+            "readOnly": false,
+            "server": "10.13.105.122"
+          }
+        },
+        {
+          "hostPath": {
+            "path": "/share1/project"
+          },
+          "name": "project"
+        },
+        {
+          "name": "scratch",
+          "persistentVolumeClaim": {
+            "claimName": "rachel-fs-pvc-scratch",
+            "readOnly": false
+          }
+        }
+      ]
+    },
+    "status": {
+      "phase": "Running"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "annotations": {
+        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+        "argocd.argoproj.io/sync-options": "Prune=false"
+      },
+      "labels": {
+        "nublado.lsst.io/category": "fileserver",
+        "nublado.lsst.io/user": "rachel",
+        "argocd.argoproj.io/instance": "fileservers"
+      },
+      "name": "rachel-fs",
+      "namespace": "fileservers"
+    },
+    "spec": {
+      "ports": [
+        {
+          "port": 8000,
+          "targetPort": 8000
+        }
+      ],
+      "selector": {
+        "nublado.lsst.io/category": "fileserver",
+        "nublado.lsst.io/user": "rachel"
+      }
+    }
+  },
+  {
+    "apiVersion": "gafaelfawr.lsst.io/v1alpha1",
+    "kind": "GafaelfawrIngress",
+    "metadata": {
+      "annotations": {
+        "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
+        "argocd.argoproj.io/sync-options": "Prune=false"
+      },
+      "labels": {
+        "nublado.lsst.io/category": "fileserver",
+        "nublado.lsst.io/user": "rachel",
+        "argocd.argoproj.io/instance": "fileservers"
+      },
+      "name": "rachel-fs",
+      "namespace": "fileservers"
+    },
+    "config": {
+      "baseUrl": "http://127.0.0.1:8080",
+      "scopes": {
+        "all": [
+          "exec:notebook"
+        ]
+      },
+      "loginRedirect": false,
+      "authType": "basic"
+    },
+    "template": {
+      "metadata": {
+        "name": "rachel-fs",
+        "labels": {
+          "nublado.lsst.io/category": "fileserver",
+          "nublado.lsst.io/user": "rachel"
+        }
+      },
+      "spec": {
+        "rules": [
+          {
+            "host": "127.0.0.1",
+            "http": {
+              "paths": [
+                {
+                  "path": "/files/rachel",
+                  "pathType": "Prefix",
+                  "backend": {
+                    "service": {
+                      "name": "rachel-fs",
+                      "port": {
+                        "number": 8000
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/controller/tests/data/homedir-schema/input/config.yaml
+++ b/controller/tests/data/homedir-schema/input/config.yaml
@@ -13,11 +13,14 @@ lab:
       cpu: 1.0
       memory: 3Gi
   volumes:
-    - containerPath: /u/home
+    - name: home
       source:
         type: nfs
         server: 10.13.105.122
         serverPath: /share1/home
+  volumeMounts:
+    - containerPath: /u/home
+      volumeName: home
 images:
   source:
     type: docker

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -70,12 +70,11 @@ lab:
         repository: ghcr.io/lsst-sqre/initdir
         tag: 0.0.3
       privileged: true
-      volumes:
+      volumeMounts:
         - containerPath: /home
-          source:
-            type: nfs
-            serverPath: /share1/home
-            server: 10.87.86.26
+          volumeName: home
+        - containerPath: /scratch
+          volumeName: scratch
   nss:
     basePasswd: |
       root:x:0:0:root:/root:/bin/bash
@@ -152,17 +151,16 @@ lab:
       cpu: 12.0
       memory: 32Gi
   volumes:
-    - containerPath: /home
+    - name: home
       source:
         type: nfs
         server: 10.13.105.122
         serverPath: /share1/home
-    - containerPath: /PROJECT
-      readOnly: true
+    - name: project
       source:
         type: hostPath
         path: /share1/project
-    - containerPath: /ScRaTcH
+    - name: scratch
       source:
         type: persistentVolumeClaim
         storageClassName: sdf-home
@@ -171,16 +169,28 @@ lab:
         resources:
           requests:
             storage: 1Gi
+    - name: temporary
+      source:
+        type: persistentVolumeClaim
+        storageClassName: sdf-home
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            storage: 1Gi
+  volumeMounts:
+    - containerPath: /home
+      volumeName: home
+    - containerPath: /PROJECT
+      readOnly: true
+      volumeName: project
+    - containerPath: /ScRaTcH
+      volumeName: scratch
+    - containerPath: /scratch
+      volumeName: scratch
     - containerPath: /temporary
       subPath: temporary
-      source:
-        type: persistentVolumeClaim
-        storageClassName: sdf-home
-        accessModes:
-          - ReadWriteMany
-        resources:
-          requests:
-            storage: 1Gi
+      volumeName: temporary
 images:
   source:
     type: docker

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -149,7 +149,7 @@
         "nublado.lsst.io/category": "lab",
         "nublado.lsst.io/user": "rachel"
       },
-      "name": "rachel-nb-pvc-1",
+      "name": "rachel-nb-pvc-scratch",
       "namespace": "userlabs-rachel"
     },
     "spec": {
@@ -177,7 +177,7 @@
         "nublado.lsst.io/category": "lab",
         "nublado.lsst.io/user": "rachel"
       },
-      "name": "rachel-nb-pvc-2",
+      "name": "rachel-nb-pvc-temporary",
       "namespace": "userlabs-rachel"
     },
     "spec": {
@@ -302,6 +302,11 @@
               "read_only": false
             },
             {
+              "mount_path": "/scratch",
+              "name": "scratch",
+              "read_only": false
+            },
+            {
               "mount_path": "/temporary",
               "name": "temporary",
               "read_only": false,
@@ -408,6 +413,11 @@
               "mount_path": "/home",
               "name": "home",
               "read_only": false
+            },
+            {
+              "mount_path": "/scratch",
+              "name": "scratch",
+              "read_only": false
             }
           ]
         }
@@ -439,14 +449,14 @@
         {
           "name": "scratch",
           "persistent_volume_claim": {
-            "claim_name": "rachel-nb-pvc-1",
+            "claim_name": "rachel-nb-pvc-scratch",
             "read_only": false
           }
         },
         {
           "name": "temporary",
           "persistent_volume_claim": {
-            "claim_name": "rachel-nb-pvc-2",
+            "claim_name": "rachel-nb-pvc-temporary",
             "read_only": false
           }
         },

--- a/controller/tests/support/kubernetes.py
+++ b/controller/tests/support/kubernetes.py
@@ -1,0 +1,49 @@
+"""Support functions for Kubernetes tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from safir.testing.kubernetes import strip_none
+
+from controller.models.domain.kubernetes import KubernetesModel
+
+__all__ = [
+    "objects_to_dicts",
+]
+
+
+def objects_to_dicts(
+    objects: list[dict | KubernetesModel]
+) -> list[dict[str, Any]]:
+    """Serialize a list of Kubernetes objects for comparison.
+
+    We often want to compare the contents of the mock Kubernetes with the
+    expected objects we were hoping to create from, for example, a JSON file.
+    This function handles the complexities of that serialization.
+
+    Parameters
+    ----------
+    objects
+        List of objects to serialize, which may include custom objects that
+        are represented by raw dicts.
+
+    Returns
+    -------
+    list of dict
+        List of serialized objects with `None` elements removed, suitable
+        for comparison.
+    """
+    results = []
+    for obj in objects:
+        if isinstance(obj, dict):
+            serialized = obj
+        else:
+            serialized = obj.to_dict(serialize=True)
+
+        # These attributes intentionally may change on every test run and thus
+        # should not be compared.
+        serialized["metadata"]["resourceVersion"] = None
+
+        results.append(strip_none(serialized))
+    return results


### PR DESCRIPTION
Previously, we were hoping to simplify the Kubernetes data model by combining volume specifications and their mount points into one data structure, under the assumption that each volume would only be mounted in one place.

Unfortunately, this broke for several reasons: we do have use cases where we want to mount the same volume on multiple paths, init containers must share volume definitions with the main container but do not share mounts, and file servers may eventually need the same volumes but different mounts. Separate the list of volumes and the list of mounts and tie them together with volume names, which are also used in constructing the Kubernetes objects.

This enables support for PVCs in init containers nearly for free; it just requires a bit of code in constructing the init container, which is added here. While doing so, also add support for PVCs for file servers, which is more complex since they have to be created and deleted and do not have fixed names.

Name the PVCs after the volume name instead of assigning them numerical names now that we have a volume name available.