### PR TITLE
DM-42212: Drop all capabilities in file server pods

### DIFF
--- a/controller/src/controller/services/builder/fileserver.py
+++ b/controller/src/controller/services/builder/fileserver.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from kubernetes_asyncio.client import (
+    V1Capabilities,
     V1Container,
     V1ContainerPort,
     V1EnvVar,
@@ -246,6 +247,7 @@ class FileserverBuilder:
             resources=resources.to_kubernetes() if resources else None,
             security_context=V1SecurityContext(
                 allow_privilege_escalation=False,
+                capabilities=V1Capabilities(drop=["all"]),
                 read_only_root_filesystem=True,
             ),
             volume_mounts=mounts,

--- a/controller/tests/data/fileserver/output/fileserver-objects.json
+++ b/controller/tests/data/fileserver/output/fileserver-objects.json
@@ -111,6 +111,9 @@
               ],
               "securityContext": {
                 "allowPrivilegeEscalation": false,
+                "capabilities": {
+                  "drop": ["all"]
+                },
                 "readOnlyRootFilesystem": true
               },
               "volumeMounts": [
@@ -299,6 +302,9 @@
           ],
           "securityContext": {
             "allowPrivilegeEscalation": false,
+            "capabilities": {
+              "drop": ["all"]
+            },
             "readOnlyRootFilesystem": true
           },
           "volumeMounts": [


### PR DESCRIPTION
File servers shouldn't need any cpaabilities, so configure them to drop all capabilities in their security context.