### PR TITLE
DM-48838: Remove the spawner connection pool limit

### DIFF
--- a/changelog.d/20250207_131615_rra_DM_48838.md
+++ b/changelog.d/20250207_131615_rra_DM_48838.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Remove the limit on the connection pool used to contact the Nublado controller from the JupyterHub spawner, since otherwise JupyterHub stops being able to do any work once the connections waiting for spawn progress exhaust the connect pool.


### PR DESCRIPTION
Remove the limit on the connection pool used to contact the Nublado controller from the JupyterHub spawner, since otherwise JupyterHub stops being able to do any work once the connections waiting for spawn progress exhaust the connect pool.