### PR TITLE
DM-42337: Add back link to REST API documentation

### DIFF
--- a/controller/src/controller/main.py
+++ b/controller/src/controller/main.py
@@ -150,9 +150,10 @@ def create_openapi() -> str:
         OpenAPI schema as serialized JSON.
     """
     app = create_app(load_config=False)
+    description = app.description + "\n\n[Return to Nublado documentation](.)"
     schema = get_openapi(
         title=app.title,
-        description=app.description,
+        description=description,
         version=app.version,
         routes=app.routes,
     )


### PR DESCRIPTION
redoc doesn't add a back link and neither does its Sphinx extension, so manually add one to the application description so that people browsing the documentation aren't stranded on the JSON API page.