### PR TITLE
DM-42477: Update documentation for Helm chart fixes

### DIFF
--- a/changelog.d/20240112_090145_rra_DM_42477.md
+++ b/changelog.d/20240112_090145_rra_DM_42477.md
@@ -1,0 +1,7 @@
+### Bug fixes
+
+- All user file servers are now protected by a `NetworkPolicy` that prevents connections except via Gafaelfawr, ensuring that authentication is properly enforced.
+
+### Other changes
+
+- Change the default namespace and Argo CD application for user file servers to `nublado-fileservers`.

--- a/docs/dev/plan.rst
+++ b/docs/dev/plan.rst
@@ -7,13 +7,6 @@ This page documents known work required, planned, or proposed for Nublado as an 
 Before end of construction
 ==========================
 
-Security fixes
---------------
-
-- All file servers must be covered by a ``NetworkPolicy``.
-  Ideally, we would do egress blocking, but I'm not sure if that works with NFS volume mounts, so we'll need to test.
-  But at the least ingress should be restricted to the ingress-nginx pod similar to what we do with all other Gafaelfawr-protected services.
-
 Architectural changes
 ---------------------
 
@@ -96,8 +89,6 @@ Documentation
 
 Minor changes
 -------------
-
-- Change the file server namespace and Argo CD app to ``nublado-fileservers`` instead of ``fileservers`` for parallelism (and sorting) with ``nublado-users``.
 
 - Use standard Kubernetes labels for the file servers where possible instead of custom Nublado labels.
 


### PR DESCRIPTION
The Helm chart in Phalanx now uses nublado-fileservers as the default Argo CD application and namespace, and now installs a NetworkPolicy to prevent unauthenticated connections to the file servers. Update the documentation accordingly.