### PR TITLE
DM-42125: Add inithome to internals documentation

### DIFF
--- a/docs/dev/api/index.rst
+++ b/docs/dev/api/index.rst
@@ -10,4 +10,5 @@ The Python API is therefore only of interest to Nublado developers.
 
    authenticator
    spawner
+   inithome
    controller

--- a/docs/dev/api/inithome.rst
+++ b/docs/dev/api/inithome.rst
@@ -1,0 +1,11 @@
+#####################
+Internal inithome API
+#####################
+
+The module ``rubin.nublado.inithome`` provides the entry point used by the ``nublado-inithome`` container (see :doc:`/admin/home-directories`).
+
+.. automodapi:: rubin.nublado.inithome.main
+   :include-all-objects:
+
+.. automodapi:: rubin.nublado.inithome.provisioner
+   :include-all-objects:

--- a/inithome/src/rubin/nublado/inithome/provisioner.py
+++ b/inithome/src/rubin/nublado/inithome/provisioner.py
@@ -51,7 +51,7 @@ class Provisioner:
 
         Raises
         ------
-        ValueError
+        InvalidHomeError
             Raised if the path exists but is not a directory, or if it has the
             wrong ownership but is not empty.
         """


### PR DESCRIPTION
Add the small rubin.nublado.inithome module to the generated internal API documentation.