### PR TITLE
DM-48216: Update to websockets 14.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - uses: lsst-sqre/run-nox@v1
         with:
-          cache-dependency: "hub/requirements/*.txt"
+          cache-dependency: "client/pyproject.toml"
           cache-key-prefix: test-client
           nox-sessions: "typing-client test-client"
           python-version: ${{ matrix.python }}

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -21,14 +21,14 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "httpx<0.28.0",  # https://github.com/lundberg/respx/issues/277
-    "httpx_sse",
+    "httpx-sse",
     "pydantic>2",
     "pydantic-settings",
     "pyyaml",
     "safir",
     "shortuuid",
     "structlog",
-    "websockets<14",  # We should update, but it will take some work
+    "websockets<15",
 ]
 
 dynamic = ["version"]

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 import respx
 import safir.logging
 import structlog
+import websockets
 from structlog.stdlib import BoundLogger
 
 from rubin.nublado.client import NubladoClient
@@ -93,7 +94,7 @@ def jupyter(
     ) -> AsyncIterator[MockJupyterWebSocket]:
         yield mock_jupyter_websocket(url, extra_headers, jupyter_mock)
 
-    with patch("rubin.nublado.client.nubladoclient.websocket_connect") as mock:
+    with patch.object(websockets, "connect") as mock:
         mock.side_effect = mock_connect
         yield jupyter_mock
 

--- a/docs/client/index.rst
+++ b/docs/client/index.rst
@@ -274,6 +274,7 @@ It depends on two other fixtures: ``environment_url`` is a string, representing 
 
     import pytest
     import respx
+    import websockets
 
     from nublado.rubin.client.testing import (
         MockJupyter,
@@ -320,7 +321,7 @@ It depends on two other fixtures: ``environment_url`` is a string, representing 
         ) -> AsyncIterator[MockJupyterWebSocket]:
             yield mock_jupyter_websocket(url, extra_headers, jupyter_mock)
 
-        with patch("rubin.nublado.client.nubladoclient.websocket_connect") as mock:
+        with patch(websockets, "connect") as mock:
             mock.side_effect = mock_connect
             yield jupyter_mock
 


### PR DESCRIPTION
Adjust the Nublado client for the new websockets 14.1 API. Fix the cache dependency for the client tests.
