### PR TITLE
DM-42153: Set privileged for privileged init containers

### DIFF
--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -718,6 +718,7 @@ class LabBuilder:
         username = user.username
         as_root = V1SecurityContext(
             allow_privilege_escalation=True,
+            privileged=True,
             run_as_non_root=False,
             run_as_user=0,
         )

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -86,13 +86,20 @@ lab:
     - name: inithome
       image:
         repository: ghcr.io/lsst-sqre/nublado-inithome
-        tag: 0.0.1
+        tag: 4.0.0
       privileged: true
       volumeMounts:
         - containerPath: /home
           volumeName: home
         - containerPath: /scratch
           volumeName: scratch
+    - name: user-setup
+      image:
+        repository: example/setup
+        tag: 0.0.1
+      volumeMounts:
+        - containerPath: /home
+          volumeName: home
   nodeSelector:
     some-label: some-value
   nss:

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -430,7 +430,7 @@
               }
             }
           ],
-          "image": "ghcr.io/lsst-sqre/nublado-inithome:0.0.1",
+          "image": "ghcr.io/lsst-sqre/nublado-inithome:4.0.0",
           "imagePullPolicy": "IfNotPresent",
           "name": "inithome",
           "resources": {
@@ -445,6 +445,7 @@
           },
           "securityContext": {
             "allowPrivilegeEscalation": true,
+            "privileged": true,
             "runAsNonRoot": false,
             "runAsUser": 0
           },
@@ -457,6 +458,55 @@
             {
               "mountPath": "/scratch",
               "name": "scratch",
+              "readOnly": false
+            }
+          ]
+        },
+        {
+          "env": [
+            {
+              "name": "NUBLADO_HOME",
+              "value": "/home/rachel"
+            },
+            {
+              "name": "NUBLADO_UID",
+              "value": "1101"
+            },
+            {
+              "name": "NUBLADO_GID",
+              "value": "1101"
+            }
+          ],
+          "envFrom": [
+            {
+              "configMapRef": {
+                "name": "rachel-nb-env"
+              }
+            }
+          ],
+          "image": "example/setup:0.0.1",
+          "imagePullPolicy": "IfNotPresent",
+          "name": "user-setup",
+          "resources": {
+            "limits": {
+              "cpu": "1.0",
+              "memory": "3221225472"
+            },
+            "requests": {
+              "cpu": "0.25",
+              "memory": "805306368"
+            }
+          },
+          "securityContext": {
+            "allowPrivilegeEscalation": false,
+            "runAsGroup": 1101,
+            "runAsNonRoot": true,
+            "runAsUser": 1101
+          },
+          "volumeMounts": [
+            {
+              "mountPath": "/home",
+              "name": "home",
               "readOnly": false
             }
           ]


### PR DESCRIPTION
Privileged init containers were being run as root but weren't being marked as privileged. This may be required to do some types of setup and was documented to be the case, and was being set with Nublado v3. Add that flag.

Add a test of a non-privileged init container and providing multiple init containers.