### PR TITLE
DM-48576: Suppress some client warnings for async generators

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -52,10 +52,7 @@ Source = "https://github.com/lsst-sqre/nublado"
 "Issue tracker" = "https://github.com/lsst-sqre/nublado/issues"
 
 [build-system]
-requires = [
-    "setuptools>=61",
-    "setuptools_scm[toml]>=6.2"
-]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
@@ -77,7 +74,7 @@ exclude_lines = [
     "raise NotImplementedError",
     "if 0:",
     "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:"
+    "if TYPE_CHECKING:",
 ]
 
 [tool.pytest.ini_options]
@@ -85,7 +82,10 @@ asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     # Bug in aiojobs
-    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning"
+    "ignore:with timeout\\(\\) is deprecated:DeprecationWarning",
+    # Arguably a bug in Python 3.13 with async iterators implemented using
+    # generators
+    "ignore:.*method 'aclose' of 'Response.aiter_lines':RuntimeWarning",
 ]
 # The python_files setting is not for test detection (pytest will pick up any
 # test files named *_test.py without this setting) but to enable special

--- a/client/tests/client/client_test.py
+++ b/client/tests/client/client_test.py
@@ -1,6 +1,7 @@
 """Tests for the NubladoClient object."""
 
 import asyncio
+from contextlib import aclosing
 from pathlib import Path
 
 import pytest
@@ -37,12 +38,13 @@ async def test_hub_flow(
     # Watch the progress meter
     progress = configured_client.watch_spawn_progress()
     progress_pct = -1
-    async with asyncio.timeout(30):
-        async for message in progress:
-            if message.ready:
-                break
-            assert message.progress > progress_pct
-            progress_pct = message.progress
+    async with aclosing(progress):
+        async with asyncio.timeout(30):
+            async for message in progress:
+                if message.ready:
+                    break
+                assert message.progress > progress_pct
+                progress_pct = message.progress
     # Is the lab running?  Should be.
     assert not (await configured_client.is_lab_stopped())
     try:

--- a/client/tests/mock/mock_test.py
+++ b/client/tests/mock/mock_test.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from contextlib import aclosing
 from pathlib import Path
 
 import pytest
@@ -42,12 +43,13 @@ async def test_register_python(
     # Watch the progress meter
     progress = configured_client.watch_spawn_progress()
     progress_pct = -1
-    async with asyncio.timeout(30):
-        async for message in progress:
-            if message.ready:
-                break
-            assert message.progress > progress_pct
-            progress_pct = message.progress
+    async with aclosing(progress):
+        async with asyncio.timeout(30):
+            async for message in progress:
+                if message.ready:
+                    break
+                assert message.progress > progress_pct
+                progress_pct = message.progress
     await configured_client.auth_to_lab()
 
     # Now test our mock
@@ -93,12 +95,13 @@ async def test_register_python_with_notebook(
     # Watch the progress meter
     progress = configured_client.watch_spawn_progress()
     progress_pct = -1
-    async with asyncio.timeout(30):
-        async for message in progress:
-            if message.ready:
-                break
-            assert message.progress > progress_pct
-            progress_pct = message.progress
+    async with aclosing(progress):
+        async with asyncio.timeout(30):
+            async for message in progress:
+                if message.ready:
+                    break
+                assert message.progress > progress_pct
+                progress_pct = message.progress
     await configured_client.auth_to_lab()
 
     # Now test our mock
@@ -139,12 +142,13 @@ async def test_register_extension(
     # Watch the progress meter
     progress = configured_client.watch_spawn_progress()
     progress_pct = -1
-    async with asyncio.timeout(30):
-        async for message in progress:
-            if message.ready:
-                break
-            assert message.progress > progress_pct
-            progress_pct = message.progress
+    async with aclosing(progress):
+        async with asyncio.timeout(30):
+            async for message in progress:
+                if message.ready:
+                    break
+                assert message.progress > progress_pct
+                progress_pct = message.progress
     await configured_client.auth_to_lab()
 
     # Now test our mock


### PR DESCRIPTION
Python 3.13 adds a new warning when the `aclose` method of an async generator is not called explicitly. Async generators should ideally be explicitly shut down with `aclose` when they are no longer in use. Fix typing in some cases where async generators were returned but typed as async iterators (which don't require `aclose`), and close more generators explicitly. Include some async iterators from third party libraries that are actually generators, which requires working around the typing and some future-proofing for API changes.

Ignore the remaining warning that's internal to httpx-sse and can't be fixed at the client level.