### PR TITLE
DM-48216: Use new Python 3.12 generics syntax

### DIFF
--- a/client/src/rubin/nublado/client/nubladoclient.py
+++ b/client/src/rubin/nublado/client/nubladoclient.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 from functools import wraps
 from pathlib import Path
 from types import TracebackType
-from typing import Concatenate, Literal, ParamSpec, Self, TypeVar
+from typing import Concatenate, Literal, Self
 from urllib.parse import urljoin, urlparse
 from uuid import uuid4
 
@@ -46,9 +46,6 @@ from .models import (
     SpawnProgressMessage,
     User,
 )
-
-P = ParamSpec("P")
-T = TypeVar("T")
 
 __all__ = ["JupyterLabSession", "NubladoClient"]
 
@@ -712,7 +709,7 @@ def _annotate_exception_from_context(
         e.annotations["cell_line_source"] = context.cell_line_source
 
 
-def _convert_exception(
+def _convert_exception[**P, T](
     f: Callable[Concatenate[NubladoClient, P], Coroutine[None, None, T]],
 ) -> Callable[Concatenate[NubladoClient, P], Coroutine[None, None, T]]:
     """Convert web error to `~rubin.nublado.client.exceptions.JupyterWebError`.
@@ -738,7 +735,7 @@ def _convert_exception(
     return wrapper
 
 
-def _convert_iterator_exception(
+def _convert_iterator_exception[**P, T](
     f: Callable[Concatenate[NubladoClient, P], AsyncIterator[T]],
 ) -> Callable[Concatenate[NubladoClient, P], AsyncIterator[T]]:
     """Convert web errors to a `~rubin.nublado.client.JupyterWebError`.

--- a/controller/src/controller/storage/kubernetes/creator.py
+++ b/controller/src/controller/storage/kubernetes/creator.py
@@ -12,10 +12,8 @@ subclasses `KubernetesObjectCreator` and adds list and delete support, and its
 subclasses.
 """
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from kubernetes_asyncio import client
 from kubernetes_asyncio.client import (
@@ -32,20 +30,16 @@ from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import KubernetesModel
 from ...timeout import Timeout
 
-#: Type of Kubernetes object being manipulated.
-T = TypeVar("T", bound=KubernetesModel)
-
 __all__ = [
     "ConfigMapStorage",
     "KubernetesObjectCreator",
     "NetworkPolicyStorage",
     "ResourceQuotaStorage",
     "SecretStorage",
-    "T",
 ]
 
 
-class KubernetesObjectCreator(Generic[T]):
+class KubernetesObjectCreator[T: KubernetesModel]:
     """Generic Kubernetes object storage supporting create and read.
 
     This class provides a wrapper around any Kubernetes object type that
@@ -157,7 +151,7 @@ class KubernetesObjectCreator(Generic[T]):
             ) from e
 
 
-class ConfigMapStorage(KubernetesObjectCreator):
+class ConfigMapStorage(KubernetesObjectCreator[V1ConfigMap]):
     """Storage layer for ``ConfigMap`` objects.
 
     Parameters
@@ -179,7 +173,7 @@ class ConfigMapStorage(KubernetesObjectCreator):
         )
 
 
-class NetworkPolicyStorage(KubernetesObjectCreator):
+class NetworkPolicyStorage(KubernetesObjectCreator[V1NetworkPolicy]):
     """Storage layer for ``NetworkPolicy`` objects.
 
     Parameters
@@ -201,7 +195,7 @@ class NetworkPolicyStorage(KubernetesObjectCreator):
         )
 
 
-class ResourceQuotaStorage(KubernetesObjectCreator):
+class ResourceQuotaStorage(KubernetesObjectCreator[V1ResourceQuota]):
     """Storage layer for ``ResourceQuota`` objects.
 
     Parameters
@@ -223,7 +217,7 @@ class ResourceQuotaStorage(KubernetesObjectCreator):
         )
 
 
-class SecretStorage(KubernetesObjectCreator):
+class SecretStorage(KubernetesObjectCreator[V1Secret]):
     """Storage layer for ``Secret`` objects.
 
     Parameters

--- a/controller/src/controller/storage/kubernetes/deleter.py
+++ b/controller/src/controller/storage/kubernetes/deleter.py
@@ -7,11 +7,9 @@ types that only need those operations are provided here; more complex storage
 classes with other operations are defined in their own modules.
 """
 
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from kubernetes_asyncio import client
 from kubernetes_asyncio.client import (
@@ -34,19 +32,15 @@ from ...timeout import Timeout
 from .creator import KubernetesObjectCreator
 from .watcher import KubernetesWatcher
 
-#: Type of Kubernetes object being manipulated.
-T = TypeVar("T", bound=KubernetesModel)
-
 __all__ = [
     "JobStorage",
     "KubernetesObjectDeleter",
     "PersistentVolumeClaimStorage",
     "ServiceStorage",
-    "T",
 ]
 
 
-class KubernetesObjectDeleter(KubernetesObjectCreator, Generic[T]):
+class KubernetesObjectDeleter[T: KubernetesModel](KubernetesObjectCreator[T]):
     """Generic Kubernetes object storage supporting list and delete.
 
     This class provides a wrapper around any Kubernetes object type that
@@ -336,7 +330,7 @@ class KubernetesObjectDeleter(KubernetesObjectCreator, Generic[T]):
         raise RuntimeError("Wait for object deletion unexpectedly stopped")
 
 
-class JobStorage(KubernetesObjectDeleter):
+class JobStorage(KubernetesObjectDeleter[V1Job]):
     """Storage layer for ``Job`` objects.
 
     Parameters
@@ -360,7 +354,9 @@ class JobStorage(KubernetesObjectDeleter):
         )
 
 
-class PersistentVolumeClaimStorage(KubernetesObjectDeleter):
+class PersistentVolumeClaimStorage(
+    KubernetesObjectDeleter[V1PersistentVolumeClaim]
+):
     """Storage layer for ``PersistentVolumeClaim`` objects.
 
     Parameters
@@ -384,7 +380,7 @@ class PersistentVolumeClaimStorage(KubernetesObjectDeleter):
         )
 
 
-class ServiceStorage(KubernetesObjectDeleter):
+class ServiceStorage(KubernetesObjectDeleter[V1Service]):
     """Storage layer for ``Service`` objects.
 
     Parameters

--- a/controller/src/controller/storage/kubernetes/ingress.py
+++ b/controller/src/controller/storage/kubernetes/ingress.py
@@ -39,7 +39,7 @@ def ingress_has_ip_address(ingress: V1Ingress) -> bool:
     return bool(ingress.status.load_balancer.ingress[0].ip)
 
 
-class IngressStorage(KubernetesObjectDeleter):
+class IngressStorage(KubernetesObjectDeleter[V1Ingress]):
     """Storage layer for ``Ingress`` objects.
 
     Parameters

--- a/controller/src/controller/storage/kubernetes/pod.py
+++ b/controller/src/controller/storage/kubernetes/pod.py
@@ -17,7 +17,7 @@ from .watcher import KubernetesWatcher
 __all__ = ["PodStorage"]
 
 
-class PodStorage(KubernetesObjectDeleter):
+class PodStorage(KubernetesObjectDeleter[V1Pod]):
     """Storage layer for ``Pod`` objects.
 
     Parameters

--- a/controller/src/controller/storage/kubernetes/watcher.py
+++ b/controller/src/controller/storage/kubernetes/watcher.py
@@ -1,11 +1,9 @@
 """Watch a Kubernetes namespace or cluster for events."""
 
-from __future__ import annotations
-
 import math
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, Generic, Self, TypeVar
+from typing import Any, Self
 
 from kubernetes_asyncio.client import ApiException
 from kubernetes_asyncio.watch import Watch
@@ -15,18 +13,14 @@ from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import WatchEventType
 from ...timeout import Timeout
 
-#: Type of Kubernetes object being watched (`dict` for custom objects).
-T = TypeVar("T")
-
 __all__ = [
     "KubernetesWatcher",
-    "T",
     "WatchEvent",
 ]
 
 
 @dataclass
-class WatchEvent(Generic[T]):
+class WatchEvent[T]:
     """Parsed event from a Kubernetes watch.
 
     This model is intended only for use within the Kubernetes storage layer.
@@ -68,7 +62,7 @@ class WatchEvent(Generic[T]):
         return cls(action=action, object=obj)
 
 
-class KubernetesWatcher(Generic[T]):
+class KubernetesWatcher[T]:
     """Watch Kubernetes for events.
 
     This wrapper around the watch API of the Kubernetes client implements

--- a/spawner/src/rubin/nublado/spawner/_internals.py
+++ b/spawner/src/rubin/nublado/spawner/_internals.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from datetime import timedelta
 from functools import wraps
 from pathlib import Path
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from httpx import AsyncClient, HTTPError, Response
 from httpx_sse import ServerSentEvent, aconnect_sse
@@ -22,9 +22,6 @@ from ._exceptions import (
 )
 from ._models import LabStatus, SpawnEvent
 
-P = ParamSpec("P")
-T = TypeVar("T")
-
 __all__ = [
     "LabStatus",
     "NubladoSpawner",
@@ -34,7 +31,7 @@ _CLIENT: AsyncClient | None = None
 """Cached global HTTP client so that we can share a connection pool."""
 
 
-def _convert_exception(
+def _convert_exception[**P, T](
     f: Callable[Concatenate[NubladoSpawner, P], Coroutine[None, None, T]],
 ) -> Callable[Concatenate[NubladoSpawner, P], Coroutine[None, None, T]]:
     """Convert ``httpx`` exceptions to `ControllerWebError`."""


### PR DESCRIPTION
Now that we can assume Python 3.12, use the new syntax for generics and eliminate uses of `Generic`, `TypeVar`, and `ParamSpec`.