### PR TITLE
DM-41979: Require explicit volume mounts for file servers

### DIFF
--- a/authenticator/pyproject.toml
+++ b/authenticator/pyproject.toml
@@ -42,7 +42,7 @@ requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = 'setuptools.build_meta'
 
 [project.entry-points."jupyterhub.authenticators"]
-gafaelfawr = "rubin.nublado.authenticator.GafaelfawrAuthenticator"
+gafaelfawr = "rubin.nublado.authenticator:GafaelfawrAuthenticator"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -129,7 +129,6 @@ class ProcessContext:
                     config=config.fileserver,
                     base_url=config.base_url,
                     volumes=config.lab.volumes,
-                    volume_mounts=config.lab.volume_mounts,
                     logger=logger,
                 ),
                 fileserver_storage=FileserverStorage(

--- a/controller/tests/data/fileserver/input/config.yaml
+++ b/controller/tests/data/fileserver/input/config.yaml
@@ -16,6 +16,11 @@ lab:
       source:
         type: hostPath
         path: /share1/project
+    - name: extra
+      source:
+        type: nfs
+        server: 10.13.105.122
+        serverPath: /share1/extra
     - name: scratch
       source:
         type: persistentVolumeClaim
@@ -31,7 +36,9 @@ lab:
     - containerPath: /project
       readOnly: true
       volumeName: project
-    - containerPath: /scratch
+    - containerPath: /extra
+      volumeName: extra
+    - containerPath: /random
       volumeName: scratch
 images:
   source:
@@ -73,3 +80,11 @@ fileserver:
   tolerations:
     - key: ""
       operator: Exists
+  volumeMounts:
+    - containerPath: /home
+      volumeName: home
+    - containerPath: /project
+      readOnly: true
+      volumeName: project
+    - containerPath: /scratch
+      volumeName: scratch

--- a/docs/admin/config/fileserver.rst
+++ b/docs/admin/config/fileserver.rst
@@ -14,6 +14,20 @@ File servers are disabled by default and must be explicitly enabled.
     Set to true to allow users to create file servers.
     The default is false.
 
+Mounted volumes
+===============
+
+``controller.config.fileserver.volumeMounts``
+    A list of volumes to expose to the user over WebDAV.
+    The volumes must correspond to volumes specified in ``controller.config.lab.volumes``.
+    The syntax of each entry is identical to the syntax of ``controller.config.lab.volumeMounts`` (see :ref:`config-lab-volumes`).
+
+    None of the volumes mounted in the main lab container are mounted in user file servers by default.
+    To expose those mounts via WebDAV, they must be listed explicitly here.
+    The ``containerPath`` setting is the relative path at which the volume will appear in WebDAV.
+
+    These mounts are independent of the main container mounts and thus can have different paths, sub-paths, and so forth, and can reference volumes not mounted in the main container.
+
 Image
 =====
 

--- a/docs/admin/config/lab.rst
+++ b/docs/admin/config/lab.rst
@@ -17,7 +17,7 @@ As with Kubernetes in general, the volumes and volume mounts are specified separ
 This allows the list of volumes to be shared with init containers (see :ref:`config-lab-init`) and for the same volume to be mounted multiple times.
 
 ``controller.config.lab.volumes``
-    List of volumes available for mounting in either the main lab container (via ``controller.config.lab.volumeMounts``) or in init containers (via the ``volumeMounts`` key of an init container).
+    List of volumes available for mounting in the main lab container (via ``controller.config.lab.volumeMounts``), init containers (via the ``volumeMounts`` key of an init container), or file servers (via ``controller.config.fileserver.volumeMounts``).
     Each volume must have the following settings:
 
     ``name``

--- a/spawner/pyproject.toml
+++ b/spawner/pyproject.toml
@@ -49,7 +49,7 @@ requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = 'setuptools.build_meta'
 
 [project.entry-points."jupyterhub.spawners"]
-nublado = "rubin.nublado.spawner.NubladoSpawner"
+nublado = "rubin.nublado.spawner:NubladoSpawner"
 
 [tool.setuptools_scm]
 root = ".."


### PR DESCRIPTION
We don't want to make available via the file server every volume that is mounted in the lab container. Add an explicit volumeMounts configuration for the file server similar to the volumeMounts configuration for init containers, which allows us to pick and choose which volumes are mounted.