### PR TITLE
DM-48216: Add @override markers for overridden methods

### DIFF
--- a/client/src/rubin/nublado/client/exceptions.py
+++ b/client/src/rubin/nublado/client/exceptions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import Self
+from typing import Self, override
 
 import httpx
 from safir.datetime import format_datetime_for_logging
@@ -128,6 +128,7 @@ class NubladoClientSlackException(SlackException):
         self.started_at = started_at
         self.annotations: dict[str, str] = {}
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Format the error as a Slack Block Kit message.
 
@@ -234,6 +235,7 @@ class NubladoClientSlackWebException(
         )
         self.started_at = started_at
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Format the error as a Slack Block Kit message.
 
@@ -257,6 +259,7 @@ class NubladoClientSlackWebException(
             msg.attachments.append(block)
         return msg
 
+    @override
     def common_blocks(self) -> list[SlackBaseBlock]:
         blocks = NubladoClientSlackException.common_blocks(self)
         url = _sanitize_url(self.url)
@@ -289,6 +292,7 @@ class CodeExecutionError(NubladoClientSlackException):
         if failed_at:
             self.failed_at = failed_at
 
+    @override
     def __str__(self) -> str:
         if self.annotations.get("notebook"):
             notebook = self.annotations["notebook"]
@@ -309,6 +313,7 @@ class CodeExecutionError(NubladoClientSlackException):
             msg += f"\nError: {_remove_ansi_escapes(self.error)}"
         return msg
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Format the error as a Slack Block Kit message."""
         if self.annotations.get("notebook"):
@@ -400,6 +405,7 @@ class ExecutionAPIError(NubladoClientSlackException):
         self.msg = _sanitize_body(body) if body else None
         self.user = username
 
+    @override
     def __str__(self) -> str:
         return (
             f"{self.user}: status {self.status} ({self.reason}) from"
@@ -477,6 +483,7 @@ class JupyterSpawnError(NubladoClientSlackException):
         )
         self.log = log
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Format the error as a Slack Block Kit message."""
         message = super().to_slack()
@@ -501,6 +508,7 @@ class JupyterTimeoutError(NubladoClientSlackException):
         super().__init__(msg, user, started_at=started_at, failed_at=failed_at)
         self.log = log
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Format the error as a Slack Block Kit message."""
         message = super().to_slack()
@@ -627,6 +635,7 @@ class JupyterWebSocketError(NubladoClientSlackException):
         if annotations:
             self.annotations.update(annotations)
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Format this exception as a Slack notification.
 

--- a/client/src/rubin/nublado/client/models/_image.py
+++ b/client/src/rubin/nublado/client/models/_image.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import Literal
+from typing import Literal, override
 
 from pydantic import BaseModel, Field
 
@@ -77,6 +77,7 @@ class NubladoImageByReference(NubladoImage):
 
     reference: str = Field(..., title="Docker reference of lab image to spawn")
 
+    @override
     def to_spawn_form(self) -> dict[str, str]:
         result = {
             "image_list": self.reference,
@@ -96,6 +97,7 @@ class NubladoImageByTag(NubladoImage):
 
     tag: str = Field(..., title="Tag of image to spawn")
 
+    @override
     def to_spawn_form(self) -> dict[str, str]:
         result = {"image_tag": self.tag, "size": self.size.value}
         if self.debug:
@@ -116,6 +118,7 @@ class NubladoImageByClass(NubladoImage):
         title="Class of image to spawn",
     )
 
+    @override
     def to_spawn_form(self) -> dict[str, str]:
         result = {
             "image_class": self.image_class.value,

--- a/controller/src/controller/exceptions.py
+++ b/controller/src/controller/exceptions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Self
+from typing import Self, override
 
 from fastapi import status
 from kubernetes_asyncio.client import ApiException
@@ -155,6 +155,7 @@ class ControllerTimeoutError(SlackException):
         msg = f"{operation} timed out after {elapsed.total_seconds()}"
         super().__init__(msg, user, failed_at=failed_at)
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Format the exception as a Slack message.
 
@@ -207,6 +208,7 @@ class DuplicateObjectError(SlackException):
         self.kind = kind
         self.namespace = namespace
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Convert to a Slack message for Slack alerting.
 
@@ -253,6 +255,7 @@ class GafaelfawrParseError(SlackException):
         super().__init__(message)
         self.error = error
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Convert to a Slack message for Slack alerting.
 
@@ -354,12 +357,14 @@ class KubernetesError(SlackException):
         self.status = status
         self.body = body
 
+    @override
     def __str__(self) -> str:
         result = self._summary()
         if self.body:
             result += f": {self.body}"
         return result
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Convert to a Slack message for Slack alerting.
 
@@ -458,6 +463,7 @@ class MissingObjectError(SlackException):
         self.namespace = namespace
         self.name = name
 
+    @override
     def to_slack(self) -> SlackMessage:
         """Convert to a Slack message for Slack alerting.
 

--- a/controller/src/controller/models/domain/kubernetes.py
+++ b/controller/src/controller/models/domain/kubernetes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Protocol, Self
+from typing import Any, Protocol, Self, override
 
 from kubernetes_asyncio.client import (
     V1Affinity,
@@ -505,6 +505,7 @@ class PodAntiAffinity(PodAffinity):
     convert to a different Kubernetes model.
     """
 
+    @override
     def to_kubernetes(self) -> V1PodAntiAffinity:
         """Convert to the corresponding Kubernetes model."""
         preferred = None

--- a/controller/src/controller/services/source/docker.py
+++ b/controller/src/controller/services/source/docker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from typing import override
 
 from structlog.stdlib import BoundLogger
 
@@ -59,6 +60,7 @@ class DockerImageSource(ImageSource):
         # Tags that have been resolved to images.
         self._images = RSPImageCollection([])
 
+    @override
     async def image_for_reference(
         self, reference: DockerReference
     ) -> RSPImage:
@@ -136,6 +138,7 @@ class DockerImageSource(ImageSource):
             digest=digest,
         )
 
+    @override
     async def image_for_tag_name(self, tag_name: str) -> RSPImage:
         """Determine the image corresponding to a tag.
 
@@ -173,6 +176,7 @@ class DockerImageSource(ImageSource):
             digest=digest,
         )
 
+    @override
     def mark_prepulled(self, image: RSPImage, node: str) -> None:
         """Optimistically mark an image as prepulled to a node.
 
@@ -187,6 +191,7 @@ class DockerImageSource(ImageSource):
         """
         self._images.mark_image_seen_on_node(image.digest, node)
 
+    @override
     def menu_images(self) -> list[MenuImage]:
         """All known images suitable for display in the spawner menu.
 
@@ -212,6 +217,7 @@ class DockerImageSource(ImageSource):
             menu_images.append(menu_image)
         return menu_images
 
+    @override
     def prepulled_images(self, nodes: set[str]) -> list[PrepulledImage]:
         """All known images with their prepulled status in the API model.
 
@@ -242,6 +248,7 @@ class DockerImageSource(ImageSource):
             prepulled_images.append(prepulled_image)
         return prepulled_images
 
+    @override
     async def update_images(
         self,
         prepull: PrepullerOptions,

--- a/controller/src/controller/services/source/gar.py
+++ b/controller/src/controller/services/source/gar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import override
 
 from structlog.stdlib import BoundLogger
 
@@ -53,6 +54,7 @@ class GARImageSource(ImageSource):
         # All available images.
         self._images = RSPImageCollection([])
 
+    @override
     async def image_for_reference(
         self, reference: DockerReference
     ) -> RSPImage:
@@ -94,6 +96,7 @@ class GARImageSource(ImageSource):
             raise UnknownDockerImageError(msg)
         return image
 
+    @override
     async def image_for_tag_name(self, tag_name: str) -> RSPImage:
         """Determine the image corresponding to a tag.
 
@@ -119,6 +122,7 @@ class GARImageSource(ImageSource):
             raise UnknownDockerImageError(f'Docker tag "{tag_name}" not found')
         return image
 
+    @override
     def mark_prepulled(self, image: RSPImage, node: str) -> None:
         """Optimistically mark an image as prepulled to a node.
 
@@ -133,6 +137,7 @@ class GARImageSource(ImageSource):
         """
         self._images.mark_image_seen_on_node(image.digest, node)
 
+    @override
     def menu_images(self) -> list[MenuImage]:
         """All known images suitable for display in the spawner menu.
 
@@ -146,6 +151,7 @@ class GARImageSource(ImageSource):
             for i in self._images.all_images()
         ]
 
+    @override
     def prepulled_images(self, nodes: set[str]) -> list[PrepulledImage]:
         """All known images with their prepulled status in the API model.
 
@@ -164,6 +170,7 @@ class GARImageSource(ImageSource):
             for i in self._images.all_images()
         ]
 
+    @override
     async def update_images(
         self,
         prepull: PrepullerOptions,

--- a/controller/tests/support/gar.py
+++ b/controller/tests/support/gar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import AsyncIterator, Iterator
-from typing import Any
+from typing import Any, override
 from unittest.mock import Mock, patch
 
 from google.cloud import artifactregistry_v1
@@ -71,6 +71,7 @@ class MockArtifactRegistry(Mock):
 
         return iterator()
 
+    @override
     def _get_child_mock(self, /, **kwargs: Any) -> Mock:
         return Mock(**kwargs)
 


### PR DESCRIPTION
mypy now supports checking that methods marked as `@override` do indeed override a method in the parent class. Mark classes with override methods accordingly, since it provides some useful typo detection.

Unfortunately, the JupyterHub plugins cannot use this because for some reason mypy doesn't detect the methods on the parent class or JupyterHub doesn't declare them all.