### PR TITLE
Set default asyncio fixture loop scope

### DIFF
--- a/authenticator/pyproject.toml
+++ b/authenticator/pyproject.toml
@@ -51,6 +51,7 @@ where = ["src"]
 root = ".."
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 filterwarnings = [
     # dateutil uses a deprecated datetime function.

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -58,6 +58,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 filterwarnings = [
     # Google modules and a Sphinx module call a deprecated pkg_resources API.

--- a/inithome/pyproject.toml
+++ b/inithome/pyproject.toml
@@ -36,6 +36,7 @@ inithome = "rubin.nublado.inithome.main:main"
 root = ".."
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 # The python_files setting is not for test detection (pytest will pick up any
 # test files named *_test.py without this setting) but to enable special

--- a/spawner/pyproject.toml
+++ b/spawner/pyproject.toml
@@ -78,6 +78,7 @@ exclude_lines = [
 ]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "strict"
 filterwarnings = [
     # Will probably be fixed with JupyterHub v4.


### PR DESCRIPTION
pytest-asyncio is changing the default for the asyncio fixture loop scope. Set it to the new default.