### PR TITLE
Fix periodic CI testing for JupyterHub modules

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: lsst-sqre/run-nox@v1
         with:
-          nox-sessions: "update-deps typing-hub test-hub"
+          nox-sessions: "update-deps-hub typing-hub test-hub"
           python-version: ${{ matrix.python }}
           use-cache: false
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,13 +104,17 @@ def _pytest(
 
 
 def _update_deps(
-    session: nox.Session, *, generate_hashes: bool = True
+    session: nox.Session,
+    *,
+    generate_hashes: bool = True,
+    hub_only: bool = False,
 ) -> None:
     session.install(
         "--upgrade", "pip-tools", "pip", "setuptools", "wheel", "pre-commit"
     )
     session.run("pre-commit", "autoupdate")
-    for directory in ("controller", "hub", "inithome"):
+    directories = ("hub",) if hub_only else ("controller", "hub", "inithome")
+    for directory in directories:
         command = [
             "pip-compile",
             "--upgrade",
@@ -365,6 +369,12 @@ def docs_linkcheck(session: nox.Session) -> None:
 def update_deps(session: nox.Session) -> None:
     """Update pinned server dependencies and pre-commit hooks."""
     _update_deps(session)
+
+
+@nox.session(name="update-deps-hub")
+def update_deps_hub(session: nox.Session) -> None:
+    """Update pinned JupyterHub dependencies and pre-commit hooks."""
+    _update_deps(session, hub_only=True)
 
 
 @nox.session(name="update-deps-no-hashes")


### PR DESCRIPTION
We need to update dependencies for the JupyterHub modules to do periodic CI testing of those modules, but we can't regenerate the dependencies of other components since they may require newer versions of Python. Add a new update-deps-hub session that can be used for that purpose.