### PR TITLE
DM-48761: Add tolerations to prepuller pods

### DIFF
--- a/changelog.d/20250203_172358_rra_DM_48761.md
+++ b/changelog.d/20250203_172358_rra_DM_48761.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add tolerations to prepuller pods as well as lab and file server pods so that images can be prepulled to tainted nodes.

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -156,6 +156,7 @@ class ProcessContext:
         prepuller = Prepuller(
             image_service=image_service,
             prepuller_builder=PrepullerBuilder(
+                config=config.lab,
                 metadata_storage=metadata_storage,
                 pull_secret=config.lab.pull_secret,
             ),

--- a/controller/tests/data/standard/output/prepull-conflict-objects.json
+++ b/controller/tests/data/standard/output/prepull-conflict-objects.json
@@ -45,7 +45,20 @@
         }
       ],
       "nodeName": "node2",
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "tolerations": [
+        {
+          "effect": "NoSchedule",
+          "key": "some-toleration",
+          "operator": "Equal",
+          "tolerationSeconds": 60,
+          "value": "some-value"
+        },
+        {
+          "key": "other-toleration",
+          "operator": "Exists"
+        }
+      ]
     },
     "status": {
       "phase": "Running"

--- a/controller/tests/data/standard/output/prepull-objects.json
+++ b/controller/tests/data/standard/output/prepull-objects.json
@@ -43,7 +43,20 @@
 	{ "name": "pull-secret" }
       ],
       "nodeName": "node2",
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "tolerations": [
+        {
+          "effect": "NoSchedule",
+          "key": "some-toleration",
+          "operator": "Equal",
+          "tolerationSeconds": 60,
+          "value": "some-value"
+        },
+        {
+          "key": "other-toleration",
+          "operator": "Exists"
+        }
+      ]
     },
     "status": {
       "phase": "Running"


### PR DESCRIPTION
When Nublado was configured to add tolerations to lab pods, those tolerations were not also applied to prepuller pods. This meant that prepuller pods were never run if the node pool targeted by Nublado was tainted, such as when using a node pool restricted to only Nublado labs. Add the tolerations to prepuller pods as well.