### PR TITLE
DM-48838: Remove Kubernetes connection pool limit

### DIFF
--- a/changelog.d/20250207_142337_rra_DM_48838.md
+++ b/changelog.d/20250207_142337_rra_DM_48838.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Remove the limit on the Kubernetes client connection pool in the Nublado controller. This will allow the controller to scale to more than 100 (the default) simultaneous watches.

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -9,7 +9,7 @@ from typing import Self
 
 import structlog
 from httpx import AsyncClient
-from kubernetes_asyncio.client.api_client import ApiClient
+from kubernetes_asyncio.client.api_client import ApiClient, Configuration
 from safir.dependencies.http_client import http_client_dependency
 from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
@@ -95,7 +95,11 @@ class ProcessContext:
             Shared context for a lab controller process.
         """
         http_client = await http_client_dependency()
-        kubernetes_client = ApiClient()
+
+        # Disable the connection pool limits in kubernetes-asyncio.
+        kubernetes_configuration = Configuration()
+        kubernetes_configuration.connection_pool_maxsize = 0
+        kubernetes_client = ApiClient(configuration=kubernetes_configuration)
 
         # This logger is used only by process-global singletons.  Everything
         # else will use a per-request logger that includes more context about


### PR DESCRIPTION
Remove the limit on the Kubernetes client connection pool in the Nublado controller. This will allow the controller to scale to more than 100 (the default) simultaneous watches.