### PR TITLE
DM-48216: Build fewer new JupyterLab base images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,12 +247,22 @@ jobs:
           # Full history is required for setuptools_scm versioning.
           fetch-depth: 0
 
+      - name: Filter paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rsp_base:
+              - "Dockerfile.jupyterlab-base"
+              - "jupyterlab-base/**"
+
       - uses: lsst-sqre/build-and-push-to-ghcr@v1
         id: build-jupyterlab-base
         with:
           dockerfile: Dockerfile.jupyterlab-base
           image: ${{ github.repository }}-jupyterlab-base
           github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.filter.outputs.rsp_base == 'true'
 
       - name: Report result
         run: |


### PR DESCRIPTION
Check the paths affected by the PR and do not build new JupyterLab base images unless the files that go into that image are affected. This will hopefully save some time in GitHub CI.