### PR TITLE
DM-49032: 8.4 backport: - fix another `websockets` >=14 breaking change

### DIFF
--- a/changelog.d/20250219_115241_danfuchs_DM_49032.md
+++ b/changelog.d/20250219_115241_danfuchs_DM_49032.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix `TypeError create_connection() got an unexpected keyword argument 'extra_headers'` exception when trying to establish websocket connections. Version 14 of [websockets](https://websockets.readthedocs.io/en/stable/) [changed the signature of the `connect` method](https://websockets.readthedocs.io/en/stable/howto/upgrade.html#extra-headers-additional-headers).

--- a/client/src/rubin/nublado/client/nubladoclient.py
+++ b/client/src/rubin/nublado/client/nubladoclient.py
@@ -287,7 +287,7 @@ class JupyterLabSession:
         try:
             self._socket_manager = websockets.connect(
                 self._url_for_websocket(url),
-                extra_headers=headers,
+                additional_headers=headers,
                 open_timeout=WEBSOCKET_OPEN_TIMEOUT,
                 max_size=self._max_websocket_size,
             )

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -88,11 +88,11 @@ def jupyter(
     @asynccontextmanager
     async def mock_connect(
         url: str,
-        extra_headers: dict[str, str],
+        additional_headers: dict[str, str],
         max_size: int | None,
         open_timeout: int,
     ) -> AsyncIterator[MockJupyterWebSocket]:
-        yield mock_jupyter_websocket(url, extra_headers, jupyter_mock)
+        yield mock_jupyter_websocket(url, additional_headers, jupyter_mock)
 
     with patch.object(websockets, "connect") as mock:
         mock.side_effect = mock_connect


### PR DESCRIPTION
Version 14 of `websockets` [changed the signature of the `connect` method](https://websockets.readthedocs.io/en/stable/howto/upgrade.html#extra-headers-additional-headers)

Without this, Mobu breaks with:
```
TypeError
create_connection() got an unexpected keyword argument 'extra_headers'
```

With this change, mobu is able to use the nublado client to execute notebooks again (tested locally).