### PR TITLE
DM-48838: Fix state tracking when deleting completed labs

### DIFF
--- a/changelog.d/20250207_153034_rra_DM_48838.md
+++ b/changelog.d/20250207_153034_rra_DM_48838.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix unsafe data structure manipulation when deleting completed labs in the Nublado controller background reconciliation thread.

--- a/controller/src/controller/services/lab.py
+++ b/controller/src/controller/services/lab.py
@@ -720,7 +720,8 @@ class LabManager:
         state are no longer running and should be garbage-collected, as long
         as the user hasn't already started a new operation on that lab.
         """
-        for username, lab in self._labs.items():
+        all_labs = list(self._labs.items())
+        for username, lab in all_labs:
             if lab.state and not lab.state.is_running:
                 if not lab.monitor.in_progress:
                     with contextlib.suppress(UnknownUserError):


### PR DESCRIPTION
The Nublado controller background reconciliation thread looks for labs that are no longer running and cleans up their resources. This loop was calling an async function in the middle of the loop over all labs, which meant that the dictionary over which it was looping could be changed by a different task in the middle of the loop. Instead, capture the current state first and loop over a snapshot of the lab to lab state mapping.