### PR TITLE
DM-42337: Add example for /spawner/v1/labs

### DIFF
--- a/controller/src/controller/handlers/labs.py
+++ b/controller/src/controller/handlers/labs.py
@@ -28,7 +28,12 @@ __all__ = ["router"]
 
 @router.get(
     "/spawner/v1/labs",
-    responses={403: {"description": "Forbidden", "model": ErrorModel}},
+    responses={
+        200: {
+            "content": {"application/json": {"example": ["user", "otheruser"]}}
+        },
+        403: {"description": "Forbidden", "model": ErrorModel},
+    },
     summary="List all users with running labs",
     tags=["hub"],
 )


### PR DESCRIPTION
Add a proper example in the OpenAPI schema for /spawner/v1/labs to make it clear that it returns a list of usernames.