### PR TITLE
DM-42527: Remove spurious lab last modified update

### DIFF
--- a/controller/src/controller/services/lab.py
+++ b/controller/src/controller/services/lab.py
@@ -380,7 +380,6 @@ class LabManager:
         # do something safe in case one appears in the future.
         if lab.monitor.in_progress == _LabOperation.DELETE:
             await lab.monitor.wait()
-            lab.last_modified = current_datetime(microseconds=True)
         elif lab.monitor.in_progress in (_LabOperation.SPAWN, None):
             if lab.monitor.in_progress == _LabOperation.SPAWN:
                 await lab.monitor.cancel()


### PR DESCRIPTION
When waiting for lab deletion, all waiters updated the lab last modified date, which doesn't make sense. Only the one that does the actual state change should update the date.