### PR TITLE
Add trigger for published releases to Github CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ env:
       - "u/**"
     tags:
       - "*"
+  release:
+    types: [published]
 
 jobs:
   lint:


### PR DESCRIPTION
Add trigger to Github CI for release action "published".