### PR TITLE
DM-48696: Add metrics events

### DIFF
--- a/changelog.d/20250131_164517_rra_DM_48696.md
+++ b/changelog.d/20250131_164517_rra_DM_48696.md
@@ -1,0 +1,3 @@
+### New features
+
+- Log metrics events in the Nublado controller for lab spawn successes and failures and a count of the number of active labs.

--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -24,6 +24,7 @@ from pydantic import (
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
+from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 from safir.pydantic import HumanTimedelta
 
 from .constants import (
@@ -1142,6 +1143,12 @@ class Config(BaseSettings):
             ),
         ),
     ] = METADATA_PATH
+
+    metrics: MetricsConfiguration = Field(
+        default_factory=metrics_configuration_factory,
+        title="Metrics configuration",
+        description="Configuration for reporting metrics to Kafka",
+    )
 
     name: Annotated[
         str,

--- a/controller/src/controller/events.py
+++ b/controller/src/controller/events.py
@@ -1,0 +1,114 @@
+"""Metrics events for the Nublado controller."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from pydantic import Field
+from safir.dependencies.metrics import EventMaker
+from safir.metrics import EventManager, EventPayload
+
+__all__ = [
+    "ActiveLabsEvent",
+    "LabEvents",
+    "LabMetadata",
+    "SpawnFailureEvent",
+    "SpawnSuccessEvent",
+]
+
+
+class ActiveLabsEvent(EventPayload):
+    """Current count of the number of active labs.
+
+    Notes
+    -----
+    This is really a gauge metric that is measured periodically, not an event.
+    For now, the Nublado controller uses the event system to log this metric,
+    since that's the system we have in place. If we later have a proper
+    metrics system for storing measurements, this event should move to that
+    system.
+    """
+
+    count: int = Field(
+        ...,
+        title="Active labs",
+        description="Number of currently-running labs",
+    )
+
+
+class LabMetadata(EventPayload):
+    """Common lab metadata for events."""
+
+    image: str = Field(
+        ...,
+        title="Lab image",
+        description="Docker reference for the lab image",
+    )
+
+    cpu_limit: float = Field(
+        ...,
+        title="Lab CPU limit",
+        description="Kubernetes pod limit of CPU equivalents",
+    )
+
+    memory_limit: int = Field(
+        ...,
+        title="Lab memory limit",
+        description="Kubernetes pod limit of memory in bytes",
+    )
+
+
+class SpawnFailureEvent(LabMetadata):
+    """A lab spawn failed."""
+
+    username: str = Field(
+        ..., title="Username", description="User who attempted to spawn a lab"
+    )
+
+    elapsed: timedelta = Field(
+        ...,
+        title="Duration of spawn attempt",
+        description="How long the spawn took before it failed",
+    )
+
+
+class SpawnSuccessEvent(LabMetadata):
+    """A lab spawn succeeded."""
+
+    username: str = Field(
+        ..., title="Username", description="User who spawned a lab"
+    )
+
+    elapsed: timedelta = Field(
+        ...,
+        title="Duration of spawn",
+        description=(
+            "How long the spawn took before Kubernetes resources were ready."
+            " This does not include the startup time of the lab itself."
+        ),
+    )
+
+
+class LabEvents(EventMaker):
+    """Event publishers for Nublado controller events about labs.
+
+    Attributes
+    ----------
+    active
+        Event publisher for the number of active labs.
+    spawn_failure
+        Event publisher for lab spawn failures.
+    spawn_success
+        Event publisher for lab spawn successes.
+    """
+
+    async def initialize(self, manager: EventManager) -> None:
+        self.active = await manager.create_publisher(
+            "active_labs", ActiveLabsEvent
+        )
+        self.spawn_failure = await manager.create_publisher(
+            "spawn_failure", SpawnFailureEvent
+        )
+        self.spawn_success = await manager.create_publisher(
+            "spawn_success", SpawnSuccessEvent
+        )

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -16,6 +16,7 @@ from structlog.stdlib import BoundLogger
 
 from .background import BackgroundTaskManager
 from .config import Config
+from .events import LabEvents
 from .exceptions import NotConfiguredError
 from .models.v1.prepuller import DockerSourceOptions, GARSourceOptions
 from .services.builder.fileserver import FileserverBuilder
@@ -163,12 +164,17 @@ class ProcessContext:
             slack_client=slack_client,
             logger=logger,
         )
+        event_manager = config.metrics.make_manager()
+        await event_manager.initialize()
+        lab_events = LabEvents()
+        await lab_events.initialize(event_manager)
         lab_manager = LabManager(
             config=config.lab,
             image_service=image_service,
             lab_builder=LabBuilder(config.lab, config.base_url, logger),
             metadata_storage=metadata_storage,
             lab_storage=LabStorage(kubernetes_client, logger),
+            events=lab_events,
             slack_client=slack_client,
             logger=logger,
         )

--- a/controller/tests/conftest.py
+++ b/controller/tests/conftest.py
@@ -34,6 +34,13 @@ from .support.gafaelfawr import MockGafaelfawr, register_mock_gafaelfawr
 from .support.gar import MockArtifactRegistry, patch_artifact_registry
 
 
+@pytest.fixture(autouse=True)
+def _mock_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("METRICS_APPLICATION", "controller")
+    monkeypatch.setenv("METRICS_ENABLED", "false")
+    monkeypatch.setenv("METRICS_MOCK", "true")
+
+
 @pytest_asyncio.fixture
 async def config() -> Config:
     """Construct default configuration for tests."""

--- a/controller/tests/services/lab_test.py
+++ b/controller/tests/services/lab_test.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 
 import pytest
 from kubernetes_asyncio.client import ApiException
+from safir.metrics import MockEventPublisher
 from safir.testing.kubernetes import MockKubernetesApi
 
 from controller.config import Config
@@ -132,6 +133,11 @@ async def test_reconcile(
     state = await factory.lab_manager.get_lab_state(user.username)
     assert state
     assert state.model_dump() == expected.model_dump()
+
+    # We should have logged a metric saying there's one active lab.
+    lab_events = factory._context.lab_manager._events
+    assert isinstance(lab_events.active, MockEventPublisher)
+    lab_events.active.published.assert_published_all([{"count": 1}])
 
 
 @pytest.mark.asyncio

--- a/docs/dev/api/controller.rst
+++ b/docs/dev/api/controller.rst
@@ -24,6 +24,9 @@ This documentation therefore exists only to assist developers and code analysis 
 .. automodapi:: controller.dependencies.user
    :include-all-objects:
 
+.. automodapi:: controller.events
+   :include-all-objects:
+
 .. automodapi:: controller.exceptions
    :include-all-objects:
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -24,11 +24,13 @@ extensions = [
 nitpicky = true
 nitpick_ignore = [
     # Ignore missing cross-references for modules that don't provide
-    # intersphinx.  The documentation itself should use double-quotes instead
+    # intersphinx. The documentation itself should use double-quotes instead
     # of single-quotes to not generate a reference, but automatic references
-    # are generated from the type signatures and can't be avoided.  These are
+    # are generated from the type signatures and can't be avoided. These are
     # intentionally listed specifically because I've caught documentation bugs
     # by having Sphinx complain about a new symbol.
+    ["py:class", "dataclasses_avroschema.pydantic.main.AvroBaseModel"],
+    ["py:class", "dataclasses_avroschema.main.AvroModel"],
     ["py:class", "fastapi.applications.FastAPI"],
     ["py:class", "fastapi.datastructures.DefaultPlaceholder"],
     ["py:class", "fastapi.exceptions.HTTPException"],


### PR DESCRIPTION
Add metrics events for spawn successes, spawn failures, and the count of active, running labs. The spawn success and failure events include the username, Docker image reference, CPU limit, memory limit, and elapsed time. We may want to add more fields later.

The active lab count is logged via the background reconcile task.