### PR TITLE
DM-42119: Add nox environment caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,13 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade nox
 
+      - name: Cache nox environments
+        id: cache-nox
+        uses: actions/cache@v3
+        with:
+          path: .nox
+          key: test-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'controller/requirements/main.txt', 'controller/requirements/dev.txt') }}
+
       - name: Run nox
         run: "nox -s typing test typing-inithome test-inithome"
 
@@ -84,6 +91,13 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade nox
 
+      - name: Cache nox environments
+        id: cache-nox
+        uses: actions/cache@v3
+        with:
+          path: .nox
+          key: test-hub-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'hub/requirements/main.txt', 'hub/requirements/dev.txt') }}
+
       - name: Run nox
         run: "nox -s typing-hub test-hub"
 
@@ -112,6 +126,13 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade nox
+
+      - name: Cache nox environments
+        id: cache-nox
+        uses: actions/cache@v3
+        with:
+          path: .nox
+          key: docs-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'authenticator/pyproject.toml', 'controller/requirements/main.txt', 'controller/requirements/dev.txt', 'spawner/pyproject.toml') }}
 
       - name: Run nox
         run: "nox -s docs"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,25 +45,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: lsst-sqre/run-nox@main
         with:
+          cache-dependency: "controller/requirements/*.txt"
+          cache-key-prefix: test
+          nox-sessions: "typing typing-inithome test test-inithome"
           python-version: ${{ matrix.python }}
-
-      - name: Install nox
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade nox
-
-      - name: Cache nox environments
-        id: cache-nox
-        uses: actions/cache@v3
-        with:
-          path: .nox
-          key: test-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'controller/requirements/main.txt', 'controller/requirements/dev.txt') }}
-
-      - name: Run nox
-        run: "nox -s typing test typing-inithome test-inithome"
 
   # The controller requires Python 3.11, but the modules we add to the Hub
   # have to run with Python 3.10 since that's what the JupyterHub image uses.
@@ -81,25 +68,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: lsst-sqre/run-nox@main
         with:
+          cache-dependency: "hub/requirements/*.txt"
+          cache-key-prefix: test-hub
+          nox-sessions: "typing-hub test-hub"
           python-version: ${{ matrix.python }}
-
-      - name: Install nox
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade nox
-
-      - name: Cache nox environments
-        id: cache-nox
-        uses: actions/cache@v3
-        with:
-          path: .nox
-          key: test-hub-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'hub/requirements/main.txt', 'hub/requirements/dev.txt') }}
-
-      - name: Run nox
-        run: "nox -s typing-hub test-hub"
 
   docs:
     runs-on: ubuntu-latest
@@ -117,25 +91,12 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: lsst-sqre/run-nox@main
         with:
+          cache-dependency: "controller/requirements/*.txt"
+          cache-key-prefix: docs
+          nox-sessions: docs
           python-version: "3.11"
-
-      - name: Install nox
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade nox
-
-      - name: Cache nox environments
-        id: cache-nox
-        uses: actions/cache@v3
-        with:
-          path: .nox
-          key: docs-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'authenticator/pyproject.toml', 'controller/requirements/main.txt', 'controller/requirements/dev.txt', 'spawner/pyproject.toml') }}
-
-      - name: Run nox
-        run: "nox -s docs"
 
       # Only attempt documentation uploads for long-lived branches, tagged
       # releases, and pull requests from ticket branches.  This avoids version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: lsst-sqre/run-nox@main
+      - uses: lsst-sqre/run-nox@v1
         with:
           cache-dependency: "controller/requirements/*.txt"
           cache-key-prefix: test
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: lsst-sqre/run-nox@main
+      - uses: lsst-sqre/run-nox@v1
         with:
           cache-dependency: "hub/requirements/*.txt"
           cache-key-prefix: test-hub
@@ -91,7 +91,7 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz
 
-      - uses: lsst-sqre/run-nox@main
+      - uses: lsst-sqre/run-nox@v1
         with:
           cache-dependency: "controller/requirements/*.txt"
           cache-key-prefix: docs

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz
 
-      - uses: lsst-sqre/run-nox@main
+      - uses: lsst-sqre/run-nox@v1
         with:
           cache-dependency: "controller/requirements/*.txt"
           cache-key-prefix: docs

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -43,22 +43,9 @@ jobs:
       - name: Install extra packages
         run: sudo apt install -y graphviz
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: lsst-sqre/run-nox@main
         with:
+          cache-dependency: "controller/requirements/*.txt"
+          cache-key-prefix: docs
+          nox-sessions: docs-linkcheck
           python-version: "3.11"
-
-      - name: Install nox
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade nox
-
-      - name: Cache nox environments
-        id: cache-nox
-        uses: actions/cache@v3
-        with:
-          path: .nox
-          key: docs-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'authenticator/pyproject.toml', 'controller/requirements/main.txt', 'controller/requirements/dev.txt', 'spawner/pyproject.toml') }}
-
-      - name: Run nox
-        run: "nox -s docs-linkcheck"

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -53,5 +53,12 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade nox
 
+      - name: Cache nox environments
+        id: cache-nox
+        uses: actions/cache@v3
+        with:
+          path: .nox
+          key: docs-${{ matrix.python }}-${{ hashFiles('noxfile.py', 'authenticator/pyproject.toml', 'controller/requirements/main.txt', 'controller/requirements/dev.txt', 'spawner/pyproject.toml') }}
+
       - name: Run nox
         run: "nox -s docs-linkcheck"

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -26,43 +26,44 @@ jobs:
       # not the matrixed Python version, since this accurately reflects
       # how dependencies should later be updated.
 
-      - uses: lsst-sqre/run-neophile@v1
+      - uses: lsst-sqre/run-nox@main
         with:
-          python-version: "3.11"
-          mode: update
-          types: pre-commit
+          nox-sessions: "upgrade-deps typing test"
+          python-version: ${{ matrix.python }}
+          use-cache: false
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
         with:
-          python-version: "3.11"
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
 
-      - name: Install nox
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade nox
+  # The controller requires Python 3.11, but the modules we add to the Hub
+  # have to run with Python 3.10 since that's what the JupyterHub image uses.
+  # Run a separate matrix to test those modules.
+  test-hub:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [test]
 
-      - name: Update dependencies
-        run: "nox -s update-deps"
+    strategy:
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
 
-      - name: Run tests with nox
-        run: "nox -s lint typing test"
+    steps:
+      - uses: actions/checkout@v4
 
-      # The Hub code has to be tested with Python 3.10 because that's what the
-      # JupyterHub image uses.
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: lsst-sqre/run-nox@main
         with:
-          python-version: "3.10"
-
-      - name: Install nox
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade nox
-
-      - name: Run hub tests with nox
-        run: "nox -s test-hub"
+          nox-sessions: "upgrade-deps typing-hub test-hub"
+          python-version: ${{ matrix.python }}
+          use-cache: false
 
       - name: Report status
         if: always()

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -26,7 +26,7 @@ jobs:
       # not the matrixed Python version, since this accurately reflects
       # how dependencies should later be updated.
 
-      - uses: lsst-sqre/run-nox@main
+      - uses: lsst-sqre/run-nox@v1
         with:
           nox-sessions: "upgrade-deps typing test"
           python-version: ${{ matrix.python }}
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: lsst-sqre/run-nox@main
+      - uses: lsst-sqre/run-nox@v1
         with:
           nox-sessions: "upgrade-deps typing-hub test-hub"
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Use the new `lsst-sqre/run-nox` composite GitHub Action to run nox, which arranges for caching of the nox virtual environments and hopefully will speed up GitHub Actions runs.