### PR TITLE
DM-45794: Catch another node image variation

### DIFF
--- a/controller/src/controller/storage/kubernetes/node.py
+++ b/controller/src/controller/storage/kubernetes/node.py
@@ -54,6 +54,7 @@ class NodeStorage:
                 image_data[node.metadata.name] = [
                     KubernetesNodeImage.from_container_image(i)
                     for i in node.status.images
+                    if i.names
                 ]
             else:
                 image_data[node.metadata.name] = []


### PR DESCRIPTION
The node information from Kubernetes apparently can have a None value for node.status.images[].names instead of a list. Catch that case and discard that image record, since we can't do anything with it.