### PR TITLE
DM-45794: Switch to a shared Ruff configuration

### DIFF
--- a/controller/src/controller/handlers/fileserver.py
+++ b/controller/src/controller/handlers/fileserver.py
@@ -7,7 +7,7 @@ That route uses a separate path prefix and is defined in a different router in
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status, Header
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from safir.models import ErrorModel
 from safir.slack.webhook import SlackRouteErrorHandler
 

--- a/controller/src/controller/timeout.py
+++ b/controller/src/controller/timeout.py
@@ -138,6 +138,5 @@ class Timeout:
                 failed_at=now,
             )
         left = self._timeout - (now - self._start)
-        if left < timeout:
-            timeout = left
+        timeout = min(left, timeout)
         return type(self)(self._operation, timeout, self._user)

--- a/controller/tests/conftest.py
+++ b/controller/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 import respx
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 from safir.testing.kubernetes import MockKubernetesApi, patch_kubernetes
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 

--- a/controller/tests/handlers/labs_test.py
+++ b/controller/tests/handlers/labs_test.py
@@ -832,9 +832,7 @@ async def test_alternate_paths(
     user: GafaelfawrUser,
     mock_kubernetes: MockKubernetesApi,
 ) -> None:
-    """Check that the command, config path, and runtime mount path can be
-    changed.
-    """
+    """Check changes to command, config, and runtime mount paths."""
     config = await configure("changed-path")
     lab = read_input_lab_specification_json("base", "lab-specification")
 
@@ -849,18 +847,18 @@ async def test_alternate_paths(
         f"{user.username}-nb",
         f"{config.lab.namespace_prefix}-{user.username}",
     )
-    ctr = pod.spec.containers[0]
-    assert ctr.args == ["/usr/local/share/jupyterlab/runlab"]
-    sec_mt = [x for x in ctr.volume_mounts if x.name == "secrets"][0]
-    assert sec_mt.mount_path == "/etc/nublado/secrets"
+    container = pod.spec.containers[0]
+    assert container.args == ["/usr/local/share/jupyterlab/runlab"]
+    secrets_mount = next(
+        x for x in container.volume_mounts if x.name == "secrets"
+    )
+    assert secrets_mount.mount_path == "/etc/nublado/secrets"
     config_map = await mock_kubernetes.read_namespaced_config_map(
         f"{user.username}-nb-env",
         f"{config.lab.namespace_prefix}-{user.username}",
     )
-    assert (
-        config_map.data["JUPYTERLAB_CONFIG_DIR"]
-        == "/usr/local/share/jupyterlab"
-    )
+    config_dir = config_map.data["JUPYTERLAB_CONFIG_DIR"]
+    assert config_dir == "/usr/local/share/jupyterlab"
 
 
 @pytest.mark.asyncio

--- a/controller/tests/services/prepuller_test.py
+++ b/controller/tests/services/prepuller_test.py
@@ -187,9 +187,7 @@ async def test_gar(
 
 @pytest.mark.asyncio
 async def test_cycle(
-    factory: Factory,
-    mock_docker: MockDockerRegistry,
-    mock_kubernetes: MockKubernetesApi,
+    mock_docker: MockDockerRegistry, mock_kubernetes: MockKubernetesApi
 ) -> None:
     config = await configure("cycle")
     mock_docker.tags = read_input_json("cycle", "docker-tags")
@@ -226,9 +224,7 @@ async def test_cycle(
 
 @pytest.mark.asyncio
 async def test_gar_cycle(
-    factory: Factory,
-    mock_gar: MockArtifactRegistry,
-    mock_kubernetes: MockKubernetesApi,
+    mock_gar: MockArtifactRegistry, mock_kubernetes: MockKubernetesApi
 ) -> None:
     config = await configure("gar-cycle")
     known_images = read_input_json("gar-cycle", "known-images")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.black]
 line-length = 79
-target-version = ["py311"]
+target-version = ["py312"]
 exclude = '''
 /(
     \.eggs
@@ -47,73 +47,9 @@ warn_untyped_fields = true
 # Reference for settings: https://beta.ruff.rs/docs/settings/
 # Reference for rules: https://beta.ruff.rs/docs/rules/
 [tool.ruff]
-exclude = [
-    "docs/conf.py",
-]
-line-length = 79
-target-version = "py311"
+extend = "ruff-shared.toml"
 
-[tools.ruff.lint]
-ignore = [
-    "ANN101",  # self should not have a type annotation
-    "ANN102",  # cls should not have a type annotation
-    "ANN401",  # sometimes Any is the right type
-    "ARG001",  # unused function arguments are often legitimate
-    "ARG002",  # unused method arguments are often legitimate
-    "ARG005",  # unused lambda arguments are often legitimate
-    "BLE001",  # we want to catch and report Exception in background tasks
-    "C414",    # nested sorted is how you sort by multiple keys with reverse
-    "COM812",  # omitting trailing commas allows black autoreformatting
-    "D102",    # sometimes we use docstring inheritence
-    "D104",    # don't see the point of documenting every package
-    "D105",    # our style doesn't require docstrings for magic methods
-    "D106",    # Pydantic uses a nested Config class that doesn't warrant docs
-    "D205",    # our documentation style allows a folded first line
-    "EM101",   # justification (duplicate string in traceback) is silly
-    "EM102",   # justification (duplicate string in traceback) is silly
-    "FBT003",  # positional booleans are normal for Pydantic field defaults
-    "FIX002",  # point of a TODO comment is that we're not ready to fix it
-    "G004",    # forbidding logging f-strings is appealing, but not our style
-    "RET505",  # disagree that omitting else always makes code more readable
-    "PLR0911", # often many returns is clearer and simpler style
-    "PLR0913", # factory pattern uses constructors with many arguments
-    "PLR2004", # too aggressive about magic values
-    "PLW0603", # yes global is discouraged but if needed, it's needed
-    "S105",    # good idea but too many false positives on non-passwords
-    "S106",    # good idea but too many false positives on non-passwords
-    "S107",    # good idea but too many false positives on non-passwords
-    "S603",    # not going to manually mark every subprocess call as reviewed
-    "S607",    # using PATH is not a security vulnerability
-    "SIM102",  # sometimes the formatting of nested if statements is clearer
-    "SIM117",  # sometimes nested with contexts are clearer
-    "TCH001",  # we decided to not maintain separate TYPE_CHECKING blocks
-    "TCH002",  # we decided to not maintain separate TYPE_CHECKING blocks
-    "TCH003",  # we decided to not maintain separate TYPE_CHECKING blocks
-    "TD003",   # we don't require issues be created for TODOs
-    "TID252",  # if we're going to use relative imports, use them always
-    "TRY003",  # good general advice but lint is way too aggressive
-    "TRY301",  # sometimes raising exceptions inside try is the best flow
-
-    # The following settings should be disabled when using ruff format
-    # per https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    "W191",
-    "E111",
-    "E114",
-    "E117",
-    "D206",
-    "D300",
-    "Q000",
-    "Q001",
-    "Q002",
-    "Q003",
-    "COM812",
-    "COM819",
-    "ISC001",
-    "ISC002",
-]
-select = ["ALL"]
-
-[tool.ruff.lint.per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "controller/src/controller/constants.py" = [
     "S108",    # constructing /tmp paths for Kubernetes Pods
 ]
@@ -122,9 +58,6 @@ select = ["ALL"]
 ]
 "controller/src/controller/services/**" = [
     "S108",    # constructing /tmp paths for Kubernetes Pods
-]
-"docs/**" = [
-    "INP001",  # Python files are embedded diagrams
 ]
 "noxfile.py" = [
     "T201",    # print makes sense as output from nox rules
@@ -152,38 +85,6 @@ known-first-party = [
     "rubin.nublado.spawner",
     "tests",
 ]
-
-[tool.ruff.lint.flake8-bugbear]
-extend-immutable-calls = [
-    "fastapi.Form",
-    "fastapi.Header",
-    "fastapi.Depends",
-    "fastapi.Path",
-    "fastapi.Query",
-]
-
-# These are too useful as attributes or methods to allow the conflict with the
-# built-in to rule out their use.
-[tool.ruff.lint.flake8-builtins]
-builtins-ignorelist = [
-    "all",
-    "any",
-    "dict",
-    "help",
-    "id",
-    "list",
-    "object",
-    "open",
-    "set",
-    "type",
-]
-
-[tool.ruff.lint.flake8-pytest-style]
-fixture-parentheses = false
-mark-parentheses = false
-
-[tool.ruff.lint.pydocstyle]
-convention = "numpy"
 
 [tool.scriv]
 categories = [

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -1,0 +1,139 @@
+# Generic shared Ruff configuration file. It should be possible to use this
+# file unmodified in different packages provided that one likes the style that
+# it enforces.
+#
+# This file should be used from pyproject.toml as follows:
+#
+#     [tool.ruff]
+#     extend = "ruff-shared.toml"
+#
+# It can then be extended with project-specific rules. A common additional
+# setting in pyproject.toml is tool.ruff.lint.extend-per-file-ignores, to add
+# additional project-specific ignore rules for specific paths.
+#
+# The rule used with Ruff configuration is to disable every non-deprecated
+# lint rule that has legitimate exceptions that are not dodgy code, rather
+# than cluttering code with noqa markers. This is therefore a reiatively
+# relaxed configuration that errs on the side of disabling legitimate rules.
+#
+# Reference for settings: https://docs.astral.sh/ruff/settings/
+# Reference for rules: https://docs.astral.sh/ruff/rules/
+exclude = ["docs/**"]
+line-length = 79
+target-version = "py312"
+
+[format]
+docstring-code-format = true
+
+[lint]
+ignore = [
+    "ANN401",   # sometimes Any is the right type
+    "ARG001",   # unused function arguments are often legitimate
+    "ARG002",   # unused method arguments are often legitimate
+    "ARG003",   # unused class method arguments are often legitimate
+    "ARG005",   # unused lambda arguments are often legitimate
+    "ASYNC109", # many async functions use asyncio.timeout internally
+    "BLE001",   # we want to catch and report Exception in background tasks
+    "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "D102",     # sometimes we use docstring inheritence
+    "D104",     # don't see the point of documenting every package
+    "D105",     # our style doesn't require docstrings for magic methods
+    "D106",     # Pydantic uses a nested Config class that doesn't warrant docs
+    "D205",     # our documentation style allows a folded first line
+    "EM101",    # justification (duplicate string in traceback) is silly
+    "EM102",    # justification (duplicate string in traceback) is silly
+    "FBT003",   # positional booleans are normal for Pydantic field defaults
+    "FIX002",   # point of a TODO comment is that we're not ready to fix it
+    "PD011",    # attempts to enforce pandas conventions for all data types
+    "G004",     # forbidding logging f-strings is appealing, but not our style
+    "RET505",   # disagree that omitting else always makes code more readable
+    "PLR0911",  # often many returns is clearer and simpler style
+    "PLR0913",  # factory pattern uses constructors with many arguments
+    "PLR2004",  # too aggressive about magic values
+    "PLW0603",  # yes global is discouraged but if needed, it's needed
+    "S105",     # good idea but too many false positives on non-passwords
+    "S106",     # good idea but too many false positives on non-passwords
+    "S107",     # good idea but too many false positives on non-passwords
+    "S603",     # not going to manually mark every subprocess call as reviewed
+    "S607",     # using PATH is not a security vulnerability
+    "SIM102",   # sometimes the formatting of nested if statements is clearer
+    "SIM117",   # sometimes nested with contexts are clearer
+    "TCH001",   # we decided to not maintain separate TYPE_CHECKING blocks
+    "TCH002",   # we decided to not maintain separate TYPE_CHECKING blocks
+    "TCH003",   # we decided to not maintain separate TYPE_CHECKING blocks
+    "TD003",    # we don't require issues be created for TODOs
+    "TID252",   # if we're going to use relative imports, use them always
+    "TRY003",   # good general advice but lint is way too aggressive
+    "TRY301",   # sometimes raising exceptions inside try is the best flow
+    "UP040",    # PEP 695 type aliases not yet supported by mypy
+
+    # The following settings should be disabled when using ruff format
+    # per https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
+]
+select = ["ALL"]
+
+[lint.per-file-ignores]
+"noxfile.py" = [
+    "T201",    # print makes sense as output from nox rules
+]
+"src/*/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
+]
+"*/src/*/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
+]
+"tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # allow tests for whether code can be pickled
+    "SLF001",  # tests are allowed to access private members
+]
+"*/tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # allow tests for whether code can be pickled
+    "SLF001",  # tests are allowed to access private members
+]
+
+# These are too useful as attributes or methods to allow the conflict with the
+# built-in to rule out their use.
+[lint.flake8-builtins]
+builtins-ignorelist = [
+    "all",
+    "any",
+    "help",
+    "id",
+    "list",
+    "type",
+]
+
+[lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[lint.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
Adopt the shared Ruff configuration from the FastAPI Safir app template, with some changes that will be pushed upstream. Refactor some code that complained with the new Ruff configuration.