### PR TITLE
DM-41998: Update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/controller/requirements/dev.txt
+++ b/controller/requirements/dev.txt
@@ -552,9 +552,9 @@ pytest==7.4.3 \
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-sugar
-pytest-asyncio==0.21.1 \
-    --hash=sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d \
-    --hash=sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b
+pytest-asyncio==0.23.2 \
+    --hash=sha256:c16052382554c7b22d48782ab3438d5b10f8cf7a4bdcae7f0f67f097d95beecc \
+    --hash=sha256:ea9021364e32d58f0be43b91c6233fb8d2224ccef2398d6837559e587682808f
     # via -r controller/requirements/dev.in
 pytest-cov==4.1.0 \
     --hash=sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \

--- a/controller/requirements/main.in
+++ b/controller/requirements/main.in
@@ -21,7 +21,7 @@ jinja2
 pydantic>2
 pydantic-settings
 PyYAML
-safir[kubernetes]>=5.0.0a5
+safir[kubernetes]>=5.0.0
 semver
 sse-starlette
 

--- a/controller/requirements/main.txt
+++ b/controller/requirements/main.txt
@@ -383,9 +383,9 @@ google-api-core[grpc]==2.14.0 \
     # via
     #   google-api-core
     #   google-cloud-artifact-registry
-google-auth==2.24.0 \
-    --hash=sha256:2ec7b2a506989d7dbfdbe81cb8d0ead8876caaed14f86d29d34483cbe99c57af \
-    --hash=sha256:9b82d5c8d3479a5391ea0a46d81cca698d328459da31d4a459d4e901a5d927e0
+google-auth==2.25.0 \
+    --hash=sha256:2e7d37702e617ea9f4ac2568625a9fc2cdea910dcdca90e378db09ac94ee9ab3 \
+    --hash=sha256:cabc5c6fd327d71baa820f745118ecb2b709412d153419a43173d91495ef8715
     # via google-api-core
 google-cloud-artifact-registry==1.9.0 \
     --hash=sha256:3484d2a2c04fadfa480be16a554d01e47e4c4f4b5a123cd3725e865b4dd7f325 \
@@ -911,9 +911,9 @@ rsa==4.9 \
     --hash=sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7 \
     --hash=sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21
     # via google-auth
-safir[kubernetes]==5.0.0a5 \
-    --hash=sha256:6a38dbdcfc63ea0261d25cefde0defc9f445a7da2a2612cd864d22bf1f292180 \
-    --hash=sha256:73348465c732fb89ddbd3b73cb8dcaa1294611c49d5db225e1d2a8205558f29b
+safir[kubernetes]==5.0.0 \
+    --hash=sha256:bc09984e09a563f2a3e61c207ca64596f894f1e09481cddc1ea30b6128794b43 \
+    --hash=sha256:cd015bdbd1d45f751d194ad88b50f11641bda80e1def85b35710c0a654ee0f76
     # via
     #   -r controller/requirements/main.in
     #   safir

--- a/controller/tests/support/kubernetes.py
+++ b/controller/tests/support/kubernetes.py
@@ -14,7 +14,7 @@ __all__ = [
 
 
 def objects_to_dicts(
-    objects: list[dict | KubernetesModel]
+    objects: list[dict | KubernetesModel],
 ) -> list[dict[str, Any]]:
     """Serialize a list of Kubernetes objects for comparison.
 

--- a/hub/requirements/dev.txt
+++ b/hub/requirements/dev.txt
@@ -121,9 +121,9 @@ pytest==7.4.3 \
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-sugar
-pytest-asyncio==0.21.1 \
-    --hash=sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d \
-    --hash=sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b
+pytest-asyncio==0.23.2 \
+    --hash=sha256:c16052382554c7b22d48782ab3438d5b10f8cf7a4bdcae7f0f67f097d95beecc \
+    --hash=sha256:ea9021364e32d58f0be43b91c6233fb8d2224ccef2398d6837559e587682808f
     # via -r hub/requirements/dev.in
 pytest-cov==4.1.0 \
     --hash=sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \

--- a/spawner/src/rubin/nublado/spawner/_internals.py
+++ b/spawner/src/rubin/nublado/spawner/_internals.py
@@ -35,7 +35,7 @@ _CLIENT: AsyncClient | None = None
 
 
 def _convert_exception(
-    f: Callable[Concatenate[NubladoSpawner, P], Coroutine[None, None, T]]
+    f: Callable[Concatenate[NubladoSpawner, P], Coroutine[None, None, T]],
 ) -> Callable[Concatenate[NubladoSpawner, P], Coroutine[None, None, T]]:
     """Convert ``httpx`` exceptions to `ControllerWebError`."""
 


### PR DESCRIPTION
Update to Safir 5.0.0, now that there is a full release supporting Pydantic v2. Update Ruff and let it change some formatting. Update Python dependencies generally.