### PR TITLE
DM-41907: Convert all Kubernetes comparison to new function

### DIFF
--- a/controller/tests/data/standard/output/prepull-objects.json
+++ b/controller/tests/data/standard/output/prepull-objects.json
@@ -1,6 +1,6 @@
 [
   {
-    "api_version": "v1",
+    "apiVersion": "v1",
     "kind": "Pod",
     "metadata": {
       "labels": {
@@ -8,16 +8,15 @@
       },
       "name": "prepull-d-2077-10-23-node2",
       "namespace": "nublado",
-      "owner_references": [
+      "ownerReferences": [
         {
-          "api_version": "v1",
-          "block_owner_deletion": true,
+          "apiVersion": "v1",
+          "blockOwnerDeletion": true,
           "kind": "Pod",
           "name": "nublado-controller",
           "uid": "12720beb-ecae-452e-982e-2f0a0a2fbaf1"
         }
-      ],
-      "resource_version": "1"
+      ]
     },
     "spec": {
       "containers": [
@@ -27,14 +26,14 @@
           ],
           "image": "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234",
           "name": "prepull",
-          "working_dir": "/tmp"
+          "workingDir": "/tmp"
         }
       ],
-      "image_pull_secrets": [
+      "imagePullSecrets": [
 	{ "name": "pull-secret" }
       ],
-      "node_name": "node2",
-      "restart_policy": "Never"
+      "nodeName": "node2",
+      "restartPolicy": "Never"
     },
     "status": {
       "phase": "Running"

--- a/controller/tests/services/prepuller_test.py
+++ b/controller/tests/services/prepuller_test.py
@@ -17,7 +17,7 @@ from kubernetes_asyncio.client import (
     V1ObjectMeta,
     V1Pod,
 )
-from safir.testing.kubernetes import MockKubernetesApi, strip_none
+from safir.testing.kubernetes import MockKubernetesApi
 from safir.testing.slack import MockSlackWebhook
 
 from controller.config import Config
@@ -86,7 +86,7 @@ async def test_docker(
     # nodes. Check that we created the correct prepuller pods.
     pod_list = await mock_kubernetes.list_namespaced_pod("nublado")
     expected = read_output_json("standard", "prepull-objects")
-    assert [strip_none(o.to_dict()) for o in pod_list.items] == expected
+    assert objects_to_dicts(pod_list.items) == expected
 
     # Update all of the pods to have a status of completed and send an event.
     for pod in pod_list.items:


### PR DESCRIPTION
Get rid of the last direct use of strip_none in the controller test suite and do all Kubernetes object comparison with the objects_to_dicts helper function, which strips changing fields and ensures the serialization follows the camel-case conventions of Kubernetes.