### PR TITLE
DM-41907: Automatically add .json extension to test files

### DIFF
--- a/controller/tests/conftest.py
+++ b/controller/tests/conftest.py
@@ -52,10 +52,10 @@ async def app(
     Wraps the application in a lifespan manager so that startup and shutdown
     events are sent during test execution.
     """
-    nodes = read_input_node_json("base", "nodes.json")
+    nodes = read_input_node_json("base", "nodes")
     mock_kubernetes.set_nodes_for_test(nodes)
     namespace = read_input_data("base", "metadata/namespace").strip()
-    for secret in read_input_secrets_json("base", "secrets.json"):
+    for secret in read_input_secrets_json("base", "secrets"):
         await mock_kubernetes.create_namespaced_secret(namespace, secret)
     app = create_app()
     async with LifespanManager(app):
@@ -77,7 +77,7 @@ async def factory(
     mock_slack: MockSlackWebhook,
 ) -> AsyncIterator[Factory]:
     """Create a component factory for tests."""
-    nodes = read_input_node_json("base", "nodes.json")
+    nodes = read_input_node_json("base", "nodes")
     mock_kubernetes.set_nodes_for_test(nodes)
     async with Factory.standalone(config) as factory:
         yield factory
@@ -89,7 +89,7 @@ def mock_docker(
     config: Config, respx_mock: respx.Router
 ) -> MockDockerRegistry:
     assert isinstance(config.images.source, DockerSourceConfig)
-    tags = read_input_json("base", "docker-tags.json")
+    tags = read_input_json("base", "docker-tags")
     return register_mock_docker(
         respx_mock,
         host=config.images.source.registry,
@@ -104,7 +104,7 @@ def mock_docker(
 def mock_gafaelfawr(
     config: Config, respx_mock: respx.Router
 ) -> MockGafaelfawr:
-    users = read_input_users_json("base", "users.json")
+    users = read_input_users_json("base", "users")
     return register_mock_gafaelfawr(respx_mock, config.base_url, users)
 
 

--- a/controller/tests/handlers/files_test.py
+++ b/controller/tests/handlers/files_test.py
@@ -91,7 +91,7 @@ async def test_file_server_objects(
     # meaningful to compare.
     objects = mock_kubernetes.get_namespace_objects_for_test(namespace)
     seen = objects_to_dicts(objects)
-    assert seen == read_output_json("fileserver", "fileserver-objects.json")
+    assert seen == read_output_json("fileserver", "fileserver-objects")
 
 
 @pytest.mark.asyncio

--- a/controller/tests/handlers/labs_test.py
+++ b/controller/tests/handlers/labs_test.py
@@ -71,7 +71,7 @@ async def test_lab_start_stop(
 ) -> None:
     assert user.quota
     assert user.quota.notebook
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     unknown_user_error = {
         "detail": [
             {
@@ -216,7 +216,7 @@ async def test_spawn_after_failure(
     user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
 
     # Create a lab.
     r = await client.post(
@@ -262,7 +262,7 @@ async def test_spawn_after_failure(
     assert pod.status.phase == PodPhase.RUNNING.value
 
     # Get the events and look for the lab recreation events.
-    expected_events = read_output_json("standard", "lab-recreate-events.json")
+    expected_events = read_output_json("standard", "lab-recreate-events")
     assert await get_lab_events(client, user.username) == expected_events
 
 
@@ -273,7 +273,7 @@ async def test_multiple_delete(
     user: GafaelfawrUser,
     mock_slack: MockSlackWebhook,
 ) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
 
     # Create a lab.
     r = await client.post(
@@ -315,7 +315,7 @@ async def test_delayed_spawn(
     user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     mock_kubernetes.initial_pod_phase = PodPhase.PENDING.value
 
     r = await client.post(
@@ -384,7 +384,7 @@ async def test_delayed_spawn(
     # The listeners should now complete successfully and we should see
     # appropriate events.
     event_lists = await asyncio.gather(*listeners)
-    expected_events = read_output_json("standard", "lab-spawn-events.json")
+    expected_events = read_output_json("standard", "lab-spawn-events")
     expected_events = (
         expected_events[:-1]
         + [
@@ -430,7 +430,7 @@ async def test_abort_spawn(
     user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     mock_kubernetes.initial_pod_phase = PodPhase.PENDING.value
 
     r = await client.post(
@@ -461,7 +461,7 @@ async def test_spawn_after_terminate(
     user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     mock_kubernetes.initial_pod_phase = PodPhase.SUCCEEDED.value
 
     r = await client.post(
@@ -495,7 +495,7 @@ async def test_lab_objects(
     user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
@@ -510,12 +510,12 @@ async def test_lab_objects(
     namespace = f"{config.lab.namespace_prefix}-{user.username}"
     objects = mock_kubernetes.get_namespace_objects_for_test(namespace)
     seen = objects_to_dicts(objects)
-    assert seen == read_output_json("standard", "lab-objects.json")
+    assert seen == read_output_json("standard", "lab-objects")
 
 
 @pytest.mark.asyncio
 async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
 
     # Wrong user.
     r = await client.post(
@@ -658,7 +658,7 @@ async def test_spawn_errors(
     mock_kubernetes: MockKubernetesApi,
     mock_slack: MockSlackWebhook,
 ) -> None:
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     apis_to_fail = set()
 
     def callback(method: str, *args: Any) -> None:
@@ -815,7 +815,7 @@ async def test_homedir_schema(
     was set.
     """
     config = await configure("homedir-schema")
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",
@@ -848,7 +848,7 @@ async def test_extra_annotations(
 ) -> None:
     """Check that the pod picks up extra annotations set in the config."""
     config = await configure("extra-annotations")
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
 
     r = await client.post(
         f"/nublado/spawner/v1/labs/{user.username}/create",

--- a/controller/tests/handlers/prepuller_test.py
+++ b/controller/tests/handlers/prepuller_test.py
@@ -19,21 +19,21 @@ from ..support.data import (
 async def test_images(client: AsyncClient) -> None:
     r = await client.get("/nublado/spawner/v1/images")
     assert r.status_code == 200
-    assert r.json() == read_output_json("standard", "images.json")
+    assert r.json() == read_output_json("standard", "images")
 
 
 @pytest.mark.asyncio
 async def test_prepulls(client: AsyncClient) -> None:
     r = await client.get("/nublado/spawner/v1/prepulls")
     assert r.status_code == 200
-    assert r.json() == read_output_json("standard", "prepulls.json")
+    assert r.json() == read_output_json("standard", "prepulls")
 
 
 @pytest.mark.asyncio
 async def test_node_selector(
     client: AsyncClient, mock_kubernetes: MockKubernetesApi
 ) -> None:
-    nodes = read_input_node_json("prepuller", "nodes.json")
+    nodes = read_input_node_json("prepuller", "nodes")
     mock_kubernetes.set_nodes_for_test(nodes)
     async with asyncio.timeout(1):
         await configure("prepuller", mock_kubernetes)
@@ -42,4 +42,4 @@ async def test_node_selector(
     # the nodes that match the node selector of our configuration.
     r = await client.get("/nublado/spawner/v1/prepulls")
     assert r.status_code == 200
-    assert r.json() == read_output_json("prepuller", "status.json")
+    assert r.json() == read_output_json("prepuller", "status")

--- a/controller/tests/handlers/user_status_test.py
+++ b/controller/tests/handlers/user_status_test.py
@@ -25,7 +25,7 @@ async def test_user_status(
 ) -> None:
     assert user.quota
     assert user.quota.notebook
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
 
     # At the start, we shouldn't have any lab.
     r = await client.get(

--- a/controller/tests/models/domain/gafaelfawruserinfo_test.py
+++ b/controller/tests/models/domain/gafaelfawruserinfo_test.py
@@ -6,5 +6,5 @@ from ...support.data import read_input_users_json
 
 
 def test_no_name() -> None:
-    users = read_input_users_json("no-name", "users.json")
+    users = read_input_users_json("no-name", "users")
     assert users["token-of-anonymity"].name is None

--- a/controller/tests/services/lab_test.py
+++ b/controller/tests/services/lab_test.py
@@ -65,7 +65,7 @@ async def create_lab(
     """
     assert user.quota
     assert user.quota.notebook
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     size = config.lab.get_size_definition(lab.options.size)
     resources = size.to_lab_resources()
     await factory.image_service.refresh()
@@ -186,14 +186,14 @@ async def test_reconcile_succeeded(
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     namespace = read_input_data("base", "metadata/namespace").strip()
-    for secret in read_input_secrets_json("base", "secrets.json"):
+    for secret in read_input_secrets_json("base", "secrets"):
         await mock_kubernetes.create_namespaced_secret(namespace, secret)
     mock_kubernetes.initial_pod_phase = PodPhase.SUCCEEDED.value
     await factory.start_background_services()
 
     # Create a lab through the controller. It should show up in a terminated
     # state.
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     await factory.lab_manager.create_lab(user, lab)
     await asyncio.sleep(0.1)
     state = await factory.lab_manager.get_lab_state(user.username)
@@ -219,11 +219,11 @@ async def test_spawn_timeout(
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     namespace = read_input_data("base", "metadata/namespace").strip()
-    for secret in read_input_secrets_json("base", "secrets.json"):
+    for secret in read_input_secrets_json("base", "secrets"):
         await mock_kubernetes.create_namespaced_secret(namespace, secret)
     mock_kubernetes.initial_pod_phase = PodPhase.PENDING.value
     config.lab.spawn_timeout = timedelta(seconds=1)
-    lab = read_input_lab_specification_json("base", "lab-specification.json")
+    lab = read_input_lab_specification_json("base", "lab-specification")
     await factory.start_background_services()
 
     # Start the lab creation.

--- a/controller/tests/services/prepuller_test.py
+++ b/controller/tests/services/prepuller_test.py
@@ -85,7 +85,7 @@ async def test_docker(
     # The default data configures Kubernetes with missing images on some
     # nodes. Check that we created the correct prepuller pods.
     pod_list = await mock_kubernetes.list_namespaced_pod("nublado")
-    expected = read_output_json("standard", "prepull-objects.json")
+    expected = read_output_json("standard", "prepull-objects")
     assert [strip_none(o.to_dict()) for o in pod_list.items] == expected
 
     # Update all of the pods to have a status of completed and send an event.
@@ -112,7 +112,7 @@ async def test_gar(
     """Test the prepuller service configured to talk to GAR."""
     config = await configure("gar")
     assert isinstance(config.images.source, GARSourceConfig)
-    known_images = read_input_json("gar", "known-images.json")
+    known_images = read_input_json("gar", "known-images")
     for known_image in known_images:
         image = DockerImage(**known_image)
         parent, _, _ = image.name.split("@", 1)[0].rsplit("/", 2)
@@ -135,7 +135,7 @@ async def test_gar(
         await asyncio.sleep(0.2)
 
         images = factory.image_service.images()
-        expected = read_output_json("gar", "images-before.json")
+        expected = read_output_json("gar", "images-before")
         assert images.model_dump(exclude_none=True) == expected
 
         menu_images = factory.image_service.menu_images()
@@ -143,7 +143,7 @@ async def test_gar(
             "menu": [asdict(e) for e in menu_images.menu],
             "dropdown": [asdict(e) for e in menu_images.dropdown],
         }
-        expected = read_output_json("gar", "menu-before.json")
+        expected = read_output_json("gar", "menu-before")
         assert seen == expected
 
         # There should be two running pods, one for each node.
@@ -173,7 +173,7 @@ async def test_gar(
         assert pod_list.items == []
 
         images = factory.image_service.images()
-        expected = read_output_json("gar", "images-after.json")
+        expected = read_output_json("gar", "images-after")
         assert images.model_dump(exclude_none=True) == expected
 
         menu_images = factory.image_service.menu_images()
@@ -181,7 +181,7 @@ async def test_gar(
             "menu": [asdict(e) for e in menu_images.menu],
             "dropdown": [asdict(e) for e in menu_images.dropdown],
         }
-        expected = read_output_json("gar", "menu-after.json")
+        expected = read_output_json("gar", "menu-after")
         assert seen == expected
 
 
@@ -192,8 +192,8 @@ async def test_cycle(
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     config = await configure("cycle")
-    mock_docker.tags = read_input_json("cycle", "docker-tags.json")
-    node_data = read_input_json("cycle", "nodes.json")
+    mock_docker.tags = read_input_json("cycle", "docker-tags")
+    node_data = read_input_json("cycle", "nodes")
     nodes = []
     for name, data in node_data.items():
         node_images = [
@@ -212,7 +212,7 @@ async def test_cycle(
         await asyncio.sleep(0.2)
 
         images = factory.image_service.images()
-        expected = read_output_json("cycle", "images.json")
+        expected = read_output_json("cycle", "images")
         assert images.model_dump(exclude_none=True) == expected
 
         menu_images = factory.image_service.menu_images()
@@ -220,7 +220,7 @@ async def test_cycle(
             "menu": [asdict(e) for e in menu_images.menu],
             "dropdown": [asdict(e) for e in menu_images.dropdown],
         }
-        expected = read_output_json("cycle", "menu.json")
+        expected = read_output_json("cycle", "menu")
         assert seen == expected
 
 
@@ -231,12 +231,12 @@ async def test_gar_cycle(
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     config = await configure("gar-cycle")
-    known_images = read_input_json("gar-cycle", "known-images.json")
+    known_images = read_input_json("gar-cycle", "known-images")
     for known_image in known_images:
         image = DockerImage(**known_image)
         parent, _, _ = image.name.split("@", 1)[0].rsplit("/", 2)
         mock_gar.add_image_for_test(parent, image)
-    nodes = read_input_node_json("gar-cycle", "nodes.json")
+    nodes = read_input_node_json("gar-cycle", "nodes")
     mock_kubernetes.set_nodes_for_test(nodes)
 
     async with Factory.standalone(config) as factory:
@@ -244,7 +244,7 @@ async def test_gar_cycle(
         await asyncio.sleep(0.2)
 
         images = factory.image_service.images()
-        expected = read_output_json("gar-cycle", "images.json")
+        expected = read_output_json("gar-cycle", "images")
         assert images.model_dump(exclude_none=True) == expected
 
         menu_images = factory.image_service.menu_images()
@@ -252,7 +252,7 @@ async def test_gar_cycle(
             "menu": [asdict(e) for e in menu_images.menu],
             "dropdown": [asdict(e) for e in menu_images.dropdown],
         }
-        expected = read_output_json("gar-cycle", "menu.json")
+        expected = read_output_json("gar-cycle", "menu")
         assert seen == expected
 
 
@@ -328,7 +328,7 @@ async def test_conflict(
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
     """Test handling of conflicts with a pre-existing prepuller pod."""
-    expected = read_output_json("standard", "prepull-conflict-objects.json")
+    expected = read_output_json("standard", "prepull-conflict-objects")
 
     # Create a pod with the same name as the prepull pod that the prepuller
     # will want to create. Don't bother to try to make this a valid pod, just

--- a/controller/tests/support/data.py
+++ b/controller/tests/support/data.py
@@ -60,7 +60,7 @@ def read_input_json(config: str, filename: str) -> Any:
     ----------
     config
         Configuration from which to read data (the name of one of the
-        directories under :file:`tests/data`).
+        directories under :file:`tests/data`). Omit the ``.json`` extension.
     filename
         File to read and parse. Must be in JSON format.
 
@@ -70,7 +70,7 @@ def read_input_json(config: str, filename: str) -> Any:
         Parsed contents of file.
     """
     base_path = Path(__file__).parent.parent / "data" / config
-    with (base_path / "input" / filename).open("r") as f:
+    with (base_path / "input" / (filename + ".json")).open("r") as f:
         return json.load(f)
 
 
@@ -83,7 +83,7 @@ def read_input_lab_specification_json(
     ----------
     config
         Configuration from which to read data (the name of one of the
-        directories under :file:`tests/data`).
+        directories under :file:`tests/data`). Omit the ``.json`` extension.
     filename
         File to read and parse. Must be in JSON format.
 
@@ -106,7 +106,7 @@ def read_input_node_json(config: str, filename: str) -> list[V1Node]:
     ----------
     config
         Configuration from which to read data (the name of one of the
-        directories under :file:`tests/data`).
+        directories under :file:`tests/data`). Omit the ``.json`` extension.
     filename
         File to read and parse. Must be in JSON format.
 
@@ -141,7 +141,7 @@ def read_input_secrets_json(config: str, filename: str) -> list[V1Secret]:
     ----------
     config
         Configuration from which to read data (the name of one of the
-        directories under :file:`tests/data`).
+        directories under :file:`tests/data`). Omit the ``.json`` extension.
     filename
         File to read and parse. Must be in JSON format.
 
@@ -169,7 +169,7 @@ def read_input_users_json(
     ----------
     config
         Configuration from which to read data (the name of one of the
-        directories under :file:`tests/data`).
+        directories under :file:`tests/data`). Omit the ``.json`` extension.
     filename
         File to read and parse. Must be in JSON format.
 
@@ -209,7 +209,7 @@ def read_output_json(config: str, filename: str) -> Any:
     ----------
     config
         Configuration from which to read data (the name of one of the
-        directories under :file:`tests/data`).
+        directories under :file:`tests/data`). Omit the ``.json`` extension.
     filename
         File to read and parse. Must be in JSON format.
 
@@ -219,7 +219,7 @@ def read_output_json(config: str, filename: str) -> Any:
         Parsed contents of file.
     """
     base_path = Path(__file__).parent.parent / "data" / config
-    with (base_path / "output" / filename).open("r") as f:
+    with (base_path / "output" / (filename + ".json")).open("r") as f:
         return json.load(f)
 
 
@@ -234,12 +234,12 @@ def write_output_json(config: str, filename: str, data: Any) -> None:
     ----------
     config
         Configuration to which to write data (the name of one of the
-        directories under :file:`tests/data`).
+        directories under :file:`tests/data`). Omit the ``.json`` extension.
     filename
         File to write.
     data
         Data to write.
     """
     base_path = Path(__file__).parent.parent / "data" / config
-    with (base_path / "output" / filename).open("w") as f:
+    with (base_path / "output" / (filename + ".json")).open("w") as f:
         json.dump(data, f, indent=2)


### PR DESCRIPTION
In the controller test suite helper functions, automatically add .json to the file name passed to any read_*_json or write_*_json functions to save some typing and enforce consistency.