### PR TITLE
DM-48714: Reconcile labs every five minutes

### DIFF
--- a/controller/src/controller/constants.py
+++ b/controller/src/controller/constants.py
@@ -69,7 +69,7 @@ the control plane is nonresponsive.
 JUPYTERLAB_DIR = "/usr/local/share/jupyterlab"
 """Location where our RSP Jupyterlab configuration is rooted."""
 
-LAB_RECONCILE_INTERVAL = timedelta(minutes=60)
+LAB_RECONCILE_INTERVAL = timedelta(minutes=5)
 """How frequently to refresh user lab state from Kubernetes.
 
 This will detect when user labs disappear out from under us without user


### PR DESCRIPTION
Now that we're no longer querying the lab status every time JupyterHub asks, background state reconciliation is more critical. Increase its frequency to every five minutes instead of once an hour and see if we can get away with that.