### PR TITLE
DM-48977: Fix client testing documentation

### DIFF
--- a/docs/client/index.rst
+++ b/docs/client/index.rst
@@ -249,7 +249,6 @@ This yields:
     1: Hello, World!
     2: Goodbye, World!
 
-
 .. _mocks-and-testing:
 
 Mocks and Testing
@@ -323,10 +322,9 @@ It depends on two other fixtures: ``environment_url`` is a string, representing 
         ) -> AsyncGenerator[MockJupyterWebSocket, None]:
             yield mock_jupyter_websocket(url, extra_headers, jupyter_mock)
 
-        with patch(websockets, "connect") as mock:
+        with patch.object(websockets, "connect") as mock:
             mock.side_effect = mock_connect
             yield jupyter_mock
-
 
 Once you've done all that, all you will need to do is supply the test
 fixture ``jupyter`` to your unit tests along with a client to communicate with it.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,11 @@ For the official Rubin images, see sciplat-lab_.
    admin/index
 
 .. toctree::
+   :maxdepth: 2
+
+   client/index
+
+.. toctree::
 
    api
 
@@ -34,11 +39,6 @@ For the official Rubin images, see sciplat-lab_.
    :hidden:
 
    changelog
-
-.. toctree::
-   :maxdepth: 2
-
-   client/index
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Fix the code example for mocking the client to use the correct mock for `websockets.connect`. Move the client documentation in the table of contents before the API and change log.