### PR TITLE
DM-38714: Add internals documentation for JupyterHub plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/_static/openapi.json
+docs/dev/api/contents/
 
 # PyBuilder
 target/

--- a/authenticator/pyproject.toml
+++ b/authenticator/pyproject.toml
@@ -41,6 +41,9 @@ Source = "https://github.com/lsst-sqre/nublado"
 requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = 'setuptools.build_meta'
 
+[project.entry-points."jupyterhub.authenticators"]
+gafaelfawr = "rubin.nublado.authenticator.GafaelfawrAuthenticator"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/docs/admin/config/hub.rst
+++ b/docs/admin/config/hub.rst
@@ -108,6 +108,14 @@ This is controlled by the following settings.
     Any lab that has been running for longer than this period of time will be automatically shut down whether it is active or not.
     The default is 5184000 (60 days).
 
+Path prefix
+===========
+
+``jupyterhub.hub.baseUrl``
+    The path prefix to use for the user interface to JupyterHub.
+    The default is ``/nb``.
+    You probably do not want to change this unless you are trying to run multiple instances of Nublado in the same Phalanx environment for some reason.
+
 Image
 =====
 

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -9,5 +9,6 @@ This documentation provides the reference manual for Nublado, including all of t
 Guides to common problems and instructions on how to integrate properly with Phalanx environments, such as for managing secrets, are found in the Phalanx documentation, specifically the `Nublado Phalanx application`_, and the general `Phalanx documentation for developers <https://phalanx.lsst.io/developers/index.html>`__.
 
 .. toctree::
+   :maxdepth: 2
 
    config/index

--- a/docs/dev/api/authenticator.rst
+++ b/docs/dev/api/authenticator.rst
@@ -1,0 +1,10 @@
+##########################
+Internal authenticator API
+##########################
+
+The module ``rubin.nublado.authenticator`` provides an implementation of the `JupyterHub Authenticator API <https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html>`__ that uses Gafaelfawr_ to authenticate users.
+
+This authenticator class is registered as ``gafaelfawr`` in the ``jupyterhub.authenticators`` entry point.
+
+.. automodapi:: rubin.nublado.authenticator
+   :include-all-objects:

--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -1,0 +1,12 @@
+####################
+Python internal APIs
+####################
+
+Nublado provides a :doc:`REST API </api>` for external users and does not provide Python libraries intended for use outside of Nublado.
+The Python API is therefore only of interest to Nublado developers.
+
+.. toctree::
+   :maxdepth: 2
+
+   authenticator
+   spawner

--- a/docs/dev/api/spawner.rst
+++ b/docs/dev/api/spawner.rst
@@ -1,0 +1,10 @@
+####################
+Internal spawner API
+####################
+
+The module ``rubin.nublado.spawner`` provides an implementation of the `JupyterHub Spawner API <https://jupyterhub.readthedocs.io/en/stable/reference/spawners.html>`__ that uses the Nublado controller to manage user labs.
+
+This authenticator class is registered as ``nublado`` in the ``jupyterhub.spawners`` entry point.
+
+.. automodapi:: rubin.nublado.spawner
+   :include-all-objects:

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -22,3 +22,8 @@ The repository uses the vertical monorepo structure defined in :sqr:`075`.
    :caption: Development
 
    plan
+
+.. toctree::
+   :caption: Reference
+
+   api/index

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -38,6 +38,7 @@ nitpick_ignore = [
     ["py:exc", "fastapi.exceptions.RequestValidationError"],
     ["py:exc", "httpx.HTTPError"],
     ["py:obj", "fastapi.routing.APIRoute"],
+    ["py:obj", "httpx.AsyncClient"],
     ["py:class", "kubernetes_asyncio.client.api_client.ApiClient"],
     ["py:class", "pydantic.env_settings.BaseSettings"],
     ["py:class", "pydantic.error_wrappers.ValidationError"],
@@ -47,16 +48,23 @@ nitpick_ignore = [
     ["py:class", "starlette.routing.Route"],
     ["py:class", "starlette.routing.BaseRoute"],
     ["py:exc", "starlette.exceptions.HTTPException"],
+    # traitlets does provide intersphinx, but the documentation generates some
+    # reference to this undocumented type.
+    ["py:class", "traitlets.traitlets.HasDescriptors"],
 ]
 nitpick_ignore_regex = [
     ["py:class", "kubernetes_asyncio\\.client\\.models\\..*"],
 ]
 rst_epilog_file = "_rst_epilog.rst"
+python_api_dir = "dev/api/contents"
 
 [sphinx.intersphinx.projects]
+jupyerhub = "https://jupyterhub.readthedocs.io/en/stable/"
 python = "https://docs.python.org/3/"
 safir = "https://safir.lsst.io/"
 structlog = "https://www.structlog.org/en/stable/"
+tornado = "https://www.tornadoweb.org/en/stable/"
+traitlets = "https://traitlets.readthedocs.io/en/stable/"
 
 [sphinx.linkcheck]
 ignore = [

--- a/noxfile.py
+++ b/noxfile.py
@@ -164,8 +164,8 @@ def typing_hub(session: nox.Session) -> None:
     )
     session.install("-r", "hub/requirements/main.txt")
     session.install("-r", "hub/requirements/dev.txt")
-    session.install("--no-deps", "-e", "authenticator[dev]")
-    session.install("--no-deps", "-e", "spawner[dev]")
+    session.install("--no-deps", "-e", "authenticator")
+    session.install("--no-deps", "-e", "spawner")
     session.run(
         "mypy",
         *session.posargs,
@@ -209,8 +209,8 @@ def test_hub(session: nox.Session) -> None:
     session.install("--upgrade", "pip", "setuptools", "wheel")
     session.install("-r", "hub/requirements/main.txt")
     session.install("-r", "hub/requirements/dev.txt")
-    session.install("--no-deps", "-e", "authenticator[dev]")
-    session.install("--no-deps", "-e", "spawner[dev]")
+    session.install("--no-deps", "-e", "authenticator")
+    session.install("--no-deps", "-e", "spawner")
     _pytest(session, "authenticator", "rubin.nublado.authenticator")
     _pytest(session, "spawner", "rubin.nublado.spawner")
 

--- a/spawner/pyproject.toml
+++ b/spawner/pyproject.toml
@@ -48,6 +48,9 @@ Source = "https://github.com/lsst-sqre/nublado"
 requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = 'setuptools.build_meta'
 
+[project.entry-points."jupyterhub.spawners"]
+nublado = "rubin.nublado.spawner.RSPRestSpawner"
+
 [tool.setuptools_scm]
 root = ".."
 

--- a/spawner/pyproject.toml
+++ b/spawner/pyproject.toml
@@ -49,7 +49,7 @@ requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = 'setuptools.build_meta'
 
 [project.entry-points."jupyterhub.spawners"]
-nublado = "rubin.nublado.spawner.RSPRestSpawner"
+nublado = "rubin.nublado.spawner.NubladoSpawner"
 
 [tool.setuptools_scm]
 root = ".."

--- a/spawner/src/rubin/nublado/spawner/__init__.py
+++ b/spawner/src/rubin/nublado/spawner/__init__.py
@@ -1,3 +1,3 @@
-from ._internals import RSPRestSpawner
+from ._internals import NubladoSpawner
 
-__all__ = ["RSPRestSpawner"]
+__all__ = ["NubladoSpawner"]

--- a/spawner/src/rubin/nublado/spawner/__init__.py
+++ b/spawner/src/rubin/nublado/spawner/__init__.py
@@ -1,3 +1,10 @@
+"""JupyterHub spawner that uses the Nublado controller to manage labs."""
+
+from ._exceptions import ControllerWebError, InvalidAuthStateError
 from ._internals import NubladoSpawner
 
-__all__ = ["NubladoSpawner"]
+__all__ = [
+    "ControllerWebError",
+    "InvalidAuthStateError",
+    "NubladoSpawner",
+]

--- a/spawner/src/rubin/nublado/spawner/_internals.py
+++ b/spawner/src/rubin/nublado/spawner/_internals.py
@@ -190,7 +190,7 @@ class NubladoSpawner(Spawner):
         InvalidAuthStateError
             Raised if there is no ``token`` attribute in the user's
             authentication state. This should always be provided by
-            `~rsp_restspawner.auth.GafaelfawrAuthenticator`.
+            `rubin.nublado.authenticator.GafaelfawrAuthenticator`.
         """
         r = await self._client.get(
             self._controller_url("lab-form", self.user.name),
@@ -257,7 +257,7 @@ class NubladoSpawner(Spawner):
 
         Yields
         ------
-        dict of str to str or int
+        dict
             Dictionary representing the event with fields ``progress``,
             containing an integer completion percentage, and ``message``,
             containing a human-readable description of the event.
@@ -351,11 +351,11 @@ class NubladoSpawner(Spawner):
         returned, JupyterHub only allows a much shorter timeout for the lab to
         fully start.
 
-        In addition, JupyterHub handles exceptions from `start` and correctly
+        Also, JupyterHub handles exceptions from `start` and correctly
         recognizes that the pod has failed to start, but exceptions from
         `progress` are treated as uncaught exceptions and cause the UI to
         break. Therefore, `progress` must never fail and all operations that
-        may fail need to be done in `start`.
+        may fail must be done in `start`.
         """
         self._start_future = asyncio.create_task(self._start())
         return self._start_future

--- a/spawner/src/rubin/nublado/spawner/_internals.py
+++ b/spawner/src/rubin/nublado/spawner/_internals.py
@@ -1,4 +1,4 @@
-"""Spawner class that uses a REST API to a separate Kubernetes service."""
+"""Spawner class that uses the Nublado controller to manage labs."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ T = TypeVar("T")
 
 __all__ = [
     "LabStatus",
-    "RSPRestSpawner",
+    "NubladoSpawner",
 ]
 
 _CLIENT: AsyncClient | None = None
@@ -35,13 +35,13 @@ _CLIENT: AsyncClient | None = None
 
 
 def _convert_exception(
-    f: Callable[Concatenate[RSPRestSpawner, P], Coroutine[None, None, T]]
-) -> Callable[Concatenate[RSPRestSpawner, P], Coroutine[None, None, T]]:
+    f: Callable[Concatenate[NubladoSpawner, P], Coroutine[None, None, T]]
+) -> Callable[Concatenate[NubladoSpawner, P], Coroutine[None, None, T]]:
     """Convert ``httpx`` exceptions to `ControllerWebError`."""
 
     @wraps(f)
     async def wrapper(
-        spawner: RSPRestSpawner, *args: P.args, **kwargs: P.kwargs
+        spawner: NubladoSpawner, *args: P.args, **kwargs: P.kwargs
     ) -> T:
         try:
             return await f(spawner, *args, **kwargs)
@@ -56,7 +56,7 @@ def _convert_exception(
     return wrapper
 
 
-class RSPRestSpawner(Spawner):
+class NubladoSpawner(Spawner):
     """Spawner class that sends requests to the RSP lab controller.
 
     Rather than having JupyterHub spawn labs directly and therefore need

--- a/spawner/tests/conftest.py
+++ b/spawner/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for tests of the Nublado JupyterHub."""
+"""Fixtures for tests of the Nublado custom spawner class."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import respx
 
-from rubin.nublado.spawner import RSPRestSpawner
+from rubin.nublado.spawner import NubladoSpawner
 
 from .support.controller import MockLabController, register_mock_lab_controller
 from .support.jupyterhub import MockHub, MockUser
@@ -26,9 +26,9 @@ def mock_lab_controller(respx_mock: respx.Router) -> MockLabController:
 
 
 @pytest.fixture
-def spawner(mock_lab_controller: MockLabController) -> RSPRestSpawner:
+def spawner(mock_lab_controller: MockLabController) -> NubladoSpawner:
     """Add spawner state that normally comes from JupyterHub."""
-    result = RSPRestSpawner()
+    result = NubladoSpawner()
     result.admin_token_path = str(
         Path(__file__).parent / "data" / "admin-token"
     )

--- a/spawner/tests/spawner_test.py
+++ b/spawner/tests/spawner_test.py
@@ -1,4 +1,4 @@
-"""Tests for the REST spawner class."""
+"""Tests for the Nublado spawner class."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 import pytest
 
-from rubin.nublado.spawner import RSPRestSpawner
+from rubin.nublado.spawner import NubladoSpawner
 from rubin.nublado.spawner._exceptions import SpawnFailedError
 from rubin.nublado.spawner._models import LabStatus
 
@@ -15,14 +15,14 @@ from .support.controller import MockLabController
 
 
 async def collect_progress(
-    spawner: RSPRestSpawner,
+    spawner: NubladoSpawner,
 ) -> list[dict[str, int | str]]:
     """Gather progress from a spawner and return it as a list when done."""
     return [m async for m in spawner.progress()]
 
 
 @pytest.mark.asyncio
-async def test_start(spawner: RSPRestSpawner) -> None:
+async def test_start(spawner: NubladoSpawner) -> None:
     user = spawner.user.name
     assert await spawner.start() == f"http://lab.nublado-{user}:8888"
 
@@ -34,7 +34,7 @@ async def test_start(spawner: RSPRestSpawner) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stop(spawner: RSPRestSpawner) -> None:
+async def test_stop(spawner: NubladoSpawner) -> None:
     user = spawner.user.name
     assert await spawner.start() == f"http://lab.nublado-{user}:8888"
     assert await spawner.poll() is None
@@ -48,7 +48,7 @@ async def test_stop(spawner: RSPRestSpawner) -> None:
 
 @pytest.mark.asyncio
 async def test_poll(
-    spawner: RSPRestSpawner, mock_lab_controller: MockLabController
+    spawner: NubladoSpawner, mock_lab_controller: MockLabController
 ) -> None:
     assert await spawner.poll() == 0
     mock_lab_controller.set_status(spawner.user.name, LabStatus.PENDING)
@@ -66,20 +66,20 @@ async def test_poll(
 
 
 @pytest.mark.asyncio
-async def test_get_url(spawner: RSPRestSpawner) -> None:
+async def test_get_url(spawner: NubladoSpawner) -> None:
     user = spawner.user.name
     assert await spawner.start() == f"http://lab.nublado-{user}:8888"
     assert await spawner.get_url() == f"http://lab.nublado-{user}:8888"
 
 
 @pytest.mark.asyncio
-async def test_options_form(spawner: RSPRestSpawner) -> None:
+async def test_options_form(spawner: NubladoSpawner) -> None:
     expected = f"<p>This is some lab form for {spawner.user.name}</p>"
     assert await spawner.options_form(spawner) == expected
 
 
 @pytest.mark.asyncio
-async def test_progress(spawner: RSPRestSpawner) -> None:
+async def test_progress(spawner: NubladoSpawner) -> None:
     await spawner.start()
     user = spawner.user.name
     expected = [
@@ -98,7 +98,7 @@ async def test_progress(spawner: RSPRestSpawner) -> None:
 
 
 @pytest.mark.asyncio
-async def test_progress_conflict(spawner: RSPRestSpawner) -> None:
+async def test_progress_conflict(spawner: NubladoSpawner) -> None:
     await spawner.start()
 
     # Start it a second time, which should trigger deleting the old lab.
@@ -122,7 +122,7 @@ async def test_progress_conflict(spawner: RSPRestSpawner) -> None:
 
 @pytest.mark.asyncio
 async def test_progress_multiple(
-    spawner: RSPRestSpawner, mock_lab_controller: MockLabController
+    spawner: NubladoSpawner, mock_lab_controller: MockLabController
 ) -> None:
     """Test multiple progress listeners for the same spawn."""
     mock_lab_controller.delay = timedelta(milliseconds=750)
@@ -150,7 +150,7 @@ async def test_progress_multiple(
 
 @pytest.mark.asyncio
 async def test_spawn_failure(
-    spawner: RSPRestSpawner, mock_lab_controller: MockLabController
+    spawner: NubladoSpawner, mock_lab_controller: MockLabController
 ) -> None:
     """Test error handling when a spawn fails.
 


### PR DESCRIPTION
Add Python API documentation in the dev section for the JupyterHub plugins. Do a proofreading pass on that rendered documentation and clean up some cross-references.

Unfortunately, there doesn't seem to be a way to reference one package installed by Nublado from another package installed by Nublado in a way that Sphinx understands well enough to generate cross-references, so the mention of GafaelfawrAuthenticator in the NubladoSpawner documentation is not a link.

Rename RSPRestSpawner to NubladoSpawner to match the new naming convention, and define entry points per the JupyterHub documentation for the authenticator and the spawner.

Add missing documentation for the `jupyterhub.hub.baseUrl` configuration setting.