### PR TITLE
DM-48216: Fix link checking issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,7 @@ jobs:
         with:
           filters: |
             docs:
+              - "CHANGELOG.md"
               - "docs/**"
 
       - name: Update package lists
@@ -162,11 +163,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Filter paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - "CHANGELOG.md"
+              - "docs/**"
+
       - name: Update package lists
         run: sudo apt-get update
+        if: steps.filter.outputs.docs == 'true'
 
       - name: Install extra packages
         run: sudo apt install -y graphviz
+        if: steps.filter.outputs.docs == 'true'
 
       - uses: lsst-sqre/run-nox@v1
         with:
@@ -174,6 +186,7 @@ jobs:
           cache-key-prefix: docs
           nox-sessions: docs-linkcheck
           python-version: ${{ env.PYTHON_VERSION }}
+        if: steps.filter.outputs.docs == 'true'
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -141,6 +141,6 @@ jobs:
         with:
           status: ${{ job.status }}
           notify_when: "failure"
-          notification_title: "Periodic link check for {repo} failed"
+          notification_title: "Periodic docs check for {repo} failed"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/docs/client/index.rst
+++ b/docs/client/index.rst
@@ -347,10 +347,3 @@ For any case involving Python that uses modules outside the standard library, us
 
 These are generally the only two methods of ``MockJupyter`` that the service developer should use directly.
 All tests should then interact with the mock Jupyter service through ``NubladoClient``, possibly with execution output mocked via registration.
-
-.. _service-usage:
-
-Service Usage
-=============
-
-The `Ghostwriter <https://ghostwriter.lsst.io/v>`_ service uses the ``rubin.nublado.client.NubladoClient`` class.  Soon `Mobu <https://mobu.lsst.io>`_ and `Noteburst <https://noteburst.lsst.io>`_ will as well.

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -54,7 +54,7 @@ At the HEAD of the ``main`` branch, create and push a tag with the semantic vers
 The tag **must** follow the :pep:`440` specification since Nublado uses setuptools_scm_ to set version metadata based on Git tags.
 In particular, **don't** prefix the tag with ``v``.
 
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm
+.. _setuptools_scm: https://github.com/pypa/setuptools-scm
 
 The `ci.yaml`_ GitHub Actions workflow uploads the new release to Docker Hub.
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -82,4 +82,7 @@ ignore = [
     # Generate redirects for authentication
     '^https://github\.com/settings/developers$',
     '^https://github\.com/.*/issues/new$',
+    # Sphinx is now trying to resolve URLs in examples because it doesn't
+    # understand Annotated
+    "^http://nublado-ribbon.nb-ribbon:8888",
 ]


### PR DESCRIPTION
Sphinx appears to turn URLs in `Annotated` arguments into actual links, which is new and annoying behavior. Add an example to the exclusion list. Remove a now-unneeded paragraph that was generating redirects, and change the setuptools-scm link. Only run a linkcheck if there were changes to the documentation; running it for every change of any type feels like a bit much.