### PR TITLE
DM-49493: Annotate the mock client fixture

### DIFF
--- a/client/src/rubin/nublado/client/nubladoclient.py
+++ b/client/src/rubin/nublado/client/nubladoclient.py
@@ -1212,7 +1212,6 @@ class NubladoClient:
         JupyterHub rejects all requests with errors about invalid XSRF cookies
         and the client can never recover. Recreating the pool ensures the
         cookie jar is cleared and we receive fresh cookies.
-
         """
         self._hub_xsrf = None
         self._client = AsyncClient(

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -70,7 +70,7 @@ def test_user() -> User:
     return User(username=username, token=mock_token)
 
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(ids=["shared", "subdomain"], params=[False, True])
 def jupyter(
     respx_mock: respx.Router,
     environment_url: str,


### PR DESCRIPTION
Add `ids` to the parameterized Nublado mock client fixture in the client tests for better test name reporting.