### PR TITLE
DM-49191: Skip to next message if Exception is raised in run_python

### DIFF
--- a/client/src/rubin/nublado/client/nubladoclient.py
+++ b/client/src/rubin/nublado/client/nubladoclient.py
@@ -419,6 +419,7 @@ class JupyterLabSession:
                         error = f"{type(e).__name__}: {e!s}"
                         msg = "Ignoring unparsable web socket message"
                         self._logger.warning(msg, error=error, message=message)
+                        continue
 
                     # Accumulate the results if they are of interest, and exit
                     # and return the results if this message indicated the end


### PR DESCRIPTION
This is related to the Sentry error here:
https://rubin-observatory.sentry.io/issues/6323642042/?project=-1&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=4

Exception was raised in `DC2_catalog_access` notebook and the `run_python` method of `nubladoclient`, but output is not set in this case so we got an **UnboundLocalError**:
`cannot access local variable 'output' where it is not associated with a value`

Fix in PR is just to skip to next message when catching an Exception