### PR TITLE
DM-42153: Do not mount service token in lab containers

### DIFF
--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -536,6 +536,7 @@ class LabBuilder:
             metadata=metadata,
             spec=V1PodSpec(
                 affinity=affinity,
+                automount_service_account_token=False,
                 containers=containers,
                 image_pull_secrets=pull_secrets,
                 init_containers=init_containers,

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -247,6 +247,7 @@
           }
         }
       },
+      "automountServiceAccountToken": false,
       "containers": [
         {
           "args": [


### PR DESCRIPTION
Disable automatic mounting of the Kubernetes service token into lab containers (including init containers). We do not set up any permissions for the service token and we don't want labs to be able to make Kubernetes API calls. We've also seen problems where lab spawning fails due to a race condition with the service token since the token value had not yet been generated, and hopefully this avoids that problem without needing to add a watch waiting for service token creation.