### PR TITLE
DM-42337: Document response type for event stream

### DIFF
--- a/controller/src/controller/handlers/labs.py
+++ b/controller/src/controller/handlers/labs.py
@@ -139,6 +139,10 @@ async def delete_user_lab(
         " succeeds or fails."
     ),
     responses={
+        200: {
+            "content": {"text/event-stream": {}},
+            "description": "Event stream for lab spawn",
+        },
         403: {"description": "Forbidden", "model": ErrorModel},
         404: {"description": "Lab not found", "model": ErrorModel},
     },


### PR DESCRIPTION
Override the FastAPI default of application/json and document in the OpenAPI schema that the events route returns text/event-stream.