### PR TITLE
DM-42337: Add Google Artifact Registry documentation

### DIFF
--- a/changelog.d/20240108_143023_rra_DM_42337.md
+++ b/changelog.d/20240108_143023_rra_DM_42337.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Add documentation on how to set up Google Artifact Registry as an image source for Nublado, and on why this is the recommended configuration when Nublado is running on Google Kubernetes Engine.

--- a/docs/admin/config/images.rst
+++ b/docs/admin/config/images.rst
@@ -23,6 +23,8 @@ Each source takes different parameters.
 ``controller.config.images.source.type``
     Set to either ``docker`` or ``google`` to choose the type of source.
 
+Using Google Artifact Repository as the image source is highly recommended if Nublado is running in a GKE cluster.
+
 Docker registries
 -----------------
 
@@ -47,6 +49,8 @@ Here is an example configuration fragment with a complete source specification:
            type: "docker"
            registry: "docker.io"
            repository: "lsstsqre/sciplat-lab"
+
+.. _config-images-gar:
 
 Google Artifact Registry
 ------------------------
@@ -76,6 +80,11 @@ Then, set the following additional configuration setting:
 
 ``controller.googleServiceAccount``
     The name of the Google service account with read access to this GAR instance.
+
+For step-by-step instructions on how to set up Google Artifact Registry for Nublado, see :doc:`/admin/setup-gar`.
+For additional information about why Google Artifact Registry is preferred, see :doc:`/admin/gar`.
+
+.. _config-prepull:
 
 Image prepulling and menu
 =========================

--- a/docs/admin/gar.rst
+++ b/docs/admin/gar.rst
@@ -1,0 +1,39 @@
+##############################
+Google Artifact Registry (GAR)
+##############################
+
+When Nublado is deployed on Google Kubernetes Engine, using Google Artifact Registry (GAR) as the image registry for lab images is strongly recommended.
+GAR has three significant advantages over the Docker Hub API:
+
+#. GAR supports container streaming to Google Kubernetes Engine clusters, which significantly speeds up spawning of uncached images.
+   See :ref:`gar-streaming` for more details.
+
+#. GAR allows Nublado to retrieve the underlying hashes for every available image tag in a single API call.
+   Docker Hub requires a ``HEAD`` request for every image to get the image hash
+   Nublado therefore avoids obtaining the image hash except for images that it knows it will need to prepull.
+   Therefore, when using the Docker Hub API, Nublado may be unable to discover when multiple tags correspond to the same image, and therefore will not be able to display as rich of a description of the image.
+
+#. Docker Hub APIs may require authentication, which in turn requires configuring a pull secret for every lab.
+   While Nublado supports this, it's additional configuration to track and manage and requires managing an external secret.
+   GAR can be configured so that the GKE cluster can pull images without further authentication, and the Nublado controller can use workload identity to authenticate to the GAR API, avoiding the need for an authentication secret.
+
+For step-by-step instructions on how to set up GAR for Nublado and configure Nublado to use GAR, see :doc:`setup-gar`.
+For details on the GAR-related configuration options in Nublado, see :ref:`config-images-gar`.
+
+.. _gar-streaming:
+
+Container image streaming
+=========================
+
+Nublado prepulls a select set of images to every eligible node to speed up image spawning.
+The configuration settings for that are documented at :ref:`config-prepull`.
+
+When the images are pulled from the Docker Hub API, the entire image needs to be downloaded to the node before a lab using that image can be spawned.
+The `sciplat-lab <https://github.com/lsst-sqre/sciplat-lab>`__ images typically used by the Rubin Science Platform are 4GB, so this can take about four minutes.
+
+Container image streaming allows the lab to be spawned before the image is fully downloaded and also improves the image download speed, which in the case of sciplat-lab images at the IDF reduced image pull time to 30 seconds.
+
+Enabling image streaming for GAR image repositories is therefore highly recommended.
+This is done by enabling the ``containerfilesystem.googleapis.com`` API and then enabling image streaming for the cluster.
+
+For more details, see the `Google documentation for container image streaming <https://cloud.google.com/blog/products/containers-kubernetes/introducing-container-image-streaming-in-gke>`__.

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -14,9 +14,11 @@ Guides to common problems and instructions on how to integrate properly with Pha
 
    home-directories
    init-containers
+   setup-gar
 
 .. toctree::
    :maxdepth: 2
    :caption: Reference
 
    config/index
+   gar

--- a/docs/admin/setup-gar.rst
+++ b/docs/admin/setup-gar.rst
@@ -1,0 +1,47 @@
+###############################
+Set up Google Artifact Registry
+###############################
+
+If Nublado is running on Google Kubernetes Engine, using Google Artifact Repository to hold its lab images is strongly recommended.
+For more information about the benefits, see :doc:`gar`.
+
+1. Create and populate a registry
+=================================
+
+#. Create a registry to hold the Nublado lab images that you will be using in some appropriate Google project.
+   This does not have to be the same Google project in which Nublado is running, and the same registry can be shared by multiple GKE clusters.
+   However, the registry must be in the same region as any GKE cluster that uses it.
+   If you have GKE clusters in multiple regions, you will need multiple populated image registries, one for each region.
+
+#. Push the images that you'll be using to that registry.
+   Ensure the tags of the images follow the :sqr:`059` rules.
+
+2. Configure each GKE cluster
+=============================
+
+For each GKE cluster that will use that registry, do the following:
+
+#. Ensure workload identity is enabled in the cluster configuration.
+   For details on how to do this, see the `Google workload identity documentation <https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable>`__.
+
+#. For each node pool in that cluster that is allowed to run Nublado lab pods, find the Google service account used by that node pool.
+   This is shown in the details screen for the node pool under :guilabel:`Security`.
+
+#. Create a Google service account that will be used by the Nublado controller to query the registry.
+   Bind that service account to the Kubernetes ``nublado-controller`` service account in the ``nublado`` namespace.
+   This is the service account used by the controller.
+   For information on how to do this, see the `Google workload identity documentation <https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to>`__
+
+#. Grant the the Artifact Registry Reader role (or equivalent permissions) for the relevant registry to the node service accounts and the Nublado controller service account.
+   You will need to do this in the project where the registry is located, not the project where the GKE cluster is located, if they are different.
+
+#. Enable the ``containerfilesystem.googleapis.com`` API for the project hosting the GKE cluster.
+   This enables container image streaming.
+
+#. Turn on container image streaming in the GKE cluster configuration.
+
+3. Configure Nublado to use GAR
+===============================
+
+Add the necessary configuration to the Phalanx ``nublado`` application to use GAR as the image source.
+See :ref:`config-images-gar` for the relevant configuration settings.


### PR DESCRIPTION
Add documentation on how to set up Google Artifact Registry as an image source for Nublado, and on why this is the recommended configuration when Nublado is running on Google Kubernetes Engine.