### PR TITLE
DM-42337: Fix broken documentation references

### DIFF
--- a/controller/src/controller/models/v1/lab.py
+++ b/controller/src/controller/models/v1/lab.py
@@ -155,9 +155,9 @@ class LabOptions(CommonLabOptions):
 
     This model represents the configuration information about a running lab
     returned by a JSON API query. It shares many attributes in common with the
-    input model, `UserLabOptions`, but reduces the requested image to a Docker
-    image reference and doesn't support the complex validation required by
-    `UserLabOptions`.
+    input model, `LabRequestOptions`, but reduces the requested image to a
+    Docker image reference and doesn't support the complex validation required
+    by `LabRequestOptions`.
     """
 
     image: str = Field(

--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -204,7 +204,7 @@ class LabBuilder:
 
         Returns
         -------
-        UserLabState or None
+        LabState or None
             Recreated lab state, or `None` if the user's lab environment did
             not exist or could not be parsed.
 


### PR DESCRIPTION
The model renaming to separate input and output models broke some documentation cross-references.