### PR TITLE
DM-48546: Merge handling of quota in spawner form

### DIFF
--- a/changelog.d/20250124_115047_rra_DM_48576.md
+++ b/changelog.d/20250124_115047_rra_DM_48576.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Return a spawner form showing only an error rather than an HTTP failure if the user's quota does not allow them to spawn any of the configured notebook sizes.


### PR DESCRIPTION
There were two possible reasons to not allow spawning in the spawner form: the `spawn` flag was set to false, or the user's quota did not allow any of the configured lab sizes. Merge those two cases into one check and use the same spawner error page for both.