### PR TITLE
Add a Nublado manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_static/openapi.json
 
 # PyBuilder
 target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,10 @@ Nublado is versioned with [semver](https://semver.org/). Dependencies are update
 Find changes for the upcoming release in the project's [changelog.d directory](https://github.com/lsst-sqre/nublado/tree/main/changelog.d/).
 
 <!-- scriv-insert-here -->
+## 4.0.0 (unreleased)
+
+This is the first release of the new merged Nublado release. It contains the Nubaldo controller, a JupyterHub spawner implementation that uses the controller to create user labs, a JupyterHub authenticator implementation to use [Gafaelfawr](https://gafaelfawr.lsst.io/), and the Docker configuration to build a custom JupyterHub image containing that spawner and authenticator.
+
+In previous versions of Nublado, the equivalents of these components were maintained in separate repositories with independent version numbers.
+As of this release, all of these components are maintained and released together using semver versioning.
+Further changes will be documented in this unified change log.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,6 @@
+########
+REST API
+########
+
+This is a stub page for the API.
+It will be replaced with the generated API documentation.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -1,0 +1,5 @@
+#############
+Configuration
+#############
+
+Placeholder.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -2,10 +2,21 @@
 title = "Nublado"
 copyright = "2022-2023 Association of Universities for Research in Astronomy, Inc. (AURA)"
 
+[project.openapi]
+openapi_path = "_static/openapi.json"
+doc_path = "api"
+
+[project.openapi.generator]
+function = "controller.main:create_openapi"
+
 [project.python]
 package = "controller"
 
 [sphinx]
+disable_primary_sidebars = [
+    "**/index",
+    "changelog",
+]
 nitpicky = true
 nitpick_ignore = [
     # Ignore missing cross-references for modules that don't provide

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,14 +2,35 @@
 Nublado
 #######
 
-Nublado is the software underlying the Notebook Aspect of the Vera C. Rubin Observatory Science Platform.
+Nublado implements a Jupyter notebook service in Kubernetes and a WebDAV file server that provides access to the same underlying POSIX file system.
+It is the software that provides the Nobebook Aspect service of the Vera C. Rubin Observatory Science Platform.
 
-This page is only a placeholder for now.
+This site documents the Nublado service for platform administrators.
+Users of the Rubin Science Platform should instead see the documentation at rsp.lsst.io_.
 
-Development
-===========
+.. _rsp.lsst.io: https://rsp.lsst.io/
+
+Nublado provides only the service to create and manage Kubernetes pods running JupyterLab and the WebDAV file servers.
+It can spawn any compatible lab image, although it currently makes assumptions about the versioning scheme that are specific to Rubin Observatory.
+For the official Rubin images, see sciplat-lab_.
+
+.. _sciplat-lab: https://github.com/lsst-sqre/sciplat-lab
 
 .. toctree::
    :maxdepth: 2
+   :caption: Usage
+
+   overview
+   configuration/index
+   api
+
+.. toctree::
+   :hidden:
+
+   changelog
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Development
 
    dev/index

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,0 +1,5 @@
+#####################
+Architecture overview
+#####################
+
+Placeholder.


### PR DESCRIPTION
Add the start of a Nublado manual, including autogenerated documentation for the REST API. Add a draft change log entry for the upcoming 4.0.0 release.