### PR TITLE
DM-41630: Remove clickable link to file server

### DIFF
--- a/controller/src/controller/templates/fileserver.html.jinja
+++ b/controller/src/controller/templates/fileserver.html.jinja
@@ -6,7 +6,7 @@ User Fileserver Created
 </head>
 </body>
 <h1>
-Your <a href="{{ base_url }}{{ path_prefix }}/{{ username }}">fileserver</a> is ready.
+Your fileserver is ready.
 <h1>
 
 <h2>

--- a/controller/tests/data/fileserver/output/fileserver.html
+++ b/controller/tests/data/fileserver/output/fileserver.html
@@ -6,7 +6,7 @@ User Fileserver Created
 </head>
 </body>
 <h1>
-Your <a href="http://127.0.0.1:8080/files/rachel">fileserver</a> is ready.
+Your fileserver is ready.
 <h1>
 
 <h2>


### PR DESCRIPTION
Remove the clickable link to the user's file server at the top of the instructions, since the file server only supports WebDAV and following that link in a browser will not do anything useful.

Leave the link farther down after the instructions about how to access it in case people want to use copy link location.