### PR TITLE
DM-48760: Handle timeout exceptions when listing nodes

### DIFF
--- a/controller/src/controller/storage/kubernetes/node.py
+++ b/controller/src/controller/storage/kubernetes/node.py
@@ -134,9 +134,10 @@ class NodeStorage:
         if node_selector:
             selector = ",".join(f"{k}={v}" for k, v in node_selector.items())
         try:
-            nodes = await self._api.list_node(
-                label_selector=selector, _request_timeout=timeout.left()
-            )
+            async with timeout.enforce():
+                nodes = await self._api.list_node(
+                    label_selector=selector, _request_timeout=timeout.left()
+                )
         except ApiException as e:
             raise KubernetesError.from_exception(
                 "Error reading node information", e, kind="Node"


### PR DESCRIPTION
If the Kubernetes control plane is overwhelmed, the Kubernetes API call to list nodes can time out. Rewrite that timeout error into the internal timeout exception so that it will be reported properly in Slack.