### PR TITLE
DM-48546: Add support for blocking spawn with a quota flag

### DIFF
--- a/changelog.d/20250122_163137_rra.md
+++ b/changelog.d/20250122_163137_rra.md
@@ -1,0 +1,3 @@
+### New features
+
+- Support the new `spawn` flag in the user's Gafaelfawr metadata. If set to false, tell the user that spawns aren't allowed rather than presenting a menu and reject spawns in the Nublado controller with a 403 error.

--- a/controller/src/controller/exceptions.py
+++ b/controller/src/controller/exceptions.py
@@ -107,7 +107,12 @@ class NotConfiguredError(ClientRequestError):
 
 
 class PermissionDeniedError(ClientRequestError):
-    """Attempt to access a resource for another user."""
+    """Attempt to access a restricted resource.
+
+    This exception may indicate an attempt to access a resource for another
+    user or an attempt to spawn a lab when the user's quota does not allow
+    lab spawning.
+    """
 
     error = "permission_denied"
     status_code = status.HTTP_403_FORBIDDEN

--- a/controller/src/controller/handlers/form.py
+++ b/controller/src/controller/handlers/form.py
@@ -37,6 +37,11 @@ async def get_user_lab_form(
 ) -> Response:
     if username != user.username:
         raise PermissionDeniedError("Permission denied")
+    if user.quota and user.quota.notebook:
+        if not user.quota.notebook.spawn:
+            return templates.TemplateResponse(
+                context.request, "unavailable.html.jinja"
+            )
     images = context.image_service.menu_images()
 
     # Filter the list of configured lab sizes to exclude labs that are larger

--- a/controller/src/controller/models/domain/gafaelfawr.py
+++ b/controller/src/controller/models/domain/gafaelfawr.py
@@ -54,6 +54,12 @@ class NotebookQuota(BaseModel):
         float, Field(title="Maximum memory use (GiB)", examples=[16.0])
     ]
 
+    spawn: bool = Field(
+        True,
+        title="Spawning allowed",
+        description="Whether the user is allowed to spawn a notebook",
+    )
+
     @property
     def memory_bytes(self) -> int:
         """Maximum memory use in bytes."""

--- a/controller/src/controller/templates/unavailable.html.jinja
+++ b/controller/src/controller/templates/unavailable.html.jinja
@@ -1,0 +1,2 @@
+<h2>Notebooks unavailable</h2>
+<p>Creating a new Nublado notebook is currently unavailable.</p>

--- a/controller/tests/data/base/input/users.json
+++ b/controller/tests/data/base/input/users.json
@@ -5,10 +5,22 @@
     "uid": 1101,
     "gid": 1101,
     "groups": [
-      {"name": "rachel", "id": 1101},
-      {"name": "lunatics", "id": 2028},
-      {"name": "mechanics", "id": 2001},
-      {"name": "storytellers", "id": 2021}
+      {
+        "name": "rachel",
+        "id": 1101
+      },
+      {
+        "name": "lunatics",
+        "id": 2028
+      },
+      {
+        "name": "mechanics",
+        "id": 2001
+      },
+      {
+        "name": "storytellers",
+        "id": 2021
+      }
     ],
     "quota": {
       "notebook": {
@@ -23,9 +35,18 @@
     "uid": 1102,
     "gid": 1102,
     "groups": [
-      {"name": "wrench", "id": 1102},
-      {"name": "jovians", "id": 2010},
-      {"name": "mechanics", "id": 2001}
+      {
+        "name": "wrench",
+        "id": 1102
+      },
+      {
+        "name": "jovians",
+        "id": 2010
+      },
+      {
+        "name": "mechanics",
+        "id": 2001
+      }
     ]
   },
   "token-of-mystery": {
@@ -34,9 +55,18 @@
     "uid": 1103,
     "gid": 1103,
     "groups": [
-      {"name": "violet", "id": 1103},
-      {"name": "saturnians", "id": 2011},
-      {"name": "pirates", "id": 2002}
+      {
+        "name": "violet",
+        "id": 1103
+      },
+      {
+        "name": "saturnians",
+        "id": 2011
+      },
+      {
+        "name": "pirates",
+        "id": 2002
+      }
     ]
   },
   "token-of-stories": {
@@ -45,9 +75,25 @@
     "uid": 1104,
     "gid": 1104,
     "groups": [
-      {"name": "ribbon", "id": 1104},
-      {"name": "ferrymen", "id": 2023},
-      {"name": "ninjas", "id": 2003}
-    ]
+      {
+        "name": "ribbon",
+        "id": 1104
+      },
+      {
+        "name": "ferrymen",
+        "id": 2023
+      },
+      {
+        "name": "ninjas",
+        "id": 2003
+      }
+    ],
+    "quota": {
+      "notebook": {
+        "cpu": 4.0,
+        "memory": 16.0,
+        "spawn": false
+      }
+    }
   }
 }

--- a/controller/tests/data/standard/output/lab-unavailable.html
+++ b/controller/tests/data/standard/output/lab-unavailable.html
@@ -1,0 +1,2 @@
+<h2>Notebooks unavailable</h2>
+<p>Creating a new Nublado notebook is currently unavailable.</p>

--- a/controller/tests/handlers/form_test.py
+++ b/controller/tests/handlers/form_test.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 from controller.models.domain.gafaelfawr import GafaelfawrUser
 
 from ..support.data import read_output_data
+from ..support.gafaelfawr import get_no_spawn_user
 
 
 @pytest.mark.asyncio
@@ -33,3 +34,15 @@ async def test_errors(client: AsyncClient, user: GafaelfawrUser) -> None:
     assert r.json() == {
         "detail": [{"msg": "Permission denied", "type": "permission_denied"}]
     }
+
+
+@pytest.mark.asyncio
+async def test_quota_spawn(client: AsyncClient) -> None:
+    token, user = get_no_spawn_user()
+    r = await client.get(
+        f"/nublado/spawner/v1/lab-form/{user.username}",
+        headers=user.to_headers(),
+    )
+    assert r.status_code == 200
+    expected = read_output_data("standard", "lab-unavailable.html").strip()
+    assert r.text == expected


### PR DESCRIPTION
Gafaelfawr now supports a flag in the user's notebook quota saying whether that user should be allowed to spawn a notebook. Implement support for that flag in the Nublado controller. If it is set to false, return an error message instead of a spawn form, and reject the actual spawn with a 403 error.