### PR TITLE
DM-48216: Use StrEnum instead of dual inheritance

### DIFF
--- a/client/src/rubin/nublado/client/models/_image.py
+++ b/client/src/rubin/nublado/client/models/_image.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Literal, override
 
 from pydantic import BaseModel, Field
 
 
-class NubladoImageClass(str, Enum):
+class NubladoImageClass(StrEnum):
     """Possible ways of selecting an image."""
 
     __slots__ = ()

--- a/controller/src/controller/models/domain/kubernetes.py
+++ b/controller/src/controller/models/domain/kubernetes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Annotated, Any, Protocol, Self, override
 
 from kubernetes_asyncio.client import (
@@ -599,7 +599,7 @@ class Affinity(BaseModel):
         )
 
 
-class PodPhase(str, Enum):
+class PodPhase(StrEnum):
     """One of the valid phases reported in the status section of a Pod."""
 
     PENDING = "Pending"
@@ -759,7 +759,7 @@ class Toleration(BaseModel):
         )
 
 
-class VolumeAccessMode(str, Enum):
+class VolumeAccessMode(StrEnum):
     """Access mode for a persistent volume.
 
     The access modes ``ReadWriteOnce`` and ``ReadWriteOncePod`` are valid

--- a/controller/src/controller/models/v1/lab.py
+++ b/controller/src/controller/models/v1/lab.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Annotated, Any, Self
 
 from kubernetes_asyncio.client import V1ResourceRequirements
@@ -35,7 +35,7 @@ __all__ = [
 ]
 
 
-class LabSize(str, Enum):
+class LabSize(StrEnum):
     """Allowable names for pod sizes.
 
     Taken from `d20 creature sizes`_.

--- a/spawner/src/rubin/nublado/spawner/_models.py
+++ b/spawner/src/rubin/nublado/spawner/_models.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 
 from httpx_sse import ServerSentEvent
 
 
-class LabStatus(str, Enum):
+class LabStatus(StrEnum):
     """Possible status conditions of a user's pod per the lab controller.
 
     This is not directly equivalent to pod phases. It is instead intended to


### PR DESCRIPTION
Rather than inheriting from `str, Enum`, use the `StrEnum` parent class, which does the same thing more thoroughly.