### PR TITLE
DM-38714: Limit link depth on developer page

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -14,16 +14,19 @@ The repository uses the vertical monorepo structure defined in :sqr:`075`.
 
 .. toctree::
    :caption: Guides
+   :maxdepth: 2
 
    development
    release
 
 .. toctree::
    :caption: Development
+   :maxdepth: 2
 
    plan
 
 .. toctree::
    :caption: Reference
+   :maxdepth: 3
 
    api/index


### PR DESCRIPTION
The internal API documentation has a ton of objects and overwhelms the development page. Limit its depth, and the depth of the other categories to make the page a bit more readable.