### PR TITLE
DM-42337: Classify routes with appropriate tags

### DIFF
--- a/changelog.d/20240102_161608_rra_DM_42337_queue.md
+++ b/changelog.d/20240102_161608_rra_DM_42337_queue.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Classify the JSON API routes with tags that reflect who has access to that API.

--- a/controller/src/controller/handlers/files.py
+++ b/controller/src/controller/handlers/files.py
@@ -46,6 +46,7 @@ __all__ = ["router"]
     summary="Create file server for user",
     responses={403: {"description": "Forbidden", "model": ErrorModel}},
     response_class=HTMLResponse,
+    tags=["user"],
 )
 async def route_user(
     context: Annotated[RequestContext, Depends(context_dependency)],

--- a/controller/src/controller/handlers/fileserver.py
+++ b/controller/src/controller/handlers/fileserver.py
@@ -24,6 +24,7 @@ __all__ = ["router"]
     "/fileserver/v1/users",
     responses={403: {"description": "Forbidden", "model": ErrorModel}},
     summary="List all users with running fileservers",
+    tags=["admin"],
 )
 async def get_fileserver_users(
     context: Annotated[RequestContext, Depends(context_dependency)],
@@ -35,6 +36,7 @@ async def get_fileserver_users(
     "/fileserver/v1/{username}",
     responses={403: {"description": "Forbidden", "model": ErrorModel}},
     summary="Remove fileserver for user",
+    tags=["admin"],
 )
 async def remove_fileserver(
     username: str,

--- a/controller/src/controller/handlers/form.py
+++ b/controller/src/controller/handlers/form.py
@@ -27,6 +27,7 @@ __all__ = ["router"]
     summary="Get lab form for user",
     response_class=HTMLResponse,
     responses={403: {"description": "Forbidden", "model": ErrorModel}},
+    tags=["user"],
 )
 async def get_user_lab_form(
     username: str,

--- a/controller/src/controller/handlers/index.py
+++ b/controller/src/controller/handlers/index.py
@@ -24,6 +24,7 @@ __all__ = ["external_router", "internal_router"]
     response_model=Index,
     response_model_exclude_none=True,
     summary="Application metadata",
+    tags=["internal"],
 )
 async def get_index(
     config: Annotated[Config, Depends(config_dependency)],
@@ -45,6 +46,7 @@ async def get_index(
     response_model=Metadata,
     response_model_exclude_none=True,
     summary="Application metadata (internal)",
+    tags=["internal"],
 )
 async def get_internal_index(
     config: Annotated[Config, Depends(config_dependency)],

--- a/controller/src/controller/handlers/labs.py
+++ b/controller/src/controller/handlers/labs.py
@@ -30,6 +30,7 @@ __all__ = ["router"]
     "/spawner/v1/labs",
     responses={403: {"description": "Forbidden", "model": ErrorModel}},
     summary="List all users with running labs",
+    tags=["hub"],
 )
 async def get_lab_users(
     context: Annotated[RequestContext, Depends(context_dependency)],
@@ -45,6 +46,7 @@ async def get_lab_users(
         404: {"description": "Lab not found", "model": ErrorModel},
     },
     summary="Status of user's lab",
+    tags=["hub"],
 )
 async def get_lab_state(
     username: str,
@@ -65,6 +67,7 @@ async def get_lab_state(
     },
     status_code=201,
     summary="Create user lab",
+    tags=["user"],
 )
 async def post_new_lab(
     username: str,
@@ -103,6 +106,7 @@ async def post_new_lab(
         },
     },
     status_code=204,
+    tags=["hub"],
 )
 async def delete_user_lab(
     username: str,
@@ -138,6 +142,7 @@ async def delete_user_lab(
         403: {"description": "Forbidden", "model": ErrorModel},
         404: {"description": "Lab not found", "model": ErrorModel},
     },
+    tags=["user"],
 )
 async def get_lab_events(
     username: Annotated[str, Depends(username_path_dependency)],

--- a/controller/src/controller/handlers/prepuller.py
+++ b/controller/src/controller/handlers/prepuller.py
@@ -19,6 +19,7 @@ __all__ = ["router"]
     summary="Known images",
     response_model=SpawnerImages,
     response_model_exclude_none=True,
+    tags=["admin"],
 )
 async def get_images(
     context: Annotated[RequestContext, Depends(context_dependency)],
@@ -31,6 +32,7 @@ async def get_images(
     summary="Status of prepulling",
     response_model=PrepullerStatus,
     response_model_by_alias=False,
+    tags=["admin"],
 )
 async def get_prepulls(
     context: Annotated[RequestContext, Depends(context_dependency)],

--- a/controller/src/controller/handlers/user_status.py
+++ b/controller/src/controller/handlers/user_status.py
@@ -21,6 +21,7 @@ __all__ = ["router"]
     responses={404: {"description": "Lab not found", "model": ErrorModel}},
     summary="State of user's lab",
     response_model=UserLabState,
+    tags=["user"],
 )
 async def get_user_state(
     x_auth_request_user: Annotated[str, Header(include_in_schema=False)],

--- a/controller/src/controller/main.py
+++ b/controller/src/controller/main.py
@@ -87,6 +87,26 @@ def create_app(*, load_config: bool = True) -> FastAPI:
         title=config.name if load_config else "Nublado",
         description=metadata("controller")["Summary"],
         version=version("controller"),
+        tags_metadata=[
+            {
+                "name": "hub",
+                "description": "APIs that can only be used by JupyterHub.",
+            },
+            {
+                "name": "user",
+                "description": "APIs that can only be used by the user.",
+            },
+            {
+                "name": "admin",
+                "description": "APIs that can only be used by administrators.",
+            },
+            {
+                "name": "internal",
+                "description": (
+                    "Internal routes used by the ingress and health checks."
+                ),
+            },
+        ],
         openapi_url=f"{path_prefix}/openapi.json",
         docs_url=f"{path_prefix}/docs",
         redoc_url=f"{path_prefix}/redoc",


### PR DESCRIPTION
Divide the routes into admin, hub, user, and internal tags and classify them according to required permissions.