### PR TITLE
DM-48714: Do not query Kubernetes for pod status

### DIFF
--- a/changelog.d/20250124_163752_rra_DM_48597.md
+++ b/changelog.d/20250124_163752_rra_DM_48597.md
@@ -1,4 +1,3 @@
 ### Bug fixes
 
 - Report Kubernetes operation timeouts properly when they cause a spawn failure rather than throwing an uncaught exception.
-- If retrieving the user's lab `Pod` phase from Kubernetes times out, optimistically assume that the status recorded in memory is correct rather than throwing an uncaught exception. This matches the behavior for Kubernetes API failures.

--- a/changelog.d/20250203_163705_rra_DM_48714.md
+++ b/changelog.d/20250203_163705_rra_DM_48714.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Do not query Kubernetes for pod status when responding to status requests, and instead assume the internal state (which is reconciled periodically) is correct. The constant Kubernetes API requests for `Pod` status seemed to be overwhelming the control plane when there were a lot of pods running. Continue to ask Kubernetes directly immediately before spawn.

--- a/controller/tests/services/lab_test.py
+++ b/controller/tests/services/lab_test.py
@@ -199,14 +199,14 @@ async def test_reconcile_succeeded(
     mock_kubernetes.initial_pod_phase = PodPhase.SUCCEEDED.value
     await factory.start_background_services()
 
-    # Create a lab through the controller. It should show up in a terminated
-    # state.
+    # Create a lab through the controller. It should show up as active since
+    # we don't detect immediately that it terminated.
     lab = read_input_lab_specification_json("base", "lab-specification")
     await factory.lab_manager.create_lab(user, lab)
     await asyncio.sleep(0.1)
     state = await factory.lab_manager.get_lab_state(user.username)
     assert state
-    assert state.status == LabStatus.TERMINATED
+    assert state.status == LabStatus.RUNNING
     assert await mock_kubernetes.read_namespace(f"userlabs-{user.username}")
 
     # Now stop and start background services to force another run. The


### PR DESCRIPTION
Do not query Kubernetes for pod status when responding to status requests, and instead assume the internal state (which is reconciled periodically) is correct. The constant Kubernetes API requests for `Pod` status seemed to be overwhelming the control plane when there were a lot of pods running. Continue to ask Kubernetes directly immediately before spawn.