### PR TITLE
Fix handling of timeouts in Kubernetes operations

### DIFF
--- a/changelog.d/20250124_163752_rra_DM_48597.md
+++ b/changelog.d/20250124_163752_rra_DM_48597.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- Report Kubernetes operation timeouts properly when they cause a spawn failure rather than throwing an uncaught exception.
+- If retrieving the user's lab `Pod` phase from Kubernetes times out, optimistically assume that the status recorded in memory is correct rather than throwing an uncaught exception. This matches the behavior for Kubernetes API failures.

--- a/controller/src/controller/storage/kubernetes/creator.py
+++ b/controller/src/controller/storage/kubernetes/creator.py
@@ -99,9 +99,10 @@ class KubernetesObjectCreator[T: KubernetesModel]:
         msg = f"Creating {self._kind}"
         self._logger.debug(msg, name=body.metadata.name, namespace=namespace)
         try:
-            await self._create(
-                namespace, body, _request_timeout=timeout.left()
-            )
+            async with timeout.enforce():
+                await self._create(
+                    namespace, body, _request_timeout=timeout.left()
+                )
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error creating object",
@@ -136,9 +137,10 @@ class KubernetesObjectCreator[T: KubernetesModel]:
             Raised for exceptions from the Kubernetes API server.
         """
         try:
-            return await self._read(
-                name, namespace, _request_timeout=timeout.left()
-            )
+            async with timeout.enforce():
+                return await self._read(
+                    name, namespace, _request_timeout=timeout.left()
+                )
         except ApiException as e:
             if e.status == 404:
                 return None

--- a/controller/src/controller/storage/kubernetes/custom.py
+++ b/controller/src/controller/storage/kubernetes/custom.py
@@ -147,14 +147,15 @@ class CustomStorage:
         msg = f"Deleting {self._kind}"
         self._logger.debug(msg, name=name, namespace=namespace)
         try:
-            await self._api.delete_namespaced_custom_object(
-                self._group,
-                self._version,
-                namespace,
-                self._plural,
-                name,
-                _request_timeout=timeout.left(),
-            )
+            async with timeout.enforce():
+                await self._api.delete_namespaced_custom_object(
+                    self._group,
+                    self._version,
+                    namespace,
+                    self._plural,
+                    name,
+                    _request_timeout=timeout.left(),
+                )
         except ApiException as e:
             if e.status == 404:
                 return
@@ -193,13 +194,14 @@ class CustomStorage:
             Raised if the timeout expired.
         """
         try:
-            objs = await self._api.list_namespaced_custom_object(
-                self._group,
-                self._version,
-                namespace,
-                self._plural,
-                _request_timeout=timeout.left(),
-            )
+            async with timeout.enforce():
+                objs = await self._api.list_namespaced_custom_object(
+                    self._group,
+                    self._version,
+                    namespace,
+                    self._plural,
+                    _request_timeout=timeout.left(),
+                )
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error listing objects",
@@ -236,14 +238,15 @@ class CustomStorage:
             Raised if the timeout expired.
         """
         try:
-            return await self._api.get_namespaced_custom_object(
-                self._group,
-                self._version,
-                namespace,
-                self._plural,
-                name,
-                _request_timeout=timeout.left(),
-            )
+            async with timeout.enforce():
+                return await self._api.get_namespaced_custom_object(
+                    self._group,
+                    self._version,
+                    namespace,
+                    self._plural,
+                    name,
+                    _request_timeout=timeout.left(),
+                )
         except ApiException as e:
             if e.status == 404:
                 return None
@@ -342,14 +345,15 @@ class CustomStorage:
         """
         name = body["metadata"]["name"]
         try:
-            await self._api.create_namespaced_custom_object(
-                self._group,
-                self._version,
-                namespace,
-                self._plural,
-                body,
-                _request_timeout=timeout.left(),
-            )
+            async with timeout.enforce():
+                await self._api.create_namespaced_custom_object(
+                    self._group,
+                    self._version,
+                    namespace,
+                    self._plural,
+                    body,
+                    _request_timeout=timeout.left(),
+                )
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error creating object",

--- a/controller/src/controller/storage/kubernetes/deleter.py
+++ b/controller/src/controller/storage/kubernetes/deleter.py
@@ -210,7 +210,8 @@ class KubernetesObjectDeleter[T: KubernetesModel](KubernetesObjectCreator[T]):
             options=extra_args,
         )
         try:
-            await self._delete(name, namespace, body=body, **extra_args)
+            async with timeout.enforce():
+                await self._delete(name, namespace, body=body, **extra_args)
         except ApiException as e:
             if e.status == 404:
                 return
@@ -260,7 +261,8 @@ class KubernetesObjectDeleter[T: KubernetesModel](KubernetesObjectCreator[T]):
         if label_selector:
             extra_args["label_selector"] = label_selector
         try:
-            objs = await self._list(namespace, **extra_args)
+            async with timeout.enforce():
+                objs = await self._list(namespace, **extra_args)
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error listing objects",

--- a/controller/src/controller/storage/kubernetes/ingress.py
+++ b/controller/src/controller/storage/kubernetes/ingress.py
@@ -105,10 +105,11 @@ class IngressStorage(KubernetesObjectDeleter[V1Ingress]):
             logger=self._logger,
         )
         try:
-            async for event in watcher.watch():
-                if event.action != WatchEventType.DELETED:
-                    if ingress_has_ip_address(event.object):
-                        return
+            async with timeout.enforce():
+                async for event in watcher.watch():
+                    if event.action != WatchEventType.DELETED:
+                        if ingress_has_ip_address(event.object):
+                            return
         finally:
             await watcher.close()
 

--- a/controller/src/controller/storage/kubernetes/namespace.py
+++ b/controller/src/controller/storage/kubernetes/namespace.py
@@ -96,8 +96,8 @@ class NamespaceStorage:
                 await self._api.delete_namespace(
                     name, _request_timeout=timeout.left()
                 )
-                if wait:
-                    await self.wait_for_deletion(name, timeout)
+            if wait:
+                await self.wait_for_deletion(name, timeout)
         except ApiException as e:
             if e.status == 404:
                 return
@@ -126,9 +126,10 @@ class NamespaceStorage:
             Raised if the timeout expired.
         """
         try:
-            objs = await self._api.list_namespace(
-                _request_timeout=timeout.left()
-            )
+            async with timeout.enforce():
+                objs = await self._api.list_namespace(
+                    _request_timeout=timeout.left()
+                )
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error listing namespaces", e, kind="Namespace"
@@ -158,9 +159,10 @@ class NamespaceStorage:
             Raised if the timeout expired.
         """
         try:
-            return await self._api.read_namespace(
-                name, _request_timeout=timeout.left()
-            )
+            async with timeout.enforce():
+                return await self._api.read_namespace(
+                    name, _request_timeout=timeout.left()
+                )
         except ApiException as e:
             if e.status == 404:
                 return None
@@ -239,9 +241,10 @@ class NamespaceStorage:
             Raised if the timeout expired.
         """
         try:
-            await self._api.create_namespace(
-                body, _request_timeout=timeout.left()
-            )
+            async with timeout.enforce():
+                await self._api.create_namespace(
+                    body, _request_timeout=timeout.left()
+                )
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error creating namespace",


### PR DESCRIPTION
When load testing Nublado, the controller raised uncaught exceptions and returned HTTP 500 errors to JupyterHub due to Kubernetes operation timeouts. This happened because the timeout parameter on the Kubernetes API call caused `TimeoutError` to be raised, but the Kubernetes storage layer was not translating that into the corresponding internal `ControllerTimeoutError` exception that would be caught and handled.

Wrap all Kubernetes API operations in `Timeout.enforce`, which will translate the `TimeoutError` exceptions properly so that they can be handled.

Catch `ControllerTimeoutError` exceptionsn when getting the lab status and optimistically return the current in-memory state, matching the behavior when we receive Kubernetes API errors when checking the lab state. JupyterHub makes this call constantly and we don't want to fail the lab due to some transient timeout that will later recover.`