### PR TITLE
DM-48216: Drop support for groups without GIDs

### DIFF
--- a/changelog.d/20241220_115317_rra_DM_48216.md
+++ b/changelog.d/20241220_115317_rra_DM_48216.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Drop support for Gafaelfawr groups without GIDs. Gafaelfawr has required all groups have GIDs since Gafaelfawr 11.0.0.

--- a/controller/src/controller/models/domain/gafaelfawr.py
+++ b/controller/src/controller/models/domain/gafaelfawr.py
@@ -36,13 +36,13 @@ class UserGroup(BaseModel):
     ]
 
     id: Annotated[
-        int | None,
+        int,
         Field(
             examples=[2023],
             title="Numeric GID of the group (POSIX)",
             description="32-bit unsigned integer",
         ),
-    ] = None
+    ]
 
 
 class NotebookQuota(BaseModel):
@@ -138,15 +138,11 @@ class GafaelfawrUserInfo(BaseModel):
     @property
     def supplemental_groups(self) -> list[int]:
         """Supplemental GIDs."""
-        return [g.id for g in self.groups if g.id]
+        return [g.id for g in self.groups]
 
     def groups_json(self) -> str:
-        """Group membership serialized to JSON.
-
-        Groups without GIDs are omitted since we can't do anything with them
-        in the context of a user lab.
-        """
-        return json.dumps([g.model_dump() for g in self.groups if g.id])
+        """Group membership serialized to JSON."""
+        return json.dumps([g.model_dump() for g in self.groups])
 
 
 class GafaelfawrUser(GafaelfawrUserInfo):

--- a/controller/src/controller/models/v1/lab.py
+++ b/controller/src/controller/models/v1/lab.py
@@ -473,7 +473,7 @@ class UserInfo(BaseModel):
             name=user.name,
             uid=user.uid,
             gid=user.gid,
-            groups=[g for g in user.groups if g.id],
+            groups=user.groups,
         )
 
 

--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -400,11 +400,7 @@ class LabBuilder:
 
         # Construct the /etc/group entry by adding all groups that have GIDs.
         # Add the user as an additional member of their supplemental groups.
-        # We can't do anything with groups that don't have GIDs, so ignore
-        # those.
         for group in user.groups:
-            if not group.id:
-                continue
             if group.id == user.gid:
                 etc_group += f"{group.name}:x:{group.id}:\n"
             else:

--- a/controller/tests/data/base/input/users.json
+++ b/controller/tests/data/base/input/users.json
@@ -8,8 +8,7 @@
       {"name": "rachel", "id": 1101},
       {"name": "lunatics", "id": 2028},
       {"name": "mechanics", "id": 2001},
-      {"name": "storytellers", "id": 2021},
-      {"name": "explorers"}
+      {"name": "storytellers", "id": 2021}
     ],
     "quota": {
       "notebook": {


### PR DESCRIPTION
The Nublado controller no longer has to handle groups in the Gafaelfawr user information without GIDs, since Gafaelfawr dropped support for groups without GIDs in the 11.0.0 release.