### PR TITLE
Bump safir upper bound now that 10.0.0 is released

### DIFF
--- a/changelog.d/20250224_201855_danfuchs.md
+++ b/changelog.d/20250224_201855_danfuchs.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Other changes
+
+- Nublado client: raise upper bound on safir dependency to `<11`.

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pydantic>2,<3",
     "pydantic-settings<3",
     "pyyaml<7",
-    "safir<10",
+    "safir<11",
     "structlog",
     "websockets>=14,<16",
 ]


### PR DESCRIPTION
The breaking change with Safir `10` is that Python 3.11 is no longer supported.