### PR TITLE
DM-48216: Use type keyword when making type aliases

### DIFF
--- a/authenticator/src/rubin/nublado/authenticator/_internals.py
+++ b/authenticator/src/rubin/nublado/authenticator/_internals.py
@@ -12,8 +12,8 @@ from jupyterhub.utils import url_path_join
 from tornado.httputil import HTTPHeaders
 from tornado.web import HTTPError, RequestHandler
 
-AuthInfo = dict[str, str | dict[str, str]]
-Route = tuple[str, type[BaseHandler]]
+type AuthInfo = dict[str, str | dict[str, str]]
+type Route = tuple[str, type[BaseHandler]]
 
 __all__ = ["GafaelfawrAuthenticator"]
 


### PR DESCRIPTION
Add the `type` keyword to two type aliases in the authenticator now that we can assume Python 3.12 or later.