### PR TITLE
DM-42477: Always retry Kubernetes watches on 410 errors

### DIFF
--- a/changelog.d/20240112_090145_rra_DM_42477.md
+++ b/changelog.d/20240112_090145_rra_DM_42477.md
@@ -4,4 +4,4 @@
 
 ### Other changes
 
-- Change the default namespace and Argo CD application for user file servers to `nublado-fileservers`.
+- Change the default Argo CD application for user file servers to `nublado-fileservers`. Continue to use `fileservers` as the default namespace, since the `nublado-fileservers` namespace would conflict with the reserved namespace pattern for user labs.

--- a/changelog.d/20240112_101507_rra_DM_42477.md
+++ b/changelog.d/20240112_101507_rra_DM_42477.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Quietly retry the file server pod watch after 410 errors, since under some circumstances they appear to happen every five minutes. Remove the delay when restarting after a 410 error without a resource version, since this appears to be a normal Kubernetes API response and the delay could miss events.


### PR DESCRIPTION
Rather than special-casing the case where a resource version is specified, always retry Kubernetes watches on 410 errors, not just those with timeouts. Remove the delay before retrying the watch.

We were seeing this error every five minutes, admittedly in situations where the namespace was potentially being deleted, but it appears to be safe to immediately retry 410 errors.