### PR TITLE
DM-42337: Rework the lab status models

### DIFF
--- a/changelog.d/20240102_161405_rra_DM_42337_queue.md
+++ b/changelog.d/20240102_161405_rra_DM_42337_queue.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- Stop returning the requested lab environment from the lab status API. Nothing uses this information and it may contain secrets that should not be this readily accessible.
+- Return the actual running Docker image reference from the lab status API rather than the form parameters the user sent when requesting a lab.

--- a/controller/src/controller/handlers/labs.py
+++ b/controller/src/controller/handlers/labs.py
@@ -18,7 +18,7 @@ from ..exceptions import (
     UnknownUserError,
 )
 from ..models.domain.gafaelfawr import GafaelfawrUser
-from ..models.v1.lab import LabSpecification, UserLabState
+from ..models.v1.lab import LabSpecification, LabState
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 """Router to mount into the application."""
@@ -40,7 +40,7 @@ async def get_lab_users(
 
 @router.get(
     "/spawner/v1/labs/{username}",
-    response_model=UserLabState,
+    response_model=LabState,
     responses={
         403: {"description": "Forbidden", "model": ErrorModel},
         404: {"description": "Lab not found", "model": ErrorModel},
@@ -51,7 +51,7 @@ async def get_lab_users(
 async def get_lab_state(
     username: str,
     context: Annotated[RequestContext, Depends(context_dependency)],
-) -> UserLabState:
+) -> LabState:
     state = await context.lab_manager.get_lab_state(username)
     if not state:
         msg = f"Unknown user {username}"

--- a/controller/src/controller/handlers/user_status.py
+++ b/controller/src/controller/handlers/user_status.py
@@ -8,7 +8,7 @@ from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..dependencies.context import RequestContext, context_dependency
 from ..exceptions import UnknownUserError
-from ..models.v1.lab import UserLabState
+from ..models.v1.lab import LabState
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 """Router to mount into the application."""
@@ -20,13 +20,13 @@ __all__ = ["router"]
     "/spawner/v1/user-status",
     responses={404: {"description": "Lab not found", "model": ErrorModel}},
     summary="State of user's lab",
-    response_model=UserLabState,
+    response_model=LabState,
     tags=["user"],
 )
 async def get_user_state(
     x_auth_request_user: Annotated[str, Header(include_in_schema=False)],
     context: Annotated[RequestContext, Depends(context_dependency)],
-) -> UserLabState:
+) -> LabState:
     context.rebind_logger(user=x_auth_request_user)
     state = await context.lab_manager.get_lab_state(x_auth_request_user)
     if not state:

--- a/controller/tests/data/standard/output/lab-status.json
+++ b/controller/tests/data/standard/output/lab-status.json
@@ -1,0 +1,48 @@
+{
+  "internal_url": "http://lab.userlabs-rachel:8888/nb/user/rachel/",
+  "options": {
+    "image": "lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234",
+    "size": "small",
+    "enable_debug": false,
+    "reset_user_env": false
+  },
+  "quota": {
+    "cpu": 9.0,
+    "memory": 28991029248
+  },
+  "resources": {
+    "limits": {
+      "cpu": 1.0,
+      "memory": 3221225472
+    },
+    "requests": {
+      "cpu": 0.25,
+      "memory": 805306368
+    }
+  },
+  "status": "running",
+  "user": {
+    "username": "rachel",
+    "name": "Rachel (?)",
+    "uid": 1101,
+    "gid": 1101,
+    "groups": [
+      {
+        "name": "rachel",
+        "id": 1101
+      },
+      {
+        "name": "lunatics",
+        "id": 2028
+      },
+      {
+        "name": "mechanics",
+        "id": 2001
+      },
+      {
+        "name": "storytellers",
+        "id": 2021
+      }
+    ]
+  }
+}

--- a/controller/tests/handlers/labs_test.py
+++ b/controller/tests/handlers/labs_test.py
@@ -136,31 +136,7 @@ async def test_lab_start_stop(
     assert r.json() == [user.username]
     r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
     assert r.status_code == 200
-    size = config.lab.get_size_definition(lab.options.size)
-    expected_resources = size.to_lab_resources()
-    expected_options = lab.options.model_dump()
-    expected_options["image_dropdown"] = expected_options["image_list"]
-    expected_options["image_list"] = None
-    expected = {
-        "env": lab.env,
-        "internal_url": (
-            f"http://lab.userlabs-{user.username}:8888/nb/user/rachel/"
-        ),
-        "options": expected_options,
-        "quota": {
-            "cpu": user.quota.notebook.cpu,
-            "memory": int(user.quota.notebook.memory * 1024 * 1024 * 1024),
-        },
-        "resources": expected_resources.model_dump(),
-        "status": "running",
-        "user": {
-            "username": user.username,
-            "name": user.name,
-            "uid": user.uid,
-            "gid": user.gid,
-            "groups": [g.model_dump() for g in user.groups if g.id],
-        },
-    }
+    expected = read_output_json("standard", "lab-status")
     assert r.json() == expected
 
     # Creating the lab again should result in a 409 error.

--- a/controller/tests/handlers/user_status_test.py
+++ b/controller/tests/handlers/user_status_test.py
@@ -12,7 +12,7 @@ from controller.models.domain.gafaelfawr import GafaelfawrUser
 from controller.models.domain.kubernetes import PodPhase
 
 from ..support.constants import TEST_BASE_URL
-from ..support.data import read_input_lab_specification_json
+from ..support.data import read_input_lab_specification_json, read_output_json
 
 
 @pytest.mark.asyncio
@@ -60,26 +60,7 @@ async def test_user_status(
         "/nublado/spawner/v1/user-status", headers=user.to_headers()
     )
     assert r.status_code == 200
-    size = config.lab.get_size_definition(lab.options.size)
-    expected_resources = size.to_lab_resources()
-    expected = {
-        "env": lab.env,
-        "internal_url": "http://lab.userlabs-rachel:8888/nb/user/rachel/",
-        "options": lab.options.model_dump(),
-        "quota": {
-            "cpu": user.quota.notebook.cpu,
-            "memory": int(user.quota.notebook.memory * 1024 * 1024 * 1024),
-        },
-        "resources": expected_resources.model_dump(),
-        "status": "running",
-        "user": {
-            "username": user.username,
-            "name": user.name,
-            "uid": user.uid,
-            "gid": user.gid,
-            "groups": [g.model_dump() for g in user.groups if g.id],
-        },
-    }
+    expected = read_output_json("standard", "lab-status")
     assert r.json() == expected
 
     # Change the pod phase. This should throw the lab into a terminated state.


### PR DESCRIPTION
The lab status routes were returning the full lab environment, which isn't desirable since the environment may contain secrets. They were also returning the complicated parameters we accept as input to specify the image, rather than clearly returning the image as chosen.

Fix this by splitting some of the models between input and output models and renaming them to avoid the word User for anything other than information about the actual user. The status now omits the environment and returns the full reference for the running image, rather than the complicated parameters passed in by the user.

This does mean we no longer have a good way of capturing the menu options that people are picking, but the right way to do that, should we ever care, is to add more logging.

Doing this removes the need to reconstruct the environment when reconciling images, so all of that code can be deleted.