### PR TITLE
DM-48124: Add service label to GafaelfawrIngress

### DIFF
--- a/changelog.d/20241212_154123_rra_DM_48124a.md
+++ b/changelog.d/20241212_154123_rra_DM_48124a.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a `service` label to `GafaelfawrIngress` resources created for user file servers for proper Gafaelfawr metrics reporting.

--- a/controller/src/controller/services/builder/fileserver.py
+++ b/controller/src/controller/services/builder/fileserver.py
@@ -201,10 +201,11 @@ class FileserverBuilder:
             "kind": "GafaelfawrIngress",
             "metadata": metadata,
             "config": {
-                "baseUrl": self._base_url,
-                "scopes": {"all": ["exec:notebook"]},
-                "loginRedirect": False,
                 "authType": "basic",
+                "baseUrl": self._base_url,
+                "loginRedirect": False,
+                "scopes": {"all": ["exec:notebook"]},
+                "service": "nublado-files",
                 "username": username,
             },
             "template": {

--- a/controller/tests/data/fileserver/output/fileserver-objects.json
+++ b/controller/tests/data/fileserver/output/fileserver-objects.json
@@ -421,14 +421,15 @@
       "namespace": "fileservers"
     },
     "config": {
+      "authType": "basic",
       "baseUrl": "http://127.0.0.1:8080",
+      "loginRedirect": false,
       "scopes": {
         "all": [
           "exec:notebook"
         ]
       },
-      "loginRedirect": false,
-      "authType": "basic",
+      "service": "nublado-files",
       "username": "rachel"
     },
     "template": {


### PR DESCRIPTION
When creating `GafaelfawrIngress` resources for the file server, add a `service` configuration setting with value `nublado-files` for Gafaelfawr metrics reporting.