### PR TITLE
DM-45794: Support human-friendly timeout configuration

### DIFF
--- a/changelog.d/20240815_164651_rra_DM_45794a.md
+++ b/changelog.d/20240815_164651_rra_DM_45794a.md
@@ -1,0 +1,3 @@
+### New features
+
+- All timeout configuration options now support the syntax parsed by Safir's `parse_timedelta` and therefore support human-friendly durations such as `6h` or `5m`.

--- a/controller/requirements/main.in
+++ b/controller/requirements/main.in
@@ -22,7 +22,7 @@ kubernetes_asyncio
 pydantic>2
 pydantic-settings
 PyYAML
-safir[kubernetes]>=5.2.0
+safir[kubernetes]>=6.2.0
 semver
 sse-starlette
 
@@ -31,6 +31,5 @@ sse-starlette
 # safir[kubernetes] @ git+https://github.com/lsst-sqre/safir@main
 
 # This one seems to be a dependency on amd64 but not arm64, so developing on
-# Mac without it looks fine locally but does not work on Github Actions
+# Mac without it looks fine locally but does not work on Github Actions.
 greenlet
-

--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -22,6 +22,7 @@ from pydantic import (
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
+from safir.pydantic import HumanTimedelta
 
 from .constants import (
     KUBERNETES_NAME_PATTERN,
@@ -328,7 +329,7 @@ class EnabledFileserverConfig(FileserverConfig):
         ),
     )
 
-    creation_timeout: timedelta = Field(
+    creation_timeout: HumanTimedelta = Field(
         timedelta(minutes=2),
         title="File server creation timeout",
         description=(
@@ -337,7 +338,7 @@ class EnabledFileserverConfig(FileserverConfig):
         ),
     )
 
-    delete_timeout: timedelta = Field(
+    delete_timeout: HumanTimedelta = Field(
         timedelta(minutes=1),
         title="File server deletion timeout",
         description=(
@@ -355,7 +356,7 @@ class EnabledFileserverConfig(FileserverConfig):
         ),
     )
 
-    idle_timeout: timedelta = Field(
+    idle_timeout: HumanTimedelta = Field(
         timedelta(hours=1),
         title="File server inactivity timeout",
         description=(
@@ -656,7 +657,7 @@ class LabConfig(BaseModel):
         description="Node and pod affinity rules for lab pods",
     )
 
-    delete_timeout: timedelta = Field(
+    delete_timeout: HumanTimedelta = Field(
         timedelta(minutes=1),
         title="Timeout for lab deletion",
         description=(
@@ -827,7 +828,7 @@ class LabConfig(BaseModel):
         ),
     )
 
-    spawn_timeout: timedelta = Field(
+    spawn_timeout: HumanTimedelta = Field(
         timedelta(minutes=10),
         title="Timeout for lab spawning",
         description=(


### PR DESCRIPTION
All timeout configuration options now support the syntax parsed by Safir's `parse_timedelta` and therefore support human-friendly durations such as `6h` or `5m`.