### PR TITLE
DM-41907: Do not run background tasks immediately

### DIFF
--- a/controller/src/controller/background.py
+++ b/controller/src/controller/background.py
@@ -161,6 +161,7 @@ class BackgroundTaskManager:
         description
             Description of the background task for error reporting.
         """
+        await asyncio.sleep(interval.total_seconds())
         while True:
             start = current_datetime(microseconds=True)
             try:


### PR DESCRIPTION
When starting background tasks, we run the ones that should run during startup immediately. We therefore want to always delay by the interval before the first time we run the same task in the background or we unnecessarily run it twice quickly.