### PR TITLE
DM-42337: Add additional upgrade and maintenance docs

### DIFF
--- a/docs/admin/config/hub.rst
+++ b/docs/admin/config/hub.rst
@@ -26,6 +26,13 @@ Production deployments should instead provide an infrastructure database and con
     The default is to use the Phalanx-internal database service.
     Use the value ``postgresql://nublado@cloud-sql-proxy.nublado/nublado`` when using Cloud SQL (see :ref:`config-hub-cloudsql`).
 
+``jupyterhub.hub.db.upgrade``
+    Set this to true to enable automatic database upgrades when JupyterHub has been upgraded.
+    This is false by default out of caution, which will cause JupyterHub to fail to start if a database schema upgrade is needed.
+
+    If you wish to be conservative, you can enable it only when you're intentionally upgrading JupyterHub and then disable it again after the upgrade.
+    This helps avoid accidentally applying a major JupyterHub upgrade without being aware that you're doing so, since most major upgrades come with schema changes.
+
 .. _config-hub-cloudsql:
 
 Cloud SQL

--- a/docs/admin/delete-user-session.rst
+++ b/docs/admin/delete-user-session.rst
@@ -1,0 +1,40 @@
+################################
+Delete a JupyterHub user session
+################################
+
+For each user with a running lab, there are three separate records of the existence of that lab: an entry in the JupyterHub session database, routes for that user in the JupyterHub proxy server, and state for that user in the Nublado controller.
+The proxy server routes are maintained by JupyterHub and the Nublado controller state is periodically refreshed from Kubernetes.
+In both cases, the data is stored only in memory.
+The JupyterHub database entry, however, is persistent.
+
+JupyterHub should maintain that entry by periodically, and on startup, asking the Nublado controller whether the user's lab is still running.
+This appears to be working correctly now with the Nublado controller, but prior to its deployment we sometimes saw the JupyterHub entry get out of sync with the state of the lab in Kubernetes.
+When this happens, it's possible for JupyterHub to think the user already has a lab and refuse to let them create or delete it.
+
+Should this happen, the solution is to remove the record from the JupyterHub session database by doing the following:
+
+#. Delete the user's lab namespace (:samp:`nublado-{username}`) if it exists, ensuring the user truly does not have a running lab.
+
+#. Determine the URL for the JupyterHub database.
+   This is the value of the ``jupyterhub.hub.db.url`` key in either :file:`values-{environment}.yaml` or, if not set there, :file:`values.yaml` in the Phalanx ``nublado`` configuration for this environment.
+
+#. Connect to the JupyterHub session database.
+   This should be done via the ``hub`` pod, since it has the necessary credentials.
+
+   .. prompt:: bash
+
+      pod=$(kubectl get pods -n nublado | grep ^hub- | awk '{print $1}')
+      kubectl exec -ti -n nublado "$pod" -- psql <URL>
+
+   Replace ``<URL>`` with the URL determined in the previous step.
+
+#. At the PostgreSQL prompt, remove the entry for this user in the ``users`` table:
+
+   .. code-block:: sql
+
+      delete from users where name='<username>'
+
+   Replace ``<username>`` with the user's username.
+
+#. If this still doesn't fix the problem, you may also have to remove the user from the ``spawners`` table.
+   To do this, run ``select * from spawners``, find the entry with the appropriate username in it, and delete that row.

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -15,6 +15,9 @@ Guides to common problems and instructions on how to integrate properly with Pha
    home-directories
    init-containers
    setup-gar
+   stop-all-labs
+   delete-user-session
+   wipe-database
 
 .. toctree::
    :maxdepth: 2

--- a/docs/admin/stop-all-labs.rst
+++ b/docs/admin/stop-all-labs.rst
@@ -1,0 +1,31 @@
+##########################
+Stop all running user labs
+##########################
+
+There are some situations where you may wish to stop all running user labs and prevent any users from spawning labs.
+Examples include major Nublado upgrades, ensuring no labs are still running ancient lab images, or Kubernetes cluster maintenance.
+
+.. warning::
+
+   Currently there is no graceful way of doing this.
+   You will have to forcibly stop the running labs, which runs the risk of losing user data.
+   Jupyter labs do autosave periodically, but any changes since the last autosave interval may be lost.
+   This action should therefore be advertised in advance.
+
+When you are ready to stop all user labs, take the following actions:
+
+#. Delete the ``hub`` deployment under the ``nublado`` application in Argo CD.
+   This will ensure that no one can start a new lab.
+
+#. Delete all Kubernetes namespaces starting with ``nublado-``.
+   Be sure to include the ``-`` so that you do not delete the ``nublado`` namespace that contains JupyterHub and the Nublado controller.
+
+This will forcibly terminate all of the user labs.
+
+Once you are ready to allow users to start labs again, sync the ``nublado`` application in Argo CD.
+This will recreate the ``hub`` deployment and start JupyterHub again.
+
+This process will leave records behind of supposedly-running labs in the JupyterHub database.
+JupyterHub should test all of those labs on startup and discover that they are no longer running and clean up automatically.
+However, if you wish, you can manually delete them.
+See :doc:`delete-user-session` for how to delete individual entries, and :doc:`wipe-database` for how to wipe the full JupyterHub database (generally only appropriate before a major upgrade).

--- a/docs/admin/wipe-database.rst
+++ b/docs/admin/wipe-database.rst
@@ -1,0 +1,53 @@
+############################
+Wipe the JupyterHub database
+############################
+
+JupyterHub uses a PostgreSQL database to record session information, user metadata, and other state.
+Normally, JupyterHub correctly handles reconciliation and schema upgrades on its own.
+However, sometimes it may be worthwhile to give JupyterHub a fresh start, such as during a major upgrade or if there are signs of persistent database inconsistency.
+
+The process for doing this is a bit different than for :doc:`stop-all-labs` or :doc:`delete-user-session` because you need to use the JupyterHub pod to make the database changes.
+
+.. warning::
+
+   Currently there is no graceful way of doing this.
+   You will have to forcibly stop the running labs, which runs the risk of losing user data.
+   Jupyter labs do autosave periodically, but any changes since the last autosave interval may be lost.
+   This action should therefore be advertised in advance.
+
+When you are ready to reset the database, take the following actions:
+
+#. Delete the ``proxy`` ``GafaelfawrIngress`` resource under the ``nublado`` application in Argo CD.
+   This will ensure that no one can start a new lab or access any existing lab.
+   This is different than the process for stopping all labs since we will need the JupyterHub pod to still be running.
+
+#. Delete all Kubernetes namespaces starting with ``nublado-``.
+   Be sure to include the ``-`` so that you do not delete the ``nublado`` namespace that contains JupyterHub and the Nublado controller.
+   This will forcibly terminate all of the user labs.
+
+#. Determine the URL for the JupyterHub database.
+   This is the value of the ``jupyterhub.hub.db.url`` key in either :file:`values-{environment}.yaml` or, if not set there, :file:`values.yaml` in the Phalanx ``nublado`` configuration for this environment.
+
+#. Connect to the JupyterHub session database.
+   This should be done via the ``hub`` pod, since it has the necessary credentials.
+
+   .. prompt:: bash
+
+      pod=$(kubectl get pods -n nublado | grep ^hub- | awk '{print $1}')
+      kubectl exec -ti -n nublado "$pod" -- psql <URL>
+
+   Replace ``<URL>`` with the URL determined in the previous step.
+
+#. Double-check that you use a dedicated user only for the JupyterHub session database and that it doesn't own anything else in the database.
+   Once you're sure of that, at the PostgreSQL prompt, drop all of the tables owned by the connecting user.
+
+   .. code-block:: sql
+
+      drop owned by current_user
+
+#. Restart the ``hub`` deployment in the ``nublado`` application in Argo CD.
+   You should do this shortly after running the previous command, since the running JupyterHub will be very confused by an empty database.
+   JupyterHub should populate the database with its current schema on restart.
+
+Once you are ready to allow users to start labs again, sync the ``nublado`` application in Argo CD.
+This will recreate the ``proxy`` ingress and start allowing user access again.


### PR DESCRIPTION
Add admin procedures for deleting a user session, stopping all labs, and resetting the JupyterHub session database. Document the setting that tells JupyterHub to automatically update its database schema.