### PR TITLE
Add pip dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: "pip"
+    directories:
+      - "/authenticator"
+      - "/client"
+      - "/spawner"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Tell dependabot to check the Python dependencies of all of the components that are maintained like libraries so that it will relax major version pins where needed.