### PR TITLE
DM-45794: Improve noxfile.py and fix some bugs

### DIFF
--- a/changelog.d/20240815_104721_rra_DM_45794.md
+++ b/changelog.d/20240815_104721_rra_DM_45794.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- Fix bootstrapping of a development environment in an existing virtualenv. Previously, uv was not installed before nox attempted to use it.
+- Work around a bug in sphinxcontrib-redoc that prevented building the documentation twice without errors.


### PR DESCRIPTION
Reuse code in more places and remove duplicate logic. Reorder the init session and configure it to not use a virtualenv so that it will install uv before nox attempts to use it and not complain about the missing backend. Work around a bug in sphinxcontrib-redoc that prevented building the documentation twice. Avoid installing more than one editable module with the same uv command, since this seems to not work reliably. Remove a bunch of unnecessary installations of pip, setuptools, and wheel.