### PR TITLE
DM-42029: Add nodeSelector support to the prepuller

### DIFF
--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -141,6 +141,7 @@ class ProcessContext:
         metadata_storage = MetadataStorage(config.metadata_path)
         image_service = ImageService(
             config=config.images,
+            node_selector=config.lab.node_selector,
             source=source,
             node_storage=NodeStorage(kubernetes_client, logger),
             slack_client=slack_client,

--- a/controller/tests/data/gar-cycle/input/nodes.json
+++ b/controller/tests/data/gar-cycle/input/nodes.json
@@ -1,22 +1,24 @@
 {
-  "node1": [
-    {
-      "names": [
-        "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b"
-      ],
-      "sizeBytes": 123456
-    },
-    {
-      "names": [
-        "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403"
-      ],
-      "sizeBytes": 23524
-    },
-    {
-      "names": [
-        "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda"
-      ],
-      "sizeBytes": 124513
-    }
-  ]
+  "node1": {
+    "images": [
+      {
+        "names": [
+          "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:49d63632237c3c0ca10c2c8de1e4310acadea2cdf2f9eaed0e2d2c0c27736c0b"
+        ],
+        "sizeBytes": 123456
+      },
+      {
+        "names": [
+          "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:b14b81ae38caa6c6d919fc02c202b5d2a99dcce0d4c16ee6ad08b3831e814403"
+        ],
+        "sizeBytes": 23524
+      },
+      {
+        "names": [
+          "us-central1-docker.pkg.dev/lighthouse-71ec/library/sketchbook@sha256:9401f5d181180167d2a2b1d111456a4b9b506245bc43da8c4c869a87d512ecda"
+        ],
+        "sizeBytes": 124513
+      }
+    ]
+  }
 }

--- a/controller/tests/data/prepuller/input/config.yaml
+++ b/controller/tests/data/prepuller/input/config.yaml
@@ -1,0 +1,16 @@
+logLevel: DEBUG
+profile: development
+lab:
+  namespacePrefix: userlabs
+  nodeSelector:
+    status: online
+    nublado: eligible
+  sizes:
+    - size: small
+      cpu: 1.0
+      memory: 3Gi
+images:
+  source:
+    type: docker
+    registry: lighthouse.ceres
+    repository: library/sketchbook

--- a/controller/tests/data/prepuller/input/nodes.json
+++ b/controller/tests/data/prepuller/input/nodes.json
@@ -20,7 +20,8 @@
       }
     ],
     "labels": {
-      "some-label": "some-value"
+      "status": "online",
+      "nublado": "eligible"
     }
   },
   "node2": {
@@ -34,9 +35,17 @@
         ],
         "sizeBytes": 65537
       }
-    ],
+    ]
+  },
+  "node3": {
     "labels": {
-      "some-label": "some-value"
+      "status": "online",
+      "nublado": "eligible"
+    }
+  },
+  "node4": {
+    "labels": {
+      "status": "online"
     }
   }
 }

--- a/controller/tests/data/prepuller/output/status.json
+++ b/controller/tests/data/prepuller/output/status.json
@@ -1,0 +1,64 @@
+{
+  "config": {
+    "source": {
+      "type": "docker",
+      "registry": "lighthouse.ceres",
+      "repository": "library/sketchbook"
+    },
+    "recommended_tag": "recommended",
+    "num_releases": 1,
+    "num_weeklies": 2,
+    "num_dailies": 3,
+    "cycle": null,
+    "pin": null,
+    "alias_tags": []
+  },
+  "images": {
+    "prepulled": [],
+    "pending": [
+      {
+        "reference": "lighthouse.ceres/library/sketchbook:w_2077_43",
+        "tag": "w_2077_43",
+        "name": "Weekly 2077_43",
+        "digest": "sha256:5678",
+        "size": 65537,
+        "nodes": [
+          "node1"
+        ],
+        "missing": [
+          "node3"
+        ]
+      },
+      {
+        "reference": "lighthouse.ceres/library/sketchbook:d_2077_10_23",
+        "tag": "d_2077_10_23",
+        "name": "Daily 2077_10_23",
+        "digest": "sha256:1234",
+        "size": 69105,
+        "nodes": [
+          "node1"
+        ],
+        "missing": [
+          "node3"
+        ]
+      }
+    ]
+  },
+  "nodes": [
+    {
+      "name": "node1",
+      "eligible": true,
+      "comment": null,
+      "cached": [
+        "lighthouse.ceres/library/sketchbook:w_2077_43",
+        "lighthouse.ceres/library/sketchbook:d_2077_10_23"
+      ]
+    },
+    {
+      "name": "node3",
+      "eligible": true,
+      "comment": null,
+      "cached": []
+    }
+  ]
+}

--- a/controller/tests/data/standard/output/prepull-conflict-objects.json
+++ b/controller/tests/data/standard/output/prepull-conflict-objects.json
@@ -1,6 +1,6 @@
 [
   {
-    "api_version": "v1",
+    "apiVersion": "v1",
     "kind": "Pod",
     "metadata": {
       "labels": {
@@ -8,16 +8,15 @@
       },
       "name": "prepull-d-2077-10-23-node2",
       "namespace": "nublado",
-      "owner_references": [
+      "ownerReferences": [
         {
-          "api_version": "v1",
-          "block_owner_deletion": true,
+          "apiVersion": "v1",
+          "blockOwnerDeletion": true,
           "kind": "Pod",
           "name": "nublado-controller",
           "uid": "12720beb-ecae-452e-982e-2f0a0a2fbaf1"
         }
-      ],
-      "resource_version": "3"
+      ]
     },
     "spec": {
       "containers": [
@@ -27,14 +26,16 @@
           ],
           "image": "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234",
           "name": "prepull",
-          "working_dir": "/tmp"
+          "workingDir": "/tmp"
         }
       ],
-      "image_pull_secrets": [
-	{ "name": "pull-secret" }
+      "imagePullSecrets": [
+	{
+          "name": "pull-secret"
+        }
       ],
-      "node_name": "node2",
-      "restart_policy": "Never"
+      "nodeName": "node2",
+      "restartPolicy": "Never"
     },
     "status": {
       "phase": "Running"

--- a/controller/tests/handlers/prepuller_test.py
+++ b/controller/tests/handlers/prepuller_test.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import pytest
 from httpx import AsyncClient
+from safir.testing.kubernetes import MockKubernetesApi
 
-from ..support.data import read_output_json
+from ..support.config import configure
+from ..support.data import (
+    read_input_node_json,
+    read_output_json,
+)
 
 
 @pytest.mark.asyncio
@@ -20,3 +25,18 @@ async def test_prepulls(client: AsyncClient) -> None:
     r = await client.get("/nublado/spawner/v1/prepulls")
     assert r.status_code == 200
     assert r.json() == read_output_json("standard", "prepulls.json")
+
+
+@pytest.mark.asyncio
+async def test_node_selector(
+    client: AsyncClient, mock_kubernetes: MockKubernetesApi
+) -> None:
+    nodes = read_input_node_json("prepuller", "nodes.json")
+    mock_kubernetes.set_nodes_for_test(nodes)
+    await configure("prepuller", mock_kubernetes)
+
+    # Wait for the the prepuller and then get its status. We should only see
+    # the nodes that match the node selector of our configuration.
+    r = await client.get("/nublado/spawner/v1/prepulls")
+    assert r.status_code == 200
+    assert r.json() == read_output_json("prepuller", "status.json")

--- a/controller/tests/services/prepuller_test.py
+++ b/controller/tests/services/prepuller_test.py
@@ -33,6 +33,7 @@ from ..support.data import (
 )
 from ..support.docker import MockDockerRegistry
 from ..support.gar import MockArtifactRegistry
+from ..support.kubernetes import objects_to_dicts
 
 
 async def mark_pod_complete(
@@ -345,4 +346,4 @@ async def test_conflict(
     await factory.start_background_services()
     await asyncio.sleep(0.2)
     pod_list = await mock_kubernetes.list_namespaced_pod("nublado")
-    assert [strip_none(o.to_dict()) for o in pod_list.items] == expected
+    assert objects_to_dicts(pod_list.items) == expected

--- a/controller/tests/support/data.py
+++ b/controller/tests/support/data.py
@@ -97,8 +97,8 @@ def read_input_lab_specification_json(
 def read_input_node_json(config: str, filename: str) -> list[V1Node]:
     """Read input node data as JSON and return it as a list of nodes.
 
-    This only includes data about which images the node has cached, since this
-    is the only thing the lab controller cares about.
+    This only includes data used to select nodes and which images the node has
+    cached, since this is the only thing the Nublado controller cares about.
 
     Parameters
     ----------
@@ -117,10 +117,10 @@ def read_input_node_json(config: str, filename: str) -> list[V1Node]:
     for name, data in read_input_json(config, filename).items():
         node_images = [
             V1ContainerImage(names=d["names"], size_bytes=d["sizeBytes"])
-            for d in data
+            for d in data.get("images", [])
         ]
         node = V1Node(
-            metadata=V1ObjectMeta(name=name),
+            metadata=V1ObjectMeta(name=name, labels=data.get("labels")),
             status=V1NodeStatus(images=node_images),
         )
         nodes.append(node)


### PR DESCRIPTION
If nodeSelector is set for Nublado labs, apply the same node selector when choosing nodes that are eligible for prepulling. For node selector, just filter out the nodes from the prepuller status entirely rather than listing them but showing why they aren't eligible for prepulling. We'll use the latter strategy for tolerations, since tolerations are more temporary.

Use the new function for formatting Kubernetes objects for comparison purposes for the prepuller test objects.