### PR TITLE
Revert module name back to dash form

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,7 +216,7 @@ jobs:
     needs: [lint, test, docs]
     environment:
       name: pypi
-      url: https://pypi.org/p/rubin.nublado.client
+      url: https://pypi.org/p/rubin-nublado-client
     permissions:
       id-token: write
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,7 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 ### Bug fixes
 
-- Canonical project name becomes `rubin.nublado.client`
-
-### Other changes
-
--
+- Rename PyPI module for the Nublado client to `rubin.nublado.client`. Either name should work for `pip install`.
 
 <a id='changelog-7.1.1'></a>
 ## 7.1.1 (2024-09-23)

--- a/changelog.d/20240924_172954_rra_naming.md
+++ b/changelog.d/20240924_172954_rra_naming.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Revert canonical PyPI module name back to `rubin-nublado-client` for consistency with other projects. As before, this change should not affect `pip install`; either form of the name should work.

--- a/docs/client/index.rst
+++ b/docs/client/index.rst
@@ -11,7 +11,7 @@ The client can be installed from PyPI with:
 
 .. prompt:: bash
 
-    pip install rubin.nublado.client
+   pip install rubin-nublado-client
 
 .. _client-usage:
 


### PR DESCRIPTION
After some more internal discussion, we decided to stick with the dash form. PyPI still seems to be using it, so change the places that used rubin.nublado.client back to rubin-nublado-client.

Clean up the change log for the 7.1.2 release somewhat.