### PR TITLE
DM-49493: Set allowOptions in ingress for file server

### DIFF
--- a/changelog.d/20250314_151626_rra_DM_49493.md
+++ b/changelog.d/20250314_151626_rra_DM_49493.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add `config.allowOptions` to the `GafaelfawrIngress` for file servers so that the server will work correctly with Gafaelfawr 13.0.0 and later.

--- a/controller/src/controller/services/builder/fileserver.py
+++ b/controller/src/controller/services/builder/fileserver.py
@@ -201,9 +201,9 @@ class FileserverBuilder:
             "kind": "GafaelfawrIngress",
             "metadata": metadata,
             "config": {
+                "allowOptions": True,
                 "authType": "basic",
                 "baseUrl": self._base_url,
-                "loginRedirect": False,
                 "scopes": {"all": ["exec:notebook"]},
                 "service": "nublado-files",
                 "username": username,

--- a/controller/tests/data/fileserver/output/fileserver-objects.json
+++ b/controller/tests/data/fileserver/output/fileserver-objects.json
@@ -429,9 +429,9 @@
       "namespace": "fileservers"
     },
     "config": {
+      "allowOptions": true,
       "authType": "basic",
       "baseUrl": "http://127.0.0.1:8080",
-      "loginRedirect": false,
       "scopes": {
         "all": [
           "exec:notebook"


### PR DESCRIPTION
Add `config.allowOptions` to the `GafaelfawrIngress` for file servers so that the server will work correctly with Gafaelfawr 13.0.0 and later.