### PR TITLE
DM-41793: Overhaul Kubernetes timeout handling (again)

### DIFF
--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -324,6 +324,15 @@ class EnabledFileserverConfig(FileserverConfig):
         ),
     )
 
+    delete_timeout: timedelta = Field(
+        timedelta(minutes=2),
+        title="File server deletion timeout",
+        description=(
+            "How long to wait for a file server's Kubernetes objects to be"
+            " deleted before raising an error"
+        ),
+    )
+
     idle_timeout: timedelta = Field(
         timedelta(hours=1),
         title="File server inactivity timeout",
@@ -549,6 +558,16 @@ class LabConfig(BaseModel):
         description=(
             "An Argo CD application under which lab objects should be shown"
         ),
+    )
+
+    delete_timeout: timedelta = Field(
+        timedelta(minutes=1),
+        title="Timeout for lab deletion",
+        description=(
+            "How long to wait in total for deletion of Kubernetes resources"
+            " for a user lab"
+        ),
+        examples=[60],
     )
 
     env: dict[str, str] = Field(

--- a/controller/src/controller/constants.py
+++ b/controller/src/controller/constants.py
@@ -11,7 +11,6 @@ __all__ = [
     "GROUPNAME_REGEX",
     "FILE_SERVER_REFRESH_INTERVAL",
     "IMAGE_REFRESH_INTERVAL",
-    "KUBERNETES_DELETE_TIMEOUT",
     "KUBERNETES_NAME_PATTERN",
     "KUBERNETES_REQUEST_TIMEOUT",
     "LAB_COMMAND",
@@ -58,24 +57,16 @@ terminated by Kubernetes node replacements or upgrades.
 IMAGE_REFRESH_INTERVAL = timedelta(minutes=5)
 """How frequently to refresh the list of remote and cached images."""
 
-KUBERNETES_DELETE_TIMEOUT = timedelta(seconds=60)
-"""How long to wait for deletion of an object to finish.
-
-In some cases, if a Kubernetes object the controller is trying to create
-already exists, it deletes that object and then retries the creation. This
-controls how long it waits for the object to go away after deletion before it
-gives up.
-"""
-
 KUBERNETES_NAME_PATTERN = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
 """Pattern matching valid Kubernetes names."""
 
 KUBERNETES_REQUEST_TIMEOUT = timedelta(seconds=30)
-"""How long to wait for any given Kubernetes API call.
+"""How long to wait for generic sequences of Kubernetes API calls.
 
-This timeout is currently applied to each Kubernetes API call in isolation,
-just to impose an upper limit on how long we'll wait of the control plane is
-nonresponsive.
+Most Kubernetes API calls are part of a sequence of operations with an overall
+timeout, but some are one-offs or one-off sequences. This timeout is used for
+one-off operations, just to impose an upper limit on how long we'll wait of
+the control plane is nonresponsive.
 """
 
 LAB_COMMAND = "/opt/lsst/software/jupyterlab/runlab.sh"

--- a/controller/src/controller/storage/kubernetes/custom.py
+++ b/controller/src/controller/storage/kubernetes/custom.py
@@ -10,9 +10,9 @@ from kubernetes_asyncio import client
 from kubernetes_asyncio.client import ApiClient, ApiException
 from structlog.stdlib import BoundLogger
 
-from ...constants import KUBERNETES_DELETE_TIMEOUT, KUBERNETES_REQUEST_TIMEOUT
 from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import PropagationPolicy, WatchEventType
+from ...timeout import Timeout
 from .watcher import KubernetesWatcher
 
 __all__ = [
@@ -65,6 +65,7 @@ class CustomStorage:
         self,
         namespace: str,
         body: dict[str, Any],
+        timeout: Timeout,
         *,
         replace: bool = False,
         propagation_policy: PropagationPolicy | None = None,
@@ -77,6 +78,8 @@ class CustomStorage:
             Namespace of the object.
         body
             Custom object to create.
+        timeout
+            Timeout on operation.
         replace
             If `True` and an object of that name already exists in that
             namespace, delete the existing object and then try again.
@@ -93,13 +96,13 @@ class CustomStorage:
         msg = f"Creating {self._kind}"
         self._logger.debug(msg, name=name, namespace=namespace)
         try:
-            await self._create(namespace, body)
+            await self._create(namespace, body, timeout)
         except KubernetesError as e:
             if replace and e.status == 409:
                 msg = f"{self._kind} already exists, deleting and recreating"
                 self._logger.warning(msg, name=name, namespace=namespace)
-                await self.delete(name, namespace, wait=True)
-                await self._create(namespace, body)
+                await self.delete(name, namespace, timeout, wait=True)
+                await self._create(namespace, body, timeout)
             else:
                 raise
 
@@ -107,6 +110,7 @@ class CustomStorage:
         self,
         name: str,
         namespace: str,
+        timeout: Timeout,
         *,
         wait: bool = False,
         propagation_policy: PropagationPolicy | None = None,
@@ -121,6 +125,8 @@ class CustomStorage:
             Name of the object.
         namespace
             Namespace of the object.
+        timeout
+            Timeout on operation.
         wait
             Whether to wait for the custom object to be deleted.
         propagation_policy
@@ -140,7 +146,7 @@ class CustomStorage:
                 namespace,
                 self._plural,
                 name,
-                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
+                _request_timeout=timeout.left(),
             )
         except ApiException as e:
             if e.status == 404:
@@ -153,15 +159,19 @@ class CustomStorage:
                 name=name,
             ) from e
         if wait:
-            await self.wait_for_deletion(name, namespace)
+            await self.wait_for_deletion(name, namespace, timeout)
 
-    async def list(self, namespace: str) -> list[dict[str, Any]]:
+    async def list(
+        self, namespace: str, timeout: Timeout
+    ) -> list[dict[str, Any]]:
         """List the custom objects in a namespace.
 
         Parameters
         ----------
         namespace
             Namespace in which to list custom objects.
+        timeout
+            Timeout on operation.
 
         Returns
         -------
@@ -179,7 +189,7 @@ class CustomStorage:
                 self._version,
                 namespace,
                 self._plural,
-                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
+                _request_timeout=timeout.left(),
             )
         except ApiException as e:
             raise KubernetesError.from_exception(
@@ -190,7 +200,9 @@ class CustomStorage:
             ) from e
         return objs.items
 
-    async def read(self, name: str, namespace: str) -> dict[str, Any] | None:
+    async def read(
+        self, name: str, namespace: str, timeout: Timeout
+    ) -> dict[str, Any] | None:
         """Read a custom object.
 
         Parameters
@@ -199,6 +211,8 @@ class CustomStorage:
             Name of the custom object.
         namespace
             Namespace of the custom object.
+        timeout
+            Timeout on operation.
 
         Returns
         -------
@@ -217,7 +231,7 @@ class CustomStorage:
                 namespace,
                 self._plural,
                 name,
-                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
+                _request_timeout=timeout.left(),
             )
         except ApiException as e:
             if e.status == 404:
@@ -234,7 +248,7 @@ class CustomStorage:
         self,
         name: str,
         namespace: str,
-        timeout: timedelta = KUBERNETES_DELETE_TIMEOUT,
+        timeout: Timeout,
     ) -> None:
         """Wait for a custom object deletion to complete.
 
@@ -252,7 +266,7 @@ class CustomStorage:
         KubernetesError
             Raised for exceptions from the Kubernetes API server.
         """
-        obj = await self.read(name, namespace)
+        obj = await self.read(name, namespace, timeout)
         if not obj:
             return
 
@@ -271,7 +285,7 @@ class CustomStorage:
             logger=self._logger,
         )
         try:
-            async with asyncio.timeout(timeout.total_seconds()):
+            async with asyncio.timeout(timeout.left()):
                 async for event in watcher.watch():
                     if event.action == WatchEventType.DELETED:
                         return
@@ -279,9 +293,10 @@ class CustomStorage:
             # If the watch had to be restarted because the resource version
             # was too old and the object was deleted while the watch was
             # restarting, we could have missed the delete event. Therefore,
-            # before timing out, do a final check to see if the object is
-            # gone.
-            if not await self.read(name, namespace):
+            # before timing out, do a final check with a short timeout to see
+            # if the object is gone.
+            short_timeout = Timeout(timedelta(seconds=5))
+            if not await self.read(name, namespace, short_timeout):
                 return
             raise
         finally:
@@ -290,7 +305,9 @@ class CustomStorage:
         # This should be impossible; someone called stop on the watcher.
         raise RuntimeError("Wait for object deletion unexpectedly stopped")
 
-    async def _create(self, namespace: str, body: dict[str, Any]) -> None:
+    async def _create(
+        self, namespace: str, body: dict[str, Any], timeout: Timeout
+    ) -> None:
         """Create a custom object (without recreation on conflict).
 
         Parameters
@@ -299,6 +316,8 @@ class CustomStorage:
             Namespace in which to create the object.
         body
             Namespace object to create.
+        timeout
+            Timeout on operation.
 
         Raises
         ------
@@ -313,7 +332,7 @@ class CustomStorage:
                 namespace,
                 self._plural,
                 body,
-                _request_timeout=KUBERNETES_REQUEST_TIMEOUT.total_seconds(),
+                _request_timeout=timeout.left(),
             )
         except ApiException as e:
             raise KubernetesError.from_exception(

--- a/controller/src/controller/storage/kubernetes/ingress.py
+++ b/controller/src/controller/storage/kubernetes/ingress.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-
 from kubernetes_asyncio import client
 from kubernetes_asyncio.client import ApiClient, V1Ingress
 from structlog.stdlib import BoundLogger
 
 from ...models.domain.kubernetes import WatchEventType
+from ...timeout import Timeout
 from .deleter import KubernetesObjectDeleter
 from .watcher import KubernetesWatcher
 
@@ -64,7 +63,7 @@ class IngressStorage(KubernetesObjectDeleter):
         )
 
     async def wait_for_ip_address(
-        self, name: str, namespace: str, timeout: timedelta
+        self, name: str, namespace: str, timeout: Timeout
     ) -> None:
         """Wait for an ingress to get an IP address assigned.
 
@@ -87,7 +86,7 @@ class IngressStorage(KubernetesObjectDeleter):
         TimeoutError
             Raised if the object is not deleted within the delete timeout.
         """
-        ingress = await self.read(name, namespace)
+        ingress = await self.read(name, namespace, timeout)
         resource_version = None
         if ingress:
             if ingress_has_ip_address(ingress):

--- a/controller/src/controller/timeout.py
+++ b/controller/src/controller/timeout.py
@@ -1,0 +1,68 @@
+"""Timeout class for Kubernetes operations."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from safir.datetime import current_datetime
+
+__all__ = ["Timeout"]
+
+
+class Timeout:
+    """Track a cumulative timeout on a series of operations.
+
+    Many Nublado controller operations involve operations that support
+    individual timeouts, where all operations must complete within a total
+    timeout. Examples include spawning a lab or creating a user file server.
+    This class encapsulates that type of timeout and provides methods to
+    retrieve timeouts for individual operations.
+    """
+
+    def __init__(self, timeout: timedelta) -> None:
+        self._timeout = timeout
+        self._start = current_datetime(microseconds=True)
+
+    def elapsed(self) -> float:
+        """Elapsed time since the timeout started.
+
+        Returns
+        -------
+        float
+            Seconds elapsed since the object was created.
+        """
+        now = current_datetime(microseconds=True)
+        return (now - self._start).total_seconds()
+
+    def error(self, operation: str) -> str:
+        """Generate an error message for an expired timeout.
+
+        The message will be based on the time since the class was created,
+        regardless of whether this is longer than the initially configured
+        timeout.
+
+        Parameters
+        ----------
+        operation
+            Operation that timed out.
+        """
+        return f"{operation} timed out after {self.elapsed()}s"
+
+    def left(self) -> float:
+        """Return the amount of time remaining in seconds.
+
+        Returns
+        -------
+        timedelta
+            Time remaining in the timeout.
+
+        Raises
+        ------
+        TimeoutError
+            Raised if the timeout has expired.
+        """
+        now = current_datetime(microseconds=True)
+        left = (self._timeout - (now - self._start)).total_seconds()
+        if left <= 0.0:
+            raise TimeoutError(self.error("Operation"))
+        return left

--- a/controller/tests/services/lab_test.py
+++ b/controller/tests/services/lab_test.py
@@ -25,6 +25,7 @@ from controller.models.v1.lab import (
     UserInfo,
     UserLabState,
 )
+from controller.timeout import Timeout
 
 from ..support.data import (
     read_input_data,
@@ -86,7 +87,7 @@ async def create_lab(
     objects = lab_builder.build_lab(
         user=user, lab=lab, image=image, secrets={}
     )
-    await lab_storage.create(objects)
+    await lab_storage.create(objects, Timeout(config.lab.spawn_timeout))
 
     phase = PodPhase(mock_kubernetes.initial_pod_phase)
     return UserLabState(


### PR DESCRIPTION
Add a new Timeout class that starts a timer when created and has methods to get the elapsed time, error message, and number of seconds left. Require a Timeout parameter to every Kubernetes storage layer function, and plumb that machinery all the way up to the service layer, using these Timeout objects for cumulative timeouts shared by a batch of operations. Operations that aren't part of a batch with their own configured timeout get a default timeout.

Add new configuration options for timeouts on deleting labs and file servers.