### PR TITLE
DM-42212: Add more security restrictions for labs

### DIFF
--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 
 from kubernetes_asyncio.client import (
+    V1Capabilities,
     V1ConfigMap,
     V1ConfigMapEnvSource,
     V1ConfigMapVolumeSource,
@@ -720,11 +721,14 @@ class LabBuilder:
         as_root = V1SecurityContext(
             allow_privilege_escalation=True,
             privileged=True,
+            read_only_root_filesystem=True,
             run_as_non_root=False,
             run_as_user=0,
         )
         as_user = V1SecurityContext(
             allow_privilege_escalation=False,
+            capabilities=V1Capabilities(drop=["all"]),
+            read_only_root_filesystem=True,
             run_as_non_root=True,
             run_as_user=user.uid,
             run_as_group=user.gid,
@@ -819,6 +823,9 @@ class LabBuilder:
             ports=[V1ContainerPort(container_port=8888, name="jupyterlab")],
             resources=resources.to_kubernetes(),
             security_context=V1SecurityContext(
+                allow_privilege_escalation=False,
+                capabilities=V1Capabilities(drop=["all"]),
+                read_only_root_filesystem=True,
                 run_as_non_root=True,
                 run_as_user=user.uid,
                 run_as_group=user.gid,

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -318,6 +318,11 @@
             }
           },
           "securityContext": {
+            "allowPrivilegeEscalation": false,
+            "capabilities": {
+              "drop": ["all"]
+            },
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 1101,
             "runAsNonRoot": true,
             "runAsUser": 1101
@@ -447,6 +452,7 @@
           "securityContext": {
             "allowPrivilegeEscalation": true,
             "privileged": true,
+            "readOnlyRootFilesystem": true,
             "runAsNonRoot": false,
             "runAsUser": 0
           },
@@ -500,6 +506,10 @@
           },
           "securityContext": {
             "allowPrivilegeEscalation": false,
+            "capabilities": {
+              "drop": ["all"]
+            },
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 1101,
             "runAsNonRoot": true,
             "runAsUser": 1101


### PR DESCRIPTION
Disable new privileges for user lab containers and drop all capabilities for user lab containers and init containers running as the user. Mark the root file system as read-only for all containers, even privileged containers, since we don't want to support dynamic modification of the root container.