### PR TITLE
DM-48216: Use standard Python way to get current time

### DIFF
--- a/client/src/rubin/nublado/client/testing/_jupyter.py
+++ b/client/src/rubin/nublado/client/testing/_jupyter.py
@@ -10,7 +10,7 @@ from base64 import urlsafe_b64decode
 from collections.abc import AsyncIterator
 from contextlib import redirect_stdout, suppress
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from io import StringIO
 from pathlib import Path
@@ -23,7 +23,6 @@ from uuid import uuid4
 
 import respx
 from httpx import Request, Response
-from safir.datetime import current_datetime
 
 from .._util import normalize_source
 from ..models import NotebookExecutionResult
@@ -209,7 +208,7 @@ class MockJupyter:
             body = {"name": user, "servers": {"": server}}
         elif state == JupyterState.LAB_RUNNING:
             delete_at = self._delete_at.get(user)
-            if delete_at and current_datetime(microseconds=True) > delete_at:
+            if delete_at and datetime.now(tz=UTC) > delete_at:
                 del self._delete_at[user]
                 self.state[user] = JupyterState.LOGGED_IN
             if delete_at:
@@ -363,7 +362,7 @@ class MockJupyter:
         if self.delete_immediate:
             self.state[user] = JupyterState.LOGGED_IN
         else:
-            now = current_datetime(microseconds=True)
+            now = datetime.now(tz=UTC)
             self._delete_at[user] = now + timedelta(seconds=5)
         return Response(202, request=request)
 

--- a/controller/src/controller/timeout.py
+++ b/controller/src/controller/timeout.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Self
-
-from safir.datetime import current_datetime
 
 from .exceptions import ControllerTimeoutError
 
@@ -40,7 +38,7 @@ class Timeout:
         self._operation = operation
         self._timeout = timeout
         self._user = user
-        self._start = current_datetime(microseconds=True)
+        self._start = datetime.now(tz=UTC)
 
     def elapsed(self) -> float:
         """Elapsed time since the timeout started.
@@ -50,7 +48,7 @@ class Timeout:
         float
             Seconds elapsed since the object was created.
         """
-        now = current_datetime(microseconds=True)
+        now = datetime.now(tz=UTC)
         return (now - self._start).total_seconds()
 
     @asynccontextmanager
@@ -71,7 +69,7 @@ class Timeout:
             async with asyncio.timeout(self.left()):
                 yield
         except (ControllerTimeoutError, TimeoutError) as e:
-            now = current_datetime(microseconds=True)
+            now = datetime.now(tz=UTC)
             raise ControllerTimeoutError(
                 self._operation,
                 self._user,
@@ -92,7 +90,7 @@ class Timeout:
         ControllerTimeoutError
             Raised if the timeout has expired.
         """
-        now = current_datetime(microseconds=True)
+        now = datetime.now(tz=UTC)
         left = (self._timeout - (now - self._start)).total_seconds()
         if left <= 0.0:
             raise ControllerTimeoutError(
@@ -129,7 +127,7 @@ class Timeout:
             if it is constructed by subtracting some time from the remaining
             time in the timeout.
         """
-        now = current_datetime(microseconds=True)
+        now = datetime.now(tz=UTC)
         if timeout < timedelta(seconds=0):
             raise ControllerTimeoutError(
                 self._operation,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,6 @@ extend = "ruff-shared.toml"
     "INP001",  # Jupyter server configuration file, so has no namespace
     "F821",    # Jupyter configuration uses a magic c variable
 ]
-"spawner/tests/support/controller.py" = [
-    "UP017",   # Python 3.10 didn't have datetime.UTC
-]
 
 [tool.ruff.lint.isort]
 known-first-party = [

--- a/spawner/tests/support/controller.py
+++ b/spawner/tests/support/controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import respx
 from httpx import AsyncByteStream, Request, Response
@@ -50,7 +50,7 @@ class MockProgress(AsyncByteStream):
         # sse-starlette sends these ping events periodically to keep the
         # connection alive. We should just ignore them.
         yield b"event: ping\r\n"
-        yield b"data: " + str(datetime.now(tz=timezone.utc)).encode() + b"\r\n"
+        yield b"data: " + str(datetime.now(tz=UTC)).encode() + b"\r\n"
         yield b"\r\n"
 
         yield b"event: info\r\n"


### PR DESCRIPTION
Use `datetime.now(tz=UTC)` instead of `current_datetime` from Safir. The latter is now only useful when truncating times for database purposes. Python added the short `UTC` abbreviation, so the standard construction is more succinct and there's no reason to avoid it.