### PR TITLE
DM-41820: Add affinity support for labs and file server pods

### DIFF
--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -30,7 +30,12 @@ from .constants import (
     RESERVED_ENV,
     RESERVED_PATHS,
 )
-from .models.domain.kubernetes import PullPolicy, Toleration, VolumeAccessMode
+from .models.domain.kubernetes import (
+    Affinity,
+    PullPolicy,
+    Toleration,
+    VolumeAccessMode,
+)
 from .models.v1.lab import LabResources, LabSize, ResourceQuantity
 from .models.v1.prepuller_config import PrepullerConfig
 from .units import memory_to_bytes
@@ -304,6 +309,12 @@ class EnabledFileserverConfig(FileserverConfig):
     """Configuration for enabled user file servers."""
 
     enabled: Literal[True]
+
+    affinity: Affinity | None = Field(
+        None,
+        title="Affinity rules",
+        description="Node and pod affinity rules for file server pods",
+    )
 
     application: str | None = Field(
         None,
@@ -585,6 +596,12 @@ class LabConfig(BaseModel):
         description=(
             "An Argo CD application under which lab objects should be shown"
         ),
+    )
+
+    affinity: Affinity | None = Field(
+        None,
+        title="Affinity rules",
+        description="Node and pod affinity rules for lab pods",
     )
 
     delete_timeout: timedelta = Field(

--- a/controller/src/controller/services/builder/fileserver.py
+++ b/controller/src/controller/services/builder/fileserver.py
@@ -261,6 +261,9 @@ class FileserverBuilder:
         metadata = self._build_metadata(user.username)
         if self._config.extra_annotations:
             metadata.annotations.update(self._config.extra_annotations)
+        affinity = None
+        if self._config.affinity:
+            affinity = self._config.affinity.to_kubernetes()
         node_selector = None
         if self._config.node_selector:
             node_selector = self._config.node_selector.copy()
@@ -278,6 +281,7 @@ class FileserverBuilder:
                         annotations=self._config.extra_annotations.copy(),
                     ),
                     spec=V1PodSpec(
+                        affinity=affinity,
                         containers=[container],
                         node_selector=node_selector,
                         restart_policy="Never",

--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -526,6 +526,9 @@ class LabBuilder:
         # Build the pod object itself.
         containers = self._build_pod_containers(user, mounts, resources, image)
         init_containers = self._build_pod_init_containers(user, resources)
+        affinity = None
+        if self._config.affinity:
+            affinity = self._config.affinity.to_kubernetes()
         node_selector = None
         if self._config.node_selector:
             node_selector = self._config.node_selector.copy()
@@ -533,6 +536,7 @@ class LabBuilder:
         return V1Pod(
             metadata=metadata,
             spec=V1PodSpec(
+                affinity=affinity,
                 containers=containers,
                 image_pull_secrets=pull_secrets,
                 init_containers=init_containers,

--- a/controller/tests/data/fileserver/input/config.yaml
+++ b/controller/tests/data/fileserver/input/config.yaml
@@ -40,6 +40,26 @@ images:
     repository: library/sketchbook
 fileserver:
   enabled: true
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - namespaceSelector:
+            matchLabels:
+              security: S1
+          topologyKey: topology.kubernetes.io/zone
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: security
+                  operator: In
+                  values:
+                    - S2
+            namespaces:
+              - fileservers
+            topologyKey: topology.kubernetes.io/zone
   application: fileservers
   creationTimeout: 1
   extraAnnotations:

--- a/controller/tests/data/fileserver/output/fileserver-objects.json
+++ b/controller/tests/data/fileserver/output/fileserver-objects.json
@@ -46,6 +46,44 @@
           "name": "rachel-fs"
         },
         "spec": {
+          "affinity": {
+            "podAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "namespaceSelector": {
+                    "matchLabels": {
+                      "security": "S1"
+                    }
+                  },
+                  "topologyKey": "topology.kubernetes.io/zone"
+                }
+              ]
+            },
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "security",
+                          "operator": "In",
+                          "values": [
+                            "S2"
+                          ]
+                        }
+                      ]
+                    },
+                    "namespaces": [
+                      "fileservers"
+                    ],
+                    "topologyKey": "topology.kubernetes.io/zone"
+                  },
+                  "weight": 100
+                }
+              ]
+            }
+          },
           "containers": [
             {
               "env": [
@@ -196,6 +234,44 @@
       "namespace": "fileservers"
     },
     "spec": {
+      "affinity": {
+        "podAffinity": {
+          "requiredDuringSchedulingIgnoredDuringExecution": [
+            {
+              "namespaceSelector": {
+                "matchLabels": {
+                  "security": "S1"
+                }
+              },
+              "topologyKey": "topology.kubernetes.io/zone"
+            }
+          ]
+        },
+        "podAntiAffinity": {
+          "preferredDuringSchedulingIgnoredDuringExecution": [
+            {
+              "podAffinityTerm": {
+                "labelSelector": {
+                  "matchExpressions": [
+                    {
+                      "key": "security",
+                      "operator": "In",
+                      "values": [
+                        "S2"
+                      ]
+                    }
+                  ]
+                },
+                "namespaces": [
+                  "fileservers"
+                ],
+                "topologyKey": "topology.kubernetes.io/zone"
+              },
+              "weight": 100
+            }
+          ]
+        }
+      },
       "containers": [
         {
           "env": [

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -1,6 +1,24 @@
 logLevel: DEBUG
 profile: development
 lab:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                  - antarctica-east1
+                  - antarctica-west1
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: another-node-label-key
+                operator: In
+                values:
+                  - another-node-label-value
   application: "nublado-users"
   namespacePrefix: userlabs
   spawnTimeout: 10

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -211,6 +211,42 @@
       "namespace": "userlabs-rachel"
     },
     "spec": {
+      "affinity": {
+        "nodeAffinity": {
+          "preferredDuringSchedulingIgnoredDuringExecution": [
+            {
+              "preference": {
+                "matchExpressions": [
+                  {
+                    "key": "another-node-label-key",
+                    "operator": "In",
+                    "values": [
+                      "another-node-label-value"
+                    ]
+                  }
+                ]
+              },
+              "weight": 1
+            }
+          ],
+          "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [
+              {
+                "matchExpressions": [
+                  {
+                    "key": "topology.kubernetes.io/zone",
+                    "operator": "In",
+                    "values": [
+                      "antarctica-east1",
+                      "antarctica-west1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
       "containers": [
         {
           "args": [
@@ -439,6 +475,7 @@
           "effect": "NoSchedule",
           "key": "some-toleration",
           "operator": "Equal",
+          "tolerationSeconds": 60,
           "value": "some-value"
         },
         {


### PR DESCRIPTION
Allow affinity rules to be specified for lab and file server pods. This unfortunately requires a whole Pydantic model for the (quite complicated) affinity models so that they can be parsed as part of the Nubaldo controller configuration.