### PR TITLE
DM-48838: Prepare 8.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-8.4.1'></a>
+## 8.4.1 (2025-02-12)
+
+### Bug fixes
+
+- Wait for the default service account of the user's lab namespace to be created before creating the `Pod` object. Creation of the service account can be slow when Kubernetes is busy, and creation of the `Pod` object will fail if the service account does not exist.
+- Remove the limit on the connection pool used to contact the Nublado controller from the JupyterHub spawner, since otherwise JupyterHub stops being able to do any work once the connections waiting for spawn progress exhaust the connect pool.
+- Remove the limit on the Kubernetes client connection pool in the Nublado controller. This will allow the controller to scale to more than 100 (the default) simultaneous watches.
+- Remove the limit on the connection pool used to look up users in Gafaelfawr and query a Docker image repository.
+- Fix unsafe data structure manipulation when deleting completed labs in the Nublado controller background reconciliation thread.
+
 <a id='changelog-8.4.0'></a>
 ## 8.4.0 (2025-02-04)
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -15,7 +15,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.13.1-slim-bookworm AS base-image
+FROM python:3.13.2-slim-bookworm AS base-image
 
 # Update system packages
 COPY controller/scripts/install-base-packages.sh .

--- a/Dockerfile.inithome
+++ b/Dockerfile.inithome
@@ -21,7 +21,7 @@
 #   - Sets up the entrypoint.
 
 # This is just an alias to avoid repeating the base image.
-FROM python:3.13.1-slim-bookworm AS base-image
+FROM python:3.13.2-slim-bookworm AS base-image
 
 FROM base-image AS install-image
 

--- a/changelog.d/20250207_131615_rra_DM_48838.md
+++ b/changelog.d/20250207_131615_rra_DM_48838.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Remove the limit on the connection pool used to contact the Nublado controller from the JupyterHub spawner, since otherwise JupyterHub stops being able to do any work once the connections waiting for spawn progress exhaust the connect pool.

--- a/changelog.d/20250207_142337_rra_DM_48838.md
+++ b/changelog.d/20250207_142337_rra_DM_48838.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Remove the limit on the Kubernetes client connection pool in the Nublado controller. This will allow the controller to scale to more than 100 (the default) simultaneous watches.

--- a/changelog.d/20250207_153034_rra_DM_48838.md
+++ b/changelog.d/20250207_153034_rra_DM_48838.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Fix unsafe data structure manipulation when deleting completed labs in the Nublado controller background reconciliation thread.

--- a/changelog.d/20250211_112354_rra_DM_48838.md
+++ b/changelog.d/20250211_112354_rra_DM_48838.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Wait for the default service account of the user's lab namespace to be created before creating the `Pod` object. Creation of the service account can be slow when Kubernetes is busy, and creation of the `Pod` object will fail if the service account does not exist.

--- a/changelog.d/20250211_163247_rra_DM_48838.md
+++ b/changelog.d/20250211_163247_rra_DM_48838.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Relax the limit on the connection pool used to look up users in Gafaelfawr and query a Docker image repository.

--- a/controller/requirements/dev.txt
+++ b/controller/requirements/dev.txt
@@ -693,9 +693,9 @@ myst-nb==1.2.0 \
     --hash=sha256:0e09909877848c0cf45e1aecee97481512efa29a0c4caa37870a03bba11c56c1 \
     --hash=sha256:af459ec753b341952182b45b0a80b4776cebf80c9ee6aaca2a3f4027b440c9de
     # via documenteer
-myst-parser==4.0.0 \
-    --hash=sha256:851c9dfb44e36e56d15d05e72f02b80da21a9e0d07cba96baf5e2d476bb91531 \
-    --hash=sha256:b9317997552424448c6096c2558872fdb6f81d3ecb3a40ce84a7518798f3f28d
+myst-parser==4.0.1 \
+    --hash=sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4 \
+    --hash=sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d
     # via
     #   documenteer
     #   myst-nb

--- a/controller/requirements/main.txt
+++ b/controller/requirements/main.txt
@@ -1344,9 +1344,9 @@ semver==3.0.4 \
     --hash=sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746 \
     --hash=sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602
     # via controller (controller/pyproject.toml)
-sentry-sdk==2.20.0 \
-    --hash=sha256:afa82713a92facf847df3c6f63cec71eb488d826a50965def3d7722aa6f0fdab \
-    --hash=sha256:c359a1edf950eb5e80cffd7d9111f3dbeef57994cb4415df37d39fda2cf22364
+sentry-sdk==2.21.0 \
+    --hash=sha256:7623cfa9e2c8150948a81ca253b8e2bfe4ce0b96ab12f8cd78e3ac9c490fd92f \
+    --hash=sha256:a6d38e0fb35edda191acf80b188ec713c863aaa5ad8d5798decb8671d02077b6
     # via safir
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -97,7 +97,7 @@ class ProcessContext:
         http_client = AsyncClient(timeout=20, limits=limits)
 
         # Disable the connection pool limits in kubernetes-asyncio.
-        kubernetes_configuration = Configuration()
+        kubernetes_configuration = Configuration.get_default_copy()
         kubernetes_configuration.connection_pool_maxsize = 0
         kubernetes_client = ApiClient(configuration=kubernetes_configuration)
 


### PR DESCRIPTION
Collect the change log for the 8.4.1 release. Update Python dependencies. Bump the minor version of Python used to construct the controller and inithome containers.