### PR TITLE
DM-43444: Add more file server routes

### DIFF
--- a/changelog.d/20240326_171124_rra_DM_43444.md
+++ b/changelog.d/20240326_171124_rra_DM_43444.md
@@ -1,0 +1,8 @@
+### Backwards-incompatible changes
+
+- Move the admin route for deleting a user's file server from `/nublado/fileserver/v1/<username>` to `/nublado/fileserver/v1/users/<username>` to better align with other routes and REST semantics.
+
+### New features
+
+- Add an admin-authenticated `/nublado/fileserver/v1/users/<username>` GET route to get the status of a user's running file server (currently only 404 if not running or 200 with trivial content if running).
+- Add a `/nublado/fileserver/v1/user-status` route a user to get the status of their own file server, which similarly returns 404 or 200 with trivial content.

--- a/controller/src/controller/handlers/fileserver.py
+++ b/controller/src/controller/handlers/fileserver.py
@@ -7,12 +7,13 @@ That route uses a separate path prefix and is defined in a different router in
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Header
 from safir.models import ErrorModel
 from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..dependencies.context import RequestContext, context_dependency
 from ..exceptions import UnknownUserError
+from ..models.v1.fileserver import FileserverStatus
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 """Router to mount into the application."""
@@ -32,9 +33,34 @@ async def get_fileserver_users(
     return await context.fileserver_manager.list()
 
 
+@router.get(
+    "/fileserver/v1/users/{username}",
+    responses={
+        404: {"description": "File server not running", "model": ErrorModel}
+    },
+    summary="Status of file server",
+    description=(
+        "On successful return, running will always be true. If the file server"
+        " is not running, a 404 error will be returned, since the file server"
+        " resource does not exist."
+    ),
+    response_model=FileserverStatus,
+    tags=["admin"],
+)
+async def get_fileserver_status(
+    username: str,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> FileserverStatus:
+    status = context.fileserver_manager.get_status(username)
+    if not status.running:
+        raise UnknownUserError("No file server running")
+    return status
+
+
 @router.delete(
-    "/fileserver/v1/{username}",
+    "/fileserver/v1/users/{username}",
     responses={403: {"description": "Forbidden", "model": ErrorModel}},
+    status_code=204,
     summary="Remove fileserver for user",
     tags=["admin"],
 )
@@ -60,3 +86,28 @@ async def remove_fileserver(
                 }
             ],
         ) from e
+
+
+@router.get(
+    "/fileserver/v1/user-status",
+    responses={
+        404: {"description": "File server not running", "model": ErrorModel}
+    },
+    summary="State of user's file server",
+    description=(
+        "On successful return, running will always be true. If the file server"
+        " is not running, a 404 error will be returned. This is consistent"
+        " with the admin endpoint and allows clients to look at the HTTP"
+        " status code without parsing the body."
+    ),
+    response_model=FileserverStatus,
+    tags=["user"],
+)
+async def get_user_state(
+    x_auth_request_user: Annotated[str, Header(include_in_schema=False)],
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> FileserverStatus:
+    status = context.fileserver_manager.get_status(x_auth_request_user)
+    if not status.running:
+        raise UnknownUserError("No file server running")
+    return status

--- a/controller/src/controller/models/v1/fileserver.py
+++ b/controller/src/controller/models/v1/fileserver.py
@@ -1,0 +1,15 @@
+"""API-visible models for user file servers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+__all__ = ["FileserverStatus"]
+
+
+class FileserverStatus(BaseModel):
+    """Status of a user's file server."""
+
+    running: bool = Field(
+        ..., title="Whether fileserver is running", examples=[True]
+    )

--- a/controller/src/controller/services/fileserver.py
+++ b/controller/src/controller/services/fileserver.py
@@ -21,6 +21,7 @@ from ..exceptions import (
 )
 from ..models.domain.gafaelfawr import GafaelfawrUserInfo
 from ..models.domain.kubernetes import PodPhase
+from ..models.v1.fileserver import FileserverStatus
 from ..storage.kubernetes.fileserver import FileserverStorage
 from ..timeout import Timeout
 from .builder.fileserver import FileserverBuilder
@@ -174,6 +175,18 @@ class FileserverManager:
                 state.running = False
             finally:
                 state.last_modified = current_datetime(microseconds=True)
+
+    def get_status(self, username: str) -> FileserverStatus:
+        """Get the status of a user's file server.
+
+        Returns
+        -------
+        FileserverStatus
+            Status of the user's file server.
+        """
+        if username not in self._servers:
+            return FileserverStatus(running=False)
+        return FileserverStatus(running=self._servers[username].running)
 
     async def list(self) -> list[str]:
         """List users with running file servers."""

--- a/docs/dev/api/controller.rst
+++ b/docs/dev/api/controller.rst
@@ -63,6 +63,9 @@ This documentation therefore exists only to assist developers and code analysis 
 .. automodapi:: controller.models.index
    :include-all-objects:
 
+.. automodapi:: controller.models.v1.fileserver
+   :include-all-objects:
+
 .. automodapi:: controller.models.v1.lab
    :include-all-objects:
 


### PR DESCRIPTION
As requested by the Portal team, add a new route for a user or a service acting on behalf of a user to get the status of their file server (/nublado/fileserver/v1/user-status). Return 404 if not running and 200 if running so that clients can ignore the body if they choose. (Currently there is no more-elaborate status to return.)

To maintain parallelism, add an admin .../v1/users/<username> route that returns the same information. Move the DELETE route for admin deletion of a file server under /users to align with the GET route that lists all users and to follow the normal REST URL pattern.