### PR TITLE
DM-38714: Document the Nublado configuration

### DIFF
--- a/controller/src/controller/models/domain/kubernetes.py
+++ b/controller/src/controller/models/domain/kubernetes.py
@@ -688,9 +688,16 @@ class Toleration(BaseModel):
 
 
 class VolumeAccessMode(str, Enum):
-    """Access mode for a persistent volume."""
+    """Access mode for a persistent volume.
 
-    READ_WRITE_ONCE = "ReadWriteOnce"
+    The access modes ``ReadWriteOnce`` and ``ReadWriteOncePod`` are valid
+    access modes in Kubernetes but are intentionally not listed here because
+    they cannot work with user labs or file servers and therefore should be
+    rejected by configuration parsing. This should change in the future if
+    access modes are used in other contexts where those access modes may make
+    sense.
+    """
+
     READ_ONLY_MANY = "ReadOnlyMany"
     READ_WRITE_MANY = "ReadWriteMany"
 

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -7,10 +7,14 @@
 .. _Mend Renovate: https://www.mend.io/renovate/
 .. _mypy: https://mypy.readthedocs.io/en/stable/
 .. _nox: https://nox.thea.codes/en/stable/
+.. _Nublado Phalanx application: https://phalanx.lsst.io/applications/nublado/index.html
 .. _Phalanx: https://phalanx.lsst.io/
 .. _Ruff: https://docs.astral.sh/ruff/
 .. _pytest: https://docs.pytest.org/en/stable/
+.. _sciplat-lab: https://github.com/lsst-sqre/sciplat-lab
 .. _scriv: https://scriv.readthedocs.io/en/stable/
 .. _semver: https://semver.org/
+.. _worblehat: https://github.com/lsst-sqre/worblehat
+.. _workload identity: https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/stable/
 .. _Zero to JupyterHub: https://z2jh.jupyter.org/en/stable/

--- a/docs/about/index.rst
+++ b/docs/about/index.rst
@@ -14,8 +14,6 @@ Architecture overview
 A Nublado deployment consists of the JupyterHub pod, its associated proxy server pod, and a Nublado controller pod, plus their supporting Kubernetes resources.
 JupyterHub and its proxy server are installed using the `Zero to JupyterHub`_ Helm chart as a subchart of the `Nublado Phalanx application`_.
 
-.. _Nublado Phalanx application: https://phalanx.lsst.io/applications/nublado/index.html
-
 The JupyterHub Docker image is the same as the normal JupyterHub image, with the addition of a custom spawner module and a custom authenticator module.
 The Nublado controller image is a standalone Python service built from the Nublado repository.
 Both the JupyterHub and the Nublado controller images are built from the Nublado source tree by GitHub Actions.
@@ -29,7 +27,7 @@ To supplement the JupyterLab interface, which only allows simple file upload and
 This allows users to use the WebDAV clients built into most operating systems to more readily copy files to and from the file space underlying their lab.
 
 Since the lab images used by Rubin Observatory are quite large and pulling an image can therefore take a considerable amount of time, the Nublado controller prepulls a configured set of images on every cluster node.
-This set of images is the same as those available as selection (not dropdown) options in the user-facing spawner form.
+This set of images is the same as those available as radio button (not dropdown) options in the user-facing spawner form.
 
 JupyterHub, its associated proxy, and its configuration and supporting Kubernetes objects other than its secret and ingress are installed using the `Zero to JupyterHub`_ Helm chart as a subchart.
 The Nublado controller, its configuration, the JupyterHub secret and configuration, and the ingress for the proxy are managed directly by Phalanx.
@@ -78,7 +76,6 @@ Here is a sequence diagram showing the operations involved in spawning a user la
 
 .. mermaid:: lab-spawn.mmd
    :caption: Spawn lab
-   :zoom:
 
 When the user exits the lab, an extension built into the lab images for the Rubin Science Platform tells JupyterHub to delete the lab.
 JupyterHub then asks the controller to delete the lab, which then asks Kubernetes to delete the lab and the namespace.
@@ -90,7 +87,6 @@ Here is a sequence diagram for creating a user file server:
 
 .. mermaid:: fileserver-create.mmd
    :caption: Create file server
-   :zoom:
 
 File servers last for as long as they are used.
 After a configurable idle period, the file server exits.

--- a/docs/admin/config/controller.rst
+++ b/docs/admin/config/controller.rst
@@ -1,0 +1,67 @@
+################################
+General controller configuration
+################################
+
+Controller image
+================
+
+None of these settings need to be changed if you are using the current release of the Nublado controller.
+They are primarily used when testing new Nublado releases.
+
+``controller.image.repository``
+    Docker image repository to use.
+    The default is the GitHub Artifact Repository releases maintained by Rubin Observatory.
+
+``controller.image.pullPolicy``
+    Pull policy for the controller image.
+    The default is ``IfNotPresent``.
+    Change to ``Always`` if you are iterating on new controller versions with the same tag, such as a Jira ticket branch.
+
+``controller.image.tag``
+    Tag of the controller to deploy.
+    By default, this is the current release of Nublado as defined in :file:`Chart.yaml` in the Nublado application chart.
+
+Kubernetes
+==========
+
+``controller.resources``
+    Resource limits and requests for the Nublado controller pod.
+    The defaults are chosen based on observed metrics from the Nublado controller running on Google Kubernetes Engine with a light user load.
+
+None of the following are set by default.
+They can be used to add additional Kubernetes configuration to the controller pod if, for example, you want it to run on specific nodes or tag it with annotations that have some external meaning for your environment.
+
+``controller.affinity``
+    Affinity rules for the Nublado controller pod.
+
+``controller.ingress.annotations``
+    Additional annotations to add to the Kubernetes ``Ingress`` for the Nublado controller pod.
+
+``controller.nodeSelector``
+    Node selector rules for the Nubaldo controller pod.
+
+``controller.podAnnotations``
+    Additional annotations to add to the Nublado controller pod.
+
+``controller.tolerations``
+    Toleration rules for the Nublado controller pod.
+
+Logging and notifications
+=========================
+
+``controller.config.logLevel``
+    Log level for the Nublado controller.
+    The default log level is ``INFO``.
+    Choose from one of the `Python logging levels <https://docs.python.org/3/library/logging.html#logging-levels>`__.
+
+``controller.slackAlerts``
+    Change this setting to true if you want Nublado to report errors to a Slack channel via a Slack incoming webhook.
+    If set to true (the default is false), you will need to provide the URL of a suitable Slack incoming webhook as a Nublado secret using the normal Phalanx secrets system.
+
+Path prefix
+===========
+
+``controller.config.pathPrefix``
+    The path prefix to use for the controller API.
+    The default is ``/nublado``.
+    You probably do not want to change this unless you are trying to run multiple instances of Nublado in the same Phalanx environment for some reason.

--- a/docs/admin/config/fileserver.rst
+++ b/docs/admin/config/fileserver.rst
@@ -1,0 +1,90 @@
+##############################
+User file server configuration
+##############################
+
+A user file server is a WebDAV server created on demand for a specific user to provide remote access to POSIX file systems.
+The intent is to provide the same paths that are available inside the user's lab via WebDAV, which allows users to mount the file system on their local machine and more easily copy files back and forth from their lab environment.
+
+Enable file servers
+===================
+
+File servers are disabled by default and must be explicitly enabled.
+
+``controller.config.fileserver.enabled``
+    Set to true to allow users to create file servers.
+    The default is false.
+
+Image
+=====
+
+The following settings configure which Docker image to use as a WebDAV file server.
+The Nublado controller uses a specific set of environment variables to configure the WebDAV file server that are only supported by worblehat_, so the only reason to change these settings is when testing a new unreleased version.
+
+``controller.config.fileserver.image.repository``
+    Docker repository from which to get the WebDAV file server image.
+    The default is the Docker repository for worblehat_.
+
+``controller.config.fileserver.image.pullPolicy``
+    Pull policy for the file server image.
+    The default is ``IfNotPresent``.
+    Change to ``Always`` if you are iterating on new file server versions with the same tag, such as a Jira ticket branch.
+
+``controller.config.fileserver.image.tag``
+    Tag for the file server image.
+    The default is the latest stable release.
+
+Kubernetes
+==========
+
+``controller.config.fileserver.application``
+    Name of the Argo CD application with which to tag user file server resources.
+    This tagging causes all of the user file server resources to show up in Argo CD, which has been convenient for deleting broken file servers or viewing pod logs.
+    The default is ``fileservers`` and should not normally be changed, since Phalanx sets up an application by that name for this purpose.
+
+``controller.config.fileserver.namespace``
+    Kubernetes namespace in which to create user file servers.
+    The default is ``fileservers`` and should not normally be changed, since Phalanx sets up a namespace for this purpose.
+    If file servers are enabled, this namespace must exist when the Nublado controller starts; it will not create it.
+
+``controller.config.fileserver.resources``
+    Resource limits and requests for user file server pods.
+    The defaults are chosen based on observed metrics from Google Kubernetes Engine.
+
+None of the following are set by default.
+They can be used to add additional Kubernetes configuration to all lab pods if, for example, you want them to run on specific nodes or tag them with annotations that have some external meaning for your environment.
+
+``controller.config.fileserver.affinity``
+    Affinity rules for user file server pods.
+
+``controller.config.fileserver.extraAnnotations``
+    Extra annotations to add to all file server pods.
+
+``controller.config.fileserver.nodeSelector``
+    Node selector rules for user file server pods.
+
+``controller.config.fileserver.tolerations``
+    Toleration rules for user file server pods.
+
+Timeouts
+========
+
+``controller.config.fileserver.creationTimeout``
+    How long in seconds to wait for Kubernetes to start the file server.
+    The default is 120 (two minutes).
+
+``controller.config.fileserver.deleteTimeout``
+    How long in seconds to wait for Kubernetes to delete a file server.
+    The default is 60 (one minute).
+
+``controller.config.fileserver.idleTimeout``
+    After this length of time in seconds, the file server exits and is automatically cleaned up to save cluster resources.
+    If the user needs to use the file server again, they will need to restart it by going to the ``/files`` URL (or other URL set by ``controller.config.fileserver.pathPrefix``).
+    The default is 3600 (one hour).
+
+Path prefix
+===========
+
+``controller.config.fileserver.pathPrefix``
+    The path prefix to use for the user file server routes.
+    The default is ``/files``.
+    You probably do not want to change this unless you are trying to run multiple instances of Nublado in the same Phalanx environment for some reason.

--- a/docs/admin/config/hub.rst
+++ b/docs/admin/config/hub.rst
@@ -1,0 +1,139 @@
+########################
+JupyterHub configuration
+########################
+
+The JupyterHub service is installed using `Zero to JupyterHub`_ as a sub-chart, so there are a lot of settings in the :file:`values.yaml` file for the ``nublado`` application that should not need to be changed.
+Documented here are the settings that may need to be changed for different Phalanx environments.
+
+Settings that start with ``jupyterhub`` are Zero to JupyterHub configuration settings and are passed to the sub-chart.
+Settings with other prefixes are Phalanx-specific.
+
+.. _config-hub-db:
+
+Database
+========
+
+By default, JupyterHub uses the internal PostgreSQL server deployed by Phalanx to store its session database.
+However, use of that database server is not recommended for anything other than testing.
+Production deployments should instead provide an infrastructure database and configure JupyterHub to use it.
+
+``hub.internalDatabase``
+    Set this to false when using an infrastructure database.
+    The default is true, indicating that the Phalanx-internal database service should be used.
+
+``jupyterhub.hub.db.url``
+    Set this to the URL of the PostgreSQL database that should be used for the session database.
+    The default is to use the Phalanx-internal database service.
+    Use the value ``postgresql://nublado@cloud-sql-proxy.nublado/nublado`` when using Cloud SQL (see :ref:`config-hub-cloudsql`).
+
+.. _config-hub-cloudsql:
+
+Cloud SQL
+---------
+
+When running a Phalanx environment on Google Kubernetes Engine, using Cloud SQL for the Nublado JupyterHub session database is strongly recommended.
+
+When using Cloud SQL, Nublado always uses workload identity via the Cloud SQL Auth Proxy to gain access to the database.
+Configuring Cloud SQL therefore requires creating a Google service account with the ``cloudsql.client`` role and binding it to the Kubernetes service account ``cloud-sql-proxy`` in the ``nublado`` namespace of the Phalanx environment.
+Then, set the following configuration settings:
+
+``cloudsql.enabled``
+    Set this to true when using Cloud SQL.
+
+``cloudsql.instanceConnectionName``
+    Database instance connection name that is hosting the JupyterHub session database.
+    This is shown in the GCP console after you have created the Cloud SQL database.
+
+``cloudsql.serviceAccount``
+    Name of the Google service account configured as described above.
+    This service account must have an IAM binding to the Kubernetes service account ``cloud-sql-proxy`` in the ``nublado`` namespace of the Phalanx environment.
+    See `workload identity`_ for more information.
+
+Also set ``jupyterhub.hub.db.url`` to ``postgresql://nublado@cloud-sql-proxy.nublado/nublado`` as described in :ref:`config-hub-db`.
+The last portion of that URL (``nublado``) names the Cloud SQL database used for the session database.
+Naming that database ``nublado`` is recommended, but it can be named anything you choose as long as the URL is consistent.
+Using a separate database solely for the JupyterHub session database is strongly recommended.
+
+See the `Google documentation <https://cloud.google.com/sql/docs/postgres/connect-overview>`__ for more information about Cloud SQL and the Cloud SQL Auth Proxy.
+
+The following additional settings are supported for configuring how the Cloud SQL Auth Proxy pod is deployed in Kubernetes.
+You will not normally need to set them.
+
+``cloudsql.affinity``
+    Affinity rules for the Cloud SQL Auth Proxy pod.
+
+``cloudsql.nodeSelector``
+    Node selector rules for the Cloud SQL Auth Proxy pod.
+
+``cloudsql.podAnnotations``
+    Additional annotations to add to the Cloud SQL Auth Proxy pod.
+
+``cloudsql.resources``
+    Resource limits and requests for the Cloud SQL Auth Proxy pod.
+    The defaults are chosen based on observed metrics from the JupyterHub running on Google Kubernetes Engine with a light user load.
+
+``cloudsql.tolerations``
+    Toleration rules for the Cloud SQL Auth Proxy pod.
+
+The following additional settings control what version of the Cloud SQL Auth Proxy is used.
+By default, the latest stable relesae is used.
+You will not normally need to change any of these settings.
+
+``cloudsql.image.repository``
+    Docker repository from which to get the Cloud SQL Auth Proxy image.
+
+``cloudsql.image.pullPolicy``
+    Pull policy for the Cloud SQL Auth Proxy image.
+    The default is ``IfNotPresent``.
+
+``cloudsql.image.tag``
+    Tag of the Cloud SQL Auth Proxy image.
+
+Automatic lab shutdown
+======================
+
+JupyterHub supports automatically shutting down labs after either a period of idle time or after a maximum age.
+This is controlled by the following settings.
+
+``jupyterhub.cull.enabled``
+    Set to false if you want to disable shutting down labs automatically.
+
+``jupyterhub.cull.timeout``
+    Idle timeout in seconds.
+    If a lab has been idle for longer than this length of time, it will be automatically shut down.
+    The default is 2592000 (30 days).
+
+``jupyterhub.cull.maxAge``
+    Maximum age of a lab in seconds.
+    Any lab that has been running for longer than this period of time will be automatically shut down whether it is active or not.
+    The default is 5184000 (60 days).
+
+Image
+=====
+
+``jupyterhub.hub.image.name``
+    Docker repository for the JupyterHub image to use.
+    The default is to use the custom JupyterHub image built by Nublado.
+
+``jupyterhub.hub.image.tag``
+    Tag of the JupyterHub image to use.
+    You may need to override this setting when testing unreleased images.
+
+    Due to limitations in Helm's handling of sub-charts, this version, unlike the version of other components such as the controller, does not automatically default to the ``appVersion`` of the ``nublado`` chart.
+    It therefore must be updated in :file:`values.yaml` whenever a new version of Nublado is released.
+    This is normally done as part of the :ref:`release process <regular-release>`.
+
+Timeouts
+========
+
+``hub.timeout.startup``
+    How long to wait in seconds for the JupyterLab process to start responding to network requests after the lab pod has started.
+    Empirically, this sometimes takes longer than 60 seconds for sciplat-lab_ images for reasons that we do not currently understand.
+    The default is 90 seconds.
+
+Phalanx internals
+=================
+
+``secrets.templateSecrets``
+    Set this to true if the Phalanx environment has been converted to the new secrets management system.
+    See `the Phalanx documentation <https://phalanx.lsst.io/admin/migrating-secrets.html>`__ for more information.

--- a/docs/admin/config/images.rst
+++ b/docs/admin/config/images.rst
@@ -1,0 +1,143 @@
+###################
+Image configuration
+###################
+
+The Nublado controller image configuration serves two purposes.
+It controls what images are listed and highlighted on the lab spawn form presented by JupyterHub.
+It also controls which images are prepulled to all Kubernetes nodes in the cluster to speed up lab start time.
+
+Nublado currently only supports a single image repository.
+The tags in that repository must follow the rules in :sqr:`059`.
+
+Currently, Nublado depends on the features of the sciplat-lab_ Docker image and probably will only work on images derived from that image.
+
+.. warning::
+
+   Currently, the Nublado controller attempts to prepull images to every node in the cluster.
+   This will not work correctly on nodes with taints, but the Nublado controller does not currently know how to skip those nodes.
+
+.. _config-images-source:
+
+Image source
+============
+
+The image source is configured via ``controller.config.images.source``.
+Nublado supports two possible sources of images: a Docker registry, or Google Artifact Registry.
+Each source takes different parameters.
+
+``controller.config.images.source.type``
+    Set to either ``docker`` or ``google`` to choose the type of source.
+
+Docker registries
+-----------------
+
+For a Docker registry image source type, also set the following parameters:
+
+``controller.config.images.source.registry``
+    Host name and optional port of the Docker registry from which to fetch images.
+    For Docker Hub, use ``docker.io``.
+
+``controller.config.images.source.repository``
+    The repository within that Docker registry to use as an image source.
+    For example, ``lsstsqre/sciplat-lab``.
+
+Here is an example configuration fragment with a complete source specification:
+
+.. code-block:: yaml
+
+   controller:
+     config:
+       images:
+         source:
+           type: "docker"
+           registry: "docker.io"
+           repository: "lsstsqre/sciplat-lab"
+
+Google Artifact Registry
+------------------------
+
+If using Google Artifact Registry as the image source, also set the following settings:
+
+``controller.config.images.source.location``
+    The region of the Google Artifact Registry instance.
+    For example, ``us-central```.
+
+``controller.config.images.source.projectId``
+    The Google Cloud Platform project ID of the Google Artifact Registry instance.
+
+``controller.config.images.source.repository``
+    The name of the Google Artifact Repository instance.
+    GAR uses slightly incompatible terminology that doesn't map one-to-one to the Docker terminology.
+    The repository is the name of a collection of images, similar to the part before the slash in the Docker repository name.
+    For example, ``sciplat``.
+
+``controller.config.images.source.image``
+    The name of the image within that Google Artifact Repository instance.
+    For example, ``sciplat-lab``.
+
+The Nublado controller uses `workload identity`_ to authenticate to Google Artifact Repository to list available images.
+When using GAR, you must configure a Google service account with read access to this GAR instance and bind it to the Kubernetes service account ``nublado-controller`` in the ``nublado`` namespace.
+Then, set the following additional configuration setting:
+
+``controller.googleServiceAccount``
+    The name of the Google service account with read access to this GAR instance.
+
+Image prepulling and menu
+=========================
+
+Because Rubin Science Platform images are large, the Nublado controller prepulls a selection of images to each cluster node.
+Those images are shown as radio button options at the top of the user HTML form for selecting what images to spawn to encourage their use.
+All other available images are collected into a drop-down list with a caution that choosing from the drop-down list may result in slow lab start times.
+
+See :sqr:`059` for the definition of release, weekly, and daily images.
+
+What images to prepull and display as radio button selections are controlled by the following settings:
+
+``controller.config.images.recommendedTag``
+    The Docker image tag that marks the recommended image.
+    This will be listed as the first entry in the radio button list on the user HTML form and will be selected by default.
+    The default value is ``recommended``.
+
+    Due to a deficiency in the Docker registry API, if you are using a Docker registry image source and the recommended image is not one of the releases, weeklies, or dailies that are prepulled as defined below, you should pin the underlying image tag as well.
+    This ensures that the Nublado controller knows the version tag underlying the recommended image and can create a good human-readable name for the image.
+    Do this with the ``controller.config.images.pin`` setting described below.
+
+``controller.config.images.numReleases``
+    How many release images to prepull (sorted by recency).
+    The default is 1.
+
+``controller.config.images.numWeeklies``
+    How many weekly images to prepull (sorted by recency).
+    The default is 2.
+
+``controller.config.images.numDailies``
+    How many daily images to prepull (sorted by recency).
+    The default is 3.
+
+``controller.config.images.pin``
+    Additional images to prepull.
+    This is a list that can contain any image tag.
+    Those images will be prepulled and added to the user HTML form after the release, weekly, and daily images.
+
+    As discussed above, when using the Docker image source, you should normally pin the version tag underlying the recommended image to ensure that the Nublado controller can determine its version and generate a good human-readable description.
+
+``controller.config.images.aliasTags``
+    Tags that alias other images.
+    This setting doesn't affect prepulling.
+    It provides additional information to the Nublado controller about which tags are moving aliases for other tags (such as additional situation-specific recommended tags).
+    That information enables better formatting of the human-readable description of those tags.
+
+Image cycles
+============
+
+Some Rubin Science Platform environments have an XML cycle associated with each release of the user lab image.
+The environment only supports one XML cycle version at a time.
+Running an image that uses a different XML cycle image is unsafe and must be blocked.
+
+In such environments, set the following configuration setting:
+
+``controller.config.images.cycle``
+    Restrict images to only those images with this XML cycle.
+    This is applied as a filter to all images, including releases, weeklies, and dailies.
+    The image matching ``controller.config.images.recommendedTag`` is not filtered, so make sure that it points to an image with the appropriate cycle.
+    Usually the best way to do this is to have a new recommended tag for each cycle version, and update the recommended tag at the same time as the cycle number.

--- a/docs/admin/config/index.rst
+++ b/docs/admin/config/index.rst
@@ -1,0 +1,35 @@
+#######################
+Configuration reference
+#######################
+
+Nublado is configured via the Helm chart for the ``nublado`` Phalanx application.
+As with any other Phalanx application, configuration goes into :file:`values-{environment}.yaml` for a given Phalanx environment.
+For more information, see the Phalanx documentation on `writing a Helm chart <https://phalanx.lsst.io/developers/write-a-helm-chart.html>`__.
+
+Most of the configuration options are for the Nublado controller.
+Only a few parameters for the other Nublado components normally need to be changed.
+
+Because Nublado uses `Zero to JupyterHub`_ to do a lot of the work of installing JupyterHub and its supporting resources, the :file:`values.yaml` file contains a lot of settings for Zero to JupyterHub that should not need to be changed.
+Those settings are not mentioned here.
+Only the settings that may need to be overridden in :file:`values-{environment}.yaml` are documented.
+
+All configuration parameters are documented using keys separated by dots (for example, ``controller.config.lab.pullSecret``).
+This corresponds to YAML structure such as:
+
+.. code-block:: yaml
+
+   controller:
+     config:
+       lab:
+         pullSecret: "pull-secret"
+
+When writing your :file:`values-{environment}.yaml` file, merge common sections together.
+For example, if you have multiple settings you are changing under ``controller.config``, there should be only one ``config:`` key and the settings should be combined beneath it.
+
+.. toctree::
+
+   controller
+   images
+   lab
+   fileserver
+   hub

--- a/docs/admin/config/lab.rst
+++ b/docs/admin/config/lab.rst
@@ -1,0 +1,333 @@
+######################
+User lab configuration
+######################
+
+The settings under ``controller.config.lab`` configure the user's lab environment.
+That configuration includes volumes and volume mounts, environment variables, secrets, injected files, and user and group information, as well as Kubernetes configuration such as timeouts and a pull secret.
+
+.. _config-lab-volumes:
+
+Mounted volumes
+===============
+
+By default, labs only have node-local temporary space (a Kubernetes ``emptyDir``) mounted in :file:`/tmp` and some read-only metadata mounted.
+All other mounted file systems must be explicitly specified, including the user's home directory if you want users to have persistent home directories.
+
+As with Kubernetes in general, the volumes and volume mounts are specified separately.
+This allows the list of volumes to be shared with init containers (see :ref:`config-lab-init`) and for the same volume to be mounted multiple times.
+
+``controller.config.lab.volumes``
+    List of volumes available for mounting in either the main lab container (via ``controller.config.lab.volumeMounts``) or in init containers (via the ``volumeMounts`` key of an init container).
+    Each volume must have the following settings:
+
+    ``name``
+        Name of the volume.
+        This is used as-is in the Kubernetes spec and therefore must be a valid Kubernetes name.
+        It must also be unique among all of the volumes.
+
+    ``source``
+        Source specification for the volume.
+        The type of source volume is determined by ``source.type``.
+        Each type of source volume requires different settings.
+        See :ref:`config-lab-volume-host`, :ref:`config-lab-volume-nfs`, and :ref:`config-lab-volume-pvc`.
+
+``controller.config.lab.volumeMounts``
+    List of volume mounts for the main lab container.
+    Each volume mount has the following settings:
+
+    ``containerPath``
+        Where to mount this volume inside the container.
+        For example, ``/home``.
+
+    ``volumeName``
+        The name of the volume (from ``controller.config.lab.volumes``) to mount.
+
+    ``subPath``
+        Subdirectory of the source volume to mount.
+        By default, if this is not specified, the top of the source volume is mounted.
+
+    ``readOnly``
+        If set to true, the volume is mounted read-only.
+        The default is false.
+
+Nublado currently supports three types of volumes, each specified with the ``source`` key of an entry in ``controller.config.lab.volumes``.
+
+.. _config-lab-volume-host:
+
+Host path volumes
+-----------------
+
+A host path volume mounts a file system that is already mounted on the Kubernetes node hosting the pod.
+It is usually used for distributed file systems on non-cloud Kubernetes clusters.
+
+Host path volumes have the following settings in their ``source`` key:
+
+``type``
+    Must be set to ``hostPath``.
+
+``path``
+    The path on the Kubernetes node to mount into the container.
+    This is the path on the host node, not the path *inside* the container.
+    The path inside the container is set by ``containerPath`` in the volume mount configuration.
+
+.. _config-lab-volume-nfs:
+
+NFS volumes
+-----------
+
+A volume mounted from an NFS server.
+NFS volumes have the following settings in their ``source`` key:
+
+``type``
+    Must be set to ``nfs``.
+
+``server``
+    The host name or IP address of the NFS server.
+
+``serverPath``
+    The exported path of the volume on the NFS server.
+
+``readOnly``
+    Whether to mount the volume read-only at the NFS protocol layer.
+    This is a lower-level setting than the ``readOnly`` setting on the volume mount.
+    Unlike the volume mount setting, it tells the NFS client that the volume is mounted read-only and all writes will be prevented even if the volume mount specifies read/write.
+
+.. _config-lab-volume-pvc:
+
+PVC volumes
+-----------
+
+A volume mounted from a Kubernetes ``PersistentVolumeClaim``.
+This can use any storage mechanism available to Kubernetes ``PersistentVolume`` resources in the Kubernetes cluster.
+A corresponding ``PersistentVolumeClaim`` will be created for each user lab inside the user's lab namespace.
+
+PVC volumes have the following settings in their ``source`` key.
+
+``type``
+    Must be set to ``persistentVolumeClaim``.
+
+``accessModes``
+    A list of Kubernetes access modes.
+    Because the same volumes are mounted for every user's lab pod, only the access modes ending in ``Many`` are supported, namely ``ReadOnlyMany`` and ``ReadWriteMany``.
+
+``storageClassName``
+    Name of the storage class.
+
+``resources``
+    Resource requests for the volume in the normal Kubernetes syntax for persistent volume claims.
+
+``readOnly``
+    If set to true, forces all mounts of this volume to be read-only.
+    This is a lower-level setting than the ``readOnly`` setting on the volume mount and effectively overrides it, although the error message for attempted writes may be different.
+
+Environment variables
+=====================
+
+``controller.config.lab.env``
+    Additional environment variables for all user labs.
+    The value must be key and value pairs to add to the environment.
+    These settings will be public in the GitHub Phalanx repository, so do not use this mechanism for secrets.
+    You can also override specific default environment variables set in :file:`values.yaml` for the Phalanx ``nublado`` application by setting that key to a different value, although do this with caution.
+
+You can also set environment variables from secrets.
+See :ref:`config-lab-secrets` for how to do that.
+
+Files
+=====
+
+``controller.config.lab.files``
+    Static files to inject into every user lab.
+    This setting should consist of key and value pairs.
+    The key is the path to the file inside the lab, and the value is the contents that file should have.
+
+    These settings will be public in the GitHub Phalanx repository, so do not use this mechanism for secrets.
+    Instead, see :ref:`config-lab-secrets`.
+
+``controller.config.lab.nss.baseGroup``
+    The base contents of :file:`/etc/group` inside the container.
+    This is used to show group names instead of GIDs in, for example, :command:`ls` listings.
+    To this, the Nublado controller will add entries for all of the user's primary and supplemental groups.
+    The default is suitable for the base sciplat-lab_ image.
+
+    It is normally not necessary to override this setting.
+    The one time when that may be useful is to add additional GID to group mappings for groups the user is not a member of, so that they can be resolved to human-readable names.
+    However, be cautious of creating duplicates of the records added by the Nublado controller, with possibly unpredictable results.
+
+    When overriding this setting, be sure to include any necessary entries from the default setting.
+
+``controller.config.lab.nss.basePasswd``
+    The base contents of :file:`/etc/passwd` inside the container.
+    This is used to show user names instead of UIDs in, for example, :command:`ls` listings.
+    To this, the Nublado controller will add an entry for the user who is spawning the lab.
+    The default is suitable for the base sciplat-lab_ image.
+
+    It is normally not necessary to override this setting.
+    The one time when that may be useful is to add additional UID to username mappings so that they can be resolved to human-readable names.
+
+    When overriding this setting, be sure to include any necessary entries from the default setting.
+
+.. _config-lab-secrets:
+
+Secrets
+=======
+
+The Nublado controller can create a Kubernetes ``Secret`` resource alongside the uesr lab and use that to pass secrets to the lab.
+
+``controller.config.lab.secrets``
+    A list of secret definitions.
+    Each secret is a string value that can be injected as either environment variables or mounted files.
+    The same secret value is injected for every lab, so do not use this for per-user secrets.
+    The default is an empty list (no injected secrets).
+
+    All secrets will be visible as files under the path :file:`/opt/lsst/software/jupyterlab/secrets`.
+    The name of the file is the key of the secret (``secretKey`` below) and the contents of the file are the value of the secret.
+    Secrets can also be injected as environment variables or files mounted elsewhere, as described below.
+
+    Each secret definition may have the following settings:
+
+    ``secretName``
+        Name of the Kubernetes ``Secret`` in the same namespace as the Nublado controller from which to read the secret.
+        Normally this must be ``nublado-lab-secret``, which is created by Phalanx from the configured Nublado secrets.
+
+    ``secretKey``
+        The key within that secret whose value should be injected into the lab.
+        This key name must be unique across all defined lab secrets.
+
+    ``env``
+        Environment variable inside the lab to set to the value of this secret.
+        The default is to not set an environment variable.
+
+    ``path``
+        File to create inside the lab with contents equal to the value of this secret.
+        The default is to not create an additional file containing this secret.
+
+.. _config-lab-init:
+
+Initialization
+==============
+
+Nublado supports running additional containers during the startup of the lab pod as Kubernetes init containers (see `the Kubernetes documentation <https://kubernetes.io/docs/concepts/workloads/pods/init-containers/>`__ for more details).
+These containers may be privileged, unlike the lab containers which always run as the user who spawned the lab.
+Examples of why one may want to run an init container include creating the user's home directory if it doesn't already exist or doing networking setup for the lab container that requires privileged operations.
+
+``controller.config.lab.initContainers``
+    A list of init containers to run before the main lab container is started.
+    Each init container has the following settings:
+
+    ``name``
+        Name of the init container.
+        This is copied into the Kubernetes manifest as the Kubernetes name for the init container, so must be a valid Kubernetes name and must be unique across all init containers.
+
+    ``image.repository``
+        Repository of the image to run.
+        For example, ``docker.io/lsstit/ddsnet4u``.
+
+    ``image.pullPolicy``
+        Kubernetes pull policy of the image.
+        The default is ``IfNotPresent``.
+        Set to ``Always`` when testing an init container by repeatedly pushing new container images with the same tag.
+
+    ``image.tag``
+        Tag of the init container to run.
+        For example, ``1.4.2``.
+
+    ``privileged``
+        If set to true, the container is run as a privileged container with all capabilities and as the root user.
+        The default is false, which runs the container as the lab user with the same restrictions and permissions as the main lab container.
+
+    ``volumeMounts``
+        A list of volumes to mount inside the container.
+        The volumes must correspond to volumes specified in ``controller.config.lab.volumes``.
+        The syntax of each entry is identical to the syntax of ``controller.config.lab.volumeMounts`` (see :ref:`config-lab-volumes`).
+        None of the volumes mounted in the main lab container are mounted in init containers by default, so if the init container needs access to them, those mounts must be reiterated here.
+        They are independent of the main container mounts and thus can have different paths, sub-paths, and so forth, and can reference volumes not mounted in the main container.
+
+Lab sizes
+=========
+
+When the user requests a new lab, they are asked to choose from a menu of possible lab sizes.
+These sizes correspond to Kubernetes resource limits and requests for the created pod.
+See the `Kubernetes documentation <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`__ for more details.
+
+``controller.config.lab.sizes``
+    The list of available lab sizes from which the user can choose.
+    If the user has a notebook quota set (see `quota settings in Gafaelfawr <https://gafaelfawr.lsst.io/user-guide/helm.html#quotas>`__), only sizes that fit within that quota will be shown.
+    The order in which the sizes are listed will be preserved in the menu, and the first size listed will be the default.
+
+    The default setting defines three sizes: ``small`` with 1 CPU unit and 4GiB of memory, ``medium`` with 2 CPU units and 8GiB of memory, and ``large`` with 4 CPU units and 16GiB of memory.
+
+    Each element of the list must contain the following keys:
+
+    ``size``
+        The human-readable name of this lab size.
+        Must be chosen from ``fine``, ``diminutive``, ``tiny``, ``small``, ``medium``, ``large``, ``huge``, ``gargantuan``, and ``colossal`` (taken from `d20 creature sizes`_).
+
+    ``cpu``
+        Number of CPU units to set as a limit.
+        If the pod attempts to use more CPU processing than this limit, it will be throttled.
+
+    ``memory``
+        Memory allocation limit.
+        If the pod attempts to allocate more memory than this limit, processes will be killed by the Linux OOM killer.
+        In practice, this often means the pod will become unusable and will have to be recreated.
+
+    The ``cpu`` and ``memory`` for a given lab size define the Kubernetes limits.
+    The Kubernetes requests are automatically set to 25% of the limits.
+
+Kubernetes
+==========
+
+``controller.config.lab.application``
+    Name of the Argo CD application with which to tag user lab resources.
+    This tagging causes all of the user lab resources to show up in Argo CD, which has been convenient for deleting broken labs or viewing pod logs.
+    The default is ``nublado-users`` and should not normally be changed, since Phalanx sets up an application by that name for this purpose.
+
+``controller.config.lab.namespacePrefix``
+    Prefix used in constructing the names of user lab namespaces.
+    All lab resources for a user will be put into a Kubernetes namespace whose name is formed by appending ``-`` and the username to the value of this setting.
+    The default is ``nublado``.
+
+``controller.config.lab.pullSecret``
+    The name of a pull secret to use for lab images.
+    This is only needed if Docker is used as an image source (see :ref:`config-images-source`) and if credentials are required to talk to the Docker registry.
+    This may be required to access private image registries, or to lift the restrictive rate limit Docker Hub imposes on unauthenticated clients.
+    If set, it should be set to the string ``pull-secret``, which will be created by Phalanx.
+    The default is unset.
+
+    See `the Phalanx documentation <https://phalanx.lsst.io/admin/update-pull-secret.html>`__ for more details about managing a pull secret in Phalanx.
+
+None of the following are set by default.
+They can be used to add additional Kubernetes configuration to all lab pods if, for example, you want them to run on specific nodes or tag them with annotations that have some external meaning for your environment.
+
+``controller.config.lab.affinity``
+    Affinity rules for user lab pods.
+
+``controller.config.lab.extraAnnotations``
+    Extra annotations to add to all user lab pods.
+
+``controller.config.lab.nodeSelector``
+    Node selector rules for user lab pods.
+
+``controller.config.lab.tolerations``
+    Toleration rules for user lab pods.
+
+Timeouts
+========
+
+``controller.config.lab.deleteTimeout``
+    How long to wait for Kubernetes to delete a user's lab in seconds, before failing the deletion with an error.
+    The default is one minute.
+    If the deletion fails and the user is left with a partially-deleted lab, the deletion will be retried when the user tries to spawn a new lab.
+
+``controller.config.lab.spawnTimeout``
+    How long to wait for Kubernetes to spawn the lab in seconds, before failing the lab creation with an error.
+    This only counts the time until Kubernetes believes the pod is running and does not include the time required for the lab process itself to start responding to network requests.
+    This timeout must be long enough to include the time required to pull the image for images that are not prepulled.
+    The default is ten minutes.
+
+JupyterHub has a separate timeout that you may need to adjust:
+
+``hub.timeout.startup``
+    How long in seconds to wait for the user's lab to start responding to network connections after the pod has started.
+    Empirically, sciplat-lab_ images sometimes take over 60 seconds to start.
+    The default is 90 seconds.

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -1,5 +1,13 @@
-#############
-Configuration
-#############
+##############
+Administrators
+##############
 
-Placeholder.
+A Nublado administrator is someone who is responsible for configuring Nublado as part of a Rubin Science Platform deployment.
+That work is primarily done in Phalanx_.
+
+This documentation provides the reference manual for Nublado, including all of the available options in the Helm chart.
+Guides to common problems and instructions on how to integrate properly with Phalanx environments, such as for managing secrets, are found in the Phalanx documentation, specifically the `Nublado Phalanx application`_, and the general `Phalanx documentation for developers <https://phalanx.lsst.io/developers/index.html>`__.
+
+.. toctree::
+
+   config/index

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -6,9 +6,9 @@ This page gives an overview of how Nublado releases are made.
 This information is only useful for maintainers.
 
 Nublado's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
-When a semantic version tag is pushed to GitHub, Nublado Docker images are published on `GitHub <https://github.com/orgs/lsst-sqre/packages?repo_name=gafaelfawr>`__ with that version.
+When a semantic version tag is pushed to GitHub, Nublado Docker images are published on `GitHub <https://github.com/orgs/lsst-sqre/packages?repo_name=nublado>`__ with that version.
 
-.. _`ci.yaml`: https://github.com/lsst-sqre/gafaelfawr/blob/main/.github/workflows/ci.yaml
+.. _`ci.yaml`: https://github.com/lsst-sqre/nublado/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
 
@@ -21,8 +21,8 @@ See :ref:`backport-release` to patch an earlier major-minor version.
 
 Release tags are semantic version identifiers following the :pep:`440` specification.
 
-1. Change log and documentation
--------------------------------
+1. Update the change log
+------------------------
 
 Change log messages for each release are accumulated using scriv_ (see :ref:`dev-change-log`).
 When it comes time to make the release, there should be a collection of change log fragments in :file:`changelog.d`.
@@ -68,6 +68,16 @@ Then, above that, paste the contents of the :file:`CHANGELOG.md` entry for this 
 Adjust the heading depth of the subsections to use ``##`` instead of ``###`` to match the pull request summary.
 
 Then, press the :guilabel:`Generate release notes` button to include the GitHub-generated summary of pull requests.
+
+4. Update Phalanx
+-----------------
+
+In the Phalanx_ repository under :file:`applications/nublado`, update the :file:`values.yaml` and :file:`values-{environment}.yaml` files for any changes in Nublado's configuration.
+
+Then, as part of the same PR, update the version in :file:`applications/nublado/Chart.yaml` to the latest release tag.
+Also update the setting ``jupyterhub.hub.image.tag`` to the same value.
+
+Test the new version on a development cluster using the instructions in the `Phalanx documentation <https://phalanx.lsst.io/developers/deploy-from-a-branch.html>`__ before merging.
 
 .. _backport-release:
 


### PR DESCRIPTION
Add a reference manual for Nublado configuration. Add more details to the release process, documenting how to update Phalanx for a new release.

Remove ReadWriteOnce from the list of supported modes for PVCs, since that access mode can never work with Nublado user labs or file servers.