### PR TITLE
DM-41793: Change default delete timeout for file servers

### DIFF
--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -325,7 +325,7 @@ class EnabledFileserverConfig(FileserverConfig):
     )
 
     delete_timeout: timedelta = Field(
-        timedelta(minutes=2),
+        timedelta(minutes=1),
         title="File server deletion timeout",
         description=(
             "How long to wait for a file server's Kubernetes objects to be"


### PR DESCRIPTION
Make the default delete timeout for file servers match that for labs: one minute.