### PR TITLE
DM-41793: Add error handling tests for file servers

### DIFF
--- a/controller/src/controller/dependencies/config.py
+++ b/controller/src/controller/dependencies/config.py
@@ -44,6 +44,11 @@ class ConfigDependency:
             self._config = Config.from_file(self._path)
         return self._config
 
+    @property
+    def is_initialized(self) -> bool:
+        """Whether the configuration has been initialized."""
+        return self._config is not None
+
     def set_path(self, path: Path) -> None:
         """Change the configuration path and reload.
 

--- a/controller/tests/support/config.py
+++ b/controller/tests/support/config.py
@@ -36,10 +36,14 @@ async def configure(
     Config
         New configuration.
     """
+    slack_webhook = None
+    if config_dependency.is_initialized:
+        slack_webhook = config_dependency.config.slack_webhook
     config_path = Path(__file__).parent.parent / "data" / directory / "input"
     base_path = Path(__file__).parent.parent / "data" / "base" / "input"
     config_dependency.set_path(config_path / "config.yaml")
     config = config_dependency.config
+    config.slack_webhook = slack_webhook
 
     # Adjust the configuration to point to external objects if they're present
     # in the configuration directory.


### PR DESCRIPTION
Test that Kubernetes errors during file server creation are caught properly and reported to Slack. This required some changes to the test setup to ensure that Slack webhook configuration is preserved when changing configurations.