### PR TITLE
DM-42029: Add tolerations support to the prepuller

### DIFF
--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -142,6 +142,7 @@ class ProcessContext:
         image_service = ImageService(
             config=config.images,
             node_selector=config.lab.node_selector,
+            tolerations=config.lab.tolerations,
             source=source,
             node_storage=NodeStorage(kubernetes_client, logger),
             slack_client=slack_client,

--- a/controller/src/controller/models/domain/image.py
+++ b/controller/src/controller/models/domain/image.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .rspimage import RSPImageCollection
+
 __all__ = [
     "MenuImage",
     "MenuImages",
@@ -30,3 +32,25 @@ class MenuImages:
 
     dropdown: list[MenuImage]
     """Extra images to populate the dropdown."""
+
+
+@dataclass(frozen=True)
+class NodeData:
+    """Cached data about a Kubernetes node.
+
+    This data is used to answer prepuller questions and as source data for the
+    prepuller status, but the prepuller status API presents it in a slightly
+    different way and with more primitive data types.
+    """
+
+    name: str
+    """Name of the node."""
+
+    images: RSPImageCollection
+    """Images of interest present on that node."""
+
+    eligible: bool = True
+    """Whether this node is eligible for prepulling."""
+
+    comment: str | None = None
+    """Reason why images aren't prepulled to this node."""

--- a/controller/src/controller/models/domain/kubernetes.py
+++ b/controller/src/controller/models/domain/kubernetes.py
@@ -41,6 +41,7 @@ __all__ = [
     "NodeSelectorRequirement",
     "NodeSelectorTerm",
     "NodeSelector",
+    "NodeToleration",
     "PodAffinity",
     "PodAffinityTerm",
     "PodChange",
@@ -590,6 +591,21 @@ class PullPolicy(Enum):
     ALWAYS = "Always"
     IF_NOT_PRESENT = "IfNotPresent"
     NEVER = "Never"
+
+
+@dataclass
+class NodeToleration:
+    """Whether a single node is tolerated.
+
+    Used to report the results of evaluating any tolerations against any node
+    taints.
+    """
+
+    eligible: bool
+    """Whether the node is tolerated."""
+
+    comment: str | None = None
+    """If the node is not tolerated, why not."""
 
 
 class TaintEffect(Enum):

--- a/controller/src/controller/storage/kubernetes/node.py
+++ b/controller/src/controller/storage/kubernetes/node.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from kubernetes_asyncio import client
-from kubernetes_asyncio.client import ApiClient, ApiException
+from kubernetes_asyncio.client import ApiClient, ApiException, V1Node, V1Taint
 from structlog.stdlib import BoundLogger
 
 from ...exceptions import KubernetesError
-from ...models.domain.kubernetes import KubernetesNodeImage
+from ...models.domain.kubernetes import (
+    KubernetesNodeImage,
+    NodeToleration,
+    Toleration,
+    TolerationOperator,
+)
 from ...timeout import Timeout
 
 __all__ = ["NodeStorage"]
@@ -28,10 +33,88 @@ class NodeStorage:
         self._api = client.CoreV1Api(api_client)
         self._logger = logger
 
-    async def get_image_data(
-        self, node_selector: dict[str, str], timeout: Timeout
+    def get_cached_images(
+        self, nodes: list[V1Node]
     ) -> dict[str, list[KubernetesNodeImage]]:
-        """Get the list of cached images from each node.
+        """Build map of what images are cached on each node.
+
+        Parameters
+        ----------
+        nodes
+            List of Kubernetes nodes with their metadata.
+
+        Returns
+        -------
+        dict of list
+            Mapping of node names to lists of cached images on that node.
+        """
+        image_data = {}
+        for node in nodes:
+            if node.status and node.status.images:
+                image_data[node.metadata.name] = [
+                    KubernetesNodeImage.from_container_image(i)
+                    for i in node.status.images
+                ]
+            else:
+                image_data[node.metadata.name] = []
+        return image_data
+
+    def is_tolerated(
+        self, node: V1Node, tolerations: list[Toleration]
+    ) -> NodeToleration:
+        """Determine whether a pod can be placed on a node.
+
+        Evaluates the node taints against the provided tolerations and
+        determines whether an image with those tolerations can be placed on
+        that node. Nodes with a ``PreferNoSchedule`` taint are still
+        tolerated.
+
+        Parameters
+        ----------
+        node
+            Kubernetes node.
+        tolerations
+            List of tolerations that the pod will have.
+
+        Returns
+        -------
+        NodeToleration
+            Information about whether that image can be placed on that node.
+        """
+        # If there are no taints, the node is always tolerated.
+        if not node.spec or not node.spec.taints:
+            return NodeToleration(eligible=True)
+
+        # Walk through each taint in turn and compare to the tolerations.
+        # Ignore PreferNoSchedule taints, since they can't make the node not
+        # tolerated.
+        for taint in node.spec.taints:
+            if taint.effect == "PreferNoSchedule":
+                continue
+            tolerated = False
+            for toleration in tolerations:
+                tolerated = self._toleration_matches(taint, toleration)
+                if tolerated:
+                    break
+
+            # If this taint was not tolerated, return the result with an
+            # explanation of the taint. This means we only report the first
+            # taint that is not tolerated.
+            if not tolerated:
+                comment = f"Node is tainted ({taint.effect}, "
+                if taint.value:
+                    comment += f"{taint.key} = {taint.value})"
+                else:
+                    comment += f"{taint.key})"
+                return NodeToleration(eligible=False, comment=comment)
+
+        # If this point was reached, all taints were tolerated.
+        return NodeToleration(eligible=True)
+
+    async def list(
+        self, node_selector: dict[str, str], timeout: Timeout
+    ) -> list[V1Node]:
+        """Get data about Kubernetes nodes.
 
         Parameters
         ----------
@@ -42,12 +125,10 @@ class NodeStorage:
 
         Returns
         -------
-        dict of list
-            Map of nodes to lists of all cached images on that node.
+        list of kubernetes_asyncio.client.models.V1Node
+            List of node metadata.
         """
-        self._logger.debug(
-            "Getting node image data", node_selector=node_selector
-        )
+        self._logger.debug("Getting node data", node_selector=node_selector)
         selector = None
         if node_selector:
             selector = ",".join(f"{k}={v}" for k, v in node_selector.items())
@@ -59,14 +140,46 @@ class NodeStorage:
             raise KubernetesError.from_exception(
                 "Error reading node information", e, kind="Node"
             ) from e
+        return nodes.items
 
-        image_data = {}
-        for node in nodes.items:
-            if node.status is not None and node.status.images is not None:
-                image_data[node.metadata.name] = [
-                    KubernetesNodeImage.from_container_image(i)
-                    for i in node.status.images
-                ]
-            else:
-                image_data[node.metadata_name] = []
-        return image_data
+    def _toleration_matches(
+        self, taint: V1Taint, toleration: Toleration
+    ) -> bool:
+        """Whether a given toleration matches a taint.
+
+        Parameters
+        ----------
+        taint
+            Taint on a node.
+        toleration
+            Toleration to check.
+
+        Returns
+        -------
+        bool
+            `True` if that toleration matches the taint with no expiration
+            time, `False` otherwise.
+        """
+        # Tolerations must have a matching effect if specified to have any
+        # effect.
+        if toleration.effect and toleration.effect.value != taint.effect:
+            return False
+
+        # Temporary tolerations are ignored for the purposes of deciding if
+        # the node is tolerated, since we don't want to prepull to a node on
+        # the basis of a temporary toleration.  It's safe to skip a prepull
+        # cycle on that node; if the taint is removed, we'll catch it on the
+        # next cycle.
+        if toleration.toleration_seconds is not None:
+            if taint.effect == "NoExecute":
+                return False
+
+        # Check if this toleration matches the taint.
+        match toleration.operator:
+            case TolerationOperator.EXISTS:
+                return taint.key == toleration.key if toleration.key else True
+            case TolerationOperator.EQUAL:
+                return (
+                    taint.key == toleration.key
+                    and taint.value == toleration.value
+                )

--- a/controller/tests/data/prepuller/input/config.yaml
+++ b/controller/tests/data/prepuller/input/config.yaml
@@ -5,6 +5,9 @@ lab:
   nodeSelector:
     status: online
     nublado: eligible
+  tolerations:
+    - key: some-taint
+      value: some-value
   sizes:
     - size: small
       cpu: 1.0

--- a/controller/tests/data/prepuller/input/nodes.json
+++ b/controller/tests/data/prepuller/input/nodes.json
@@ -47,5 +47,61 @@
     "labels": {
       "status": "online"
     }
+  },
+  "node5": {
+    "images": [
+      {
+        "names": [
+          "lighthouse.ceres/library/sketchbook:latest_daily",
+          "lighthouse.ceres/library/sketchbook:d_2077_10_23",
+          "lighthouse.ceres/library/sketchbook@sha256:1234"
+        ],
+        "sizeBytes": 69105
+      },
+      {
+        "names": [
+          "lighthouse.ceres/library/sketchbook:latest_weekly",
+          "lighthouse.ceres/library/sketchbook:w_2077_43",
+          "lighthouse.ceres/library/sketchbook:recommended",
+          "lighthouse.ceres/library/sketchbook@sha256:5678"
+        ],
+        "sizeBytes": 65537
+      }
+    ],
+    "labels": {
+      "status": "online",
+      "nublado": "eligible"
+    },
+    "taints": [
+      {
+        "effect": "NoSchedule",
+        "key": "some-taint",
+        "value": "some-value"
+      }
+    ]
+  },
+  "node6": {
+    "images": [
+      {
+        "names": [
+          "lighthouse.ceres/library/sketchbook:latest_weekly",
+          "lighthouse.ceres/library/sketchbook:w_2077_43",
+          "lighthouse.ceres/library/sketchbook:recommended",
+          "lighthouse.ceres/library/sketchbook@sha256:5678"
+        ],
+        "sizeBytes": 65537
+      }
+    ],
+    "labels": {
+      "status": "online",
+      "nublado": "eligible"
+    },
+    "taints": [
+      {
+        "effect": "NoSchedule",
+        "key": "some-taint",
+        "value": "other-value"
+      }
+    ]
   }
 }

--- a/controller/tests/data/prepuller/output/status.json
+++ b/controller/tests/data/prepuller/output/status.json
@@ -23,7 +23,9 @@
         "digest": "sha256:5678",
         "size": 65537,
         "nodes": [
-          "node1"
+          "node1",
+          "node5",
+          "node6"
         ],
         "missing": [
           "node3"
@@ -36,7 +38,8 @@
         "digest": "sha256:1234",
         "size": 69105,
         "nodes": [
-          "node1"
+          "node1",
+          "node5"
         ],
         "missing": [
           "node3"
@@ -59,6 +62,23 @@
       "eligible": true,
       "comment": null,
       "cached": []
+    },
+    {
+      "name": "node5",
+      "eligible": true,
+      "comment": null,
+      "cached": [
+        "lighthouse.ceres/library/sketchbook:w_2077_43",
+        "lighthouse.ceres/library/sketchbook:d_2077_10_23"
+      ]
+    },
+    {
+      "name": "node6",
+      "eligible": false,
+      "comment": "Node is tainted (NoSchedule, some-taint = other-value)",
+      "cached": [
+        "lighthouse.ceres/library/sketchbook:w_2077_43"
+      ]
     }
   ]
 }

--- a/controller/tests/handlers/prepuller_test.py
+++ b/controller/tests/handlers/prepuller_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from httpx import AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi
@@ -33,7 +35,8 @@ async def test_node_selector(
 ) -> None:
     nodes = read_input_node_json("prepuller", "nodes.json")
     mock_kubernetes.set_nodes_for_test(nodes)
-    await configure("prepuller", mock_kubernetes)
+    async with asyncio.timeout(1):
+        await configure("prepuller", mock_kubernetes)
 
     # Wait for the the prepuller and then get its status. We should only see
     # the nodes that match the node selector of our configuration.

--- a/controller/tests/services/prepuller_test.py
+++ b/controller/tests/services/prepuller_test.py
@@ -135,7 +135,8 @@ async def test_gar(
     mock_kubernetes.set_nodes_for_test(nodes)
 
     async with Factory.standalone(config) as factory:
-        await factory.start_background_services()
+        async with asyncio.timeout(1):
+            await factory.start_background_services()
         await asyncio.sleep(0.2)
 
         images = factory.image_service.images()

--- a/controller/tests/storage/kubernetes/node_test.py
+++ b/controller/tests/storage/kubernetes/node_test.py
@@ -1,0 +1,146 @@
+"""Tests for the Kubernetes node storage layer."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from kubernetes_asyncio.client import ApiClient, V1Node, V1NodeSpec, V1Taint
+from safir.testing.kubernetes import MockKubernetesApi
+
+from controller.models.domain.kubernetes import (
+    TaintEffect,
+    Toleration,
+    TolerationOperator,
+)
+from controller.storage.kubernetes.node import NodeStorage
+
+
+@pytest.mark.asyncio
+async def test_is_tolerated(mock_kubernetes: MockKubernetesApi) -> None:
+    node = V1Node()
+    logger = structlog.get_logger(__name__)
+    storage = NodeStorage(ApiClient(), logger)
+
+    assert storage.is_tolerated(node, []).eligible
+    node.spec = V1NodeSpec()
+    assert storage.is_tolerated(node, []).eligible
+    node.spec.taints = []
+    assert storage.is_tolerated(node, []).eligible
+
+    # PreferNoSchedule taints are ignored.
+    node.spec.taints = [V1Taint(effect="PreferNoSchedule", key="foo")]
+    assert storage.is_tolerated(node, []).eligible
+
+    node.spec.taints = [V1Taint(effect="NoSchedule", key="foo")]
+    tolerated = storage.is_tolerated(node, [])
+    assert not tolerated.eligible
+    assert tolerated.comment == "Node is tainted (NoSchedule, foo)"
+    assert storage.is_tolerated(
+        node, [Toleration(operator=TolerationOperator.EXISTS)]
+    ).eligible
+    assert storage.is_tolerated(
+        node, [Toleration(operator=TolerationOperator.EXISTS, key="foo")]
+    ).eligible
+    assert not storage.is_tolerated(
+        node, [Toleration(operator=TolerationOperator.EXISTS, key="bar")]
+    ).eligible
+    assert storage.is_tolerated(
+        node,
+        [
+            Toleration(
+                effect=TaintEffect.NO_SCHEDULE,
+                operator=TolerationOperator.EXISTS,
+                key="foo",
+            )
+        ],
+    ).eligible
+    assert not storage.is_tolerated(
+        node,
+        [
+            Toleration(
+                effect=TaintEffect.NO_EXECUTE,
+                operator=TolerationOperator.EXISTS,
+                key="foo",
+            )
+        ],
+    ).eligible
+
+    node.spec.taints = [V1Taint(effect="NoSchedule", key="foo", value="bar")]
+    assert storage.is_tolerated(
+        node, [Toleration(operator=TolerationOperator.EXISTS)]
+    ).eligible
+    assert storage.is_tolerated(
+        node, [Toleration(operator=TolerationOperator.EXISTS, key="foo")]
+    ).eligible
+    assert storage.is_tolerated(
+        node, [Toleration(key="foo", value="bar")]
+    ).eligible
+    tolerated = storage.is_tolerated(
+        node, [Toleration(key="bar", value="bar")]
+    )
+    assert not tolerated.eligible
+    assert tolerated.comment == "Node is tainted (NoSchedule, foo = bar)"
+    assert not storage.is_tolerated(
+        node, [Toleration(key="foo", value="barbar")]
+    ).eligible
+
+    # Tolerations with toleration_seconds set are ignored for NoExecute taints
+    # but honored for other types of taints.
+    node.spec.taints = [V1Taint(effect="NoExecute", key="foo", value="bar")]
+    toleration = Toleration(key="foo", value="bar", toleration_seconds=5)
+    assert not storage.is_tolerated(node, [toleration]).eligible
+    node.spec.taints = [V1Taint(effect="NoSchedule", key="foo", value="bar")]
+    assert storage.is_tolerated(node, [toleration]).eligible
+
+    # For multiple taints, all of the taints have to be tolerated.
+    node.spec.taints = [
+        V1Taint(effect="NoSchedule", key="foo", value="bar"),
+        V1Taint(effect="NoExecute", key="foo", value="other"),
+    ]
+    tolerated = storage.is_tolerated(
+        node, [Toleration(key="foo", value="bar")]
+    )
+    assert not tolerated.eligible
+    assert tolerated.comment == "Node is tainted (NoExecute, foo = other)"
+    assert storage.is_tolerated(
+        node,
+        [
+            Toleration(key="foo", value="bar"),
+            Toleration(key="foo", value="other"),
+        ],
+    ).eligible
+    assert not storage.is_tolerated(
+        node,
+        [
+            Toleration(key="foo", value="bar"),
+            Toleration(key="foo", value="baz"),
+        ],
+    ).eligible
+    assert storage.is_tolerated(
+        node, [Toleration(key="foo", operator=TolerationOperator.EXISTS)]
+    ).eligible
+    assert not storage.is_tolerated(
+        node,
+        [
+            Toleration(
+                effect=TaintEffect.NO_SCHEDULE,
+                key="foo",
+                operator=TolerationOperator.EXISTS,
+            )
+        ],
+    ).eligible
+    assert storage.is_tolerated(
+        node,
+        [
+            Toleration(
+                effect=TaintEffect.NO_SCHEDULE,
+                key="foo",
+                operator=TolerationOperator.EXISTS,
+            ),
+            Toleration(
+                effect=TaintEffect.NO_EXECUTE,
+                key="foo",
+                operator=TolerationOperator.EXISTS,
+            ),
+        ],
+    ).eligible

--- a/controller/tests/support/data.py
+++ b/controller/tests/support/data.py
@@ -10,9 +10,11 @@ from typing import Any
 from kubernetes_asyncio.client import (
     V1ContainerImage,
     V1Node,
+    V1NodeSpec,
     V1NodeStatus,
     V1ObjectMeta,
     V1Secret,
+    V1Taint,
 )
 
 from controller.models.domain.gafaelfawr import GafaelfawrUserInfo
@@ -119,8 +121,10 @@ def read_input_node_json(config: str, filename: str) -> list[V1Node]:
             V1ContainerImage(names=d["names"], size_bytes=d["sizeBytes"])
             for d in data.get("images", [])
         ]
+        taints = [V1Taint(**t) for t in data.get("taints", [])]
         node = V1Node(
             metadata=V1ObjectMeta(name=name, labels=data.get("labels")),
+            spec=V1NodeSpec(taints=taints),
             status=V1NodeStatus(images=node_images),
         )
         nodes.append(node)

--- a/docs/admin/config/images.rst
+++ b/docs/admin/config/images.rst
@@ -11,11 +11,6 @@ The tags in that repository must follow the rules in :sqr:`059`.
 
 Currently, Nublado depends on the features of the sciplat-lab_ Docker image and probably will only work on images derived from that image.
 
-.. warning::
-
-   Currently, the Nublado controller attempts to prepull images to every node in the cluster.
-   This will not work correctly on nodes with taints, but the Nublado controller does not currently know how to skip those nodes.
-
 .. _config-images-source:
 
 Image source
@@ -91,7 +86,7 @@ All other available images are collected into a drop-down list with a caution th
 
 See :sqr:`059` for the definition of release, weekly, and daily images.
 
-What images to prepull and display as radio button selections are controlled by the following settings:
+What images to prepull and display as radio button selections are controlled by the following settings.
 
 ``controller.config.images.recommendedTag``
     The Docker image tag that marks the recommended image.
@@ -126,6 +121,9 @@ What images to prepull and display as radio button selections are controlled by 
     This setting doesn't affect prepulling.
     It provides additional information to the Nublado controller about which tags are moving aliases for other tags (such as additional situation-specific recommended tags).
     That information enables better formatting of the human-readable description of those tags.
+
+The prepuller is also affected by the ``config.lab.nodeSelector`` and ``config.lab.tolerations`` settings documented in :ref:`the lab configuration <config-lab-kubernetes>`.
+Images are only prepulled to nodes that are selected and tolerated by those settings, if present.
 
 Image cycles
 ============

--- a/docs/admin/config/lab.rst
+++ b/docs/admin/config/lab.rst
@@ -274,6 +274,8 @@ See the `Kubernetes documentation <https://kubernetes.io/docs/concepts/configura
     The ``cpu`` and ``memory`` for a given lab size define the Kubernetes limits.
     The Kubernetes requests are automatically set to 25% of the limits.
 
+.. _config-lab-kubernetes:
+
 Kubernetes
 ==========
 
@@ -307,9 +309,11 @@ They can be used to add additional Kubernetes configuration to all lab pods if, 
 
 ``controller.config.lab.nodeSelector``
     Node selector rules for user lab pods.
+    This also restricts which nodes images are prepulled to.
 
 ``controller.config.lab.tolerations``
     Toleration rules for user lab pods.
+    These tolerations are also applied to when choosing which nodes to prepull images to.
 
 Timeouts
 ========


### PR DESCRIPTION
If config.lab.tolerations are set, use them to select which nodes to which to prepull images. Report the nodes that are excluded by tolerations (but not the ones excluded by nodeSelector) in the prepull status as not eligible.

This required some restructuring of the data stored by the image service to retain more information about Kubernetes nodes.