### PR TITLE
DM-49558: Fix NetworkPolicy for user labs

### DIFF
--- a/changelog.d/20250318_164842_rra_DM_49558.md
+++ b/changelog.d/20250318_164842_rra_DM_49558.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix the `NetworkPolicy` created for user labs so that it actually restricts access to only JupyterHub and its proxy as was intended.

--- a/changelog.d/20250318_164842_rra_DM_49558.md
+++ b/changelog.d/20250318_164842_rra_DM_49558.md
@@ -1,3 +1,3 @@
 ### Bug fixes
 
-- Fix the `NetworkPolicy` created for user labs so that it actually restricts access to only JupyterHub and its proxy as was intended.
+- Fix the `NetworkPolicy` created for user labs so that it actually restricts access to only JupyterHub, its proxy, and the lab itself as was intended.

--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -26,6 +26,7 @@ from kubernetes_asyncio.client import (
     V1Namespace,
     V1NetworkPolicy,
     V1NetworkPolicyIngressRule,
+    V1NetworkPolicyPeer,
     V1NetworkPolicyPort,
     V1NetworkPolicySpec,
     V1ObjectFieldSelector,
@@ -421,11 +422,19 @@ class LabBuilder:
             spec=V1NetworkPolicySpec(
                 policy_types=["Ingress"],
                 pod_selector=V1LabelSelector(
-                    match_labels={"app": "jupyterhub", "component": "hub"}
+                    match_labels={"nublado.lsst.io/category": "lab"}
                 ),
                 ingress=[
                     V1NetworkPolicyIngressRule(
-                        ports=[V1NetworkPolicyPort(port=8888)]
+                        _from=[
+                            V1NetworkPolicyPeer(
+                                namespace_selector=V1LabelSelector(),
+                                pod_selector=V1LabelSelector(
+                                    match_labels={"app": "jupyterhub"}
+                                ),
+                            )
+                        ],
+                        ports=[V1NetworkPolicyPort(port=8888)],
                     ),
                 ],
             ),

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -121,6 +121,16 @@
     "spec": {
       "ingress": [
         {
+          "from": [
+            {
+              "namespaceSelector": {},
+              "podSelector": {
+                "matchLabels": {
+                  "app": "jupyterhub"
+                }
+              }
+            }
+          ],
           "ports": [
             {
               "port": 8888
@@ -130,8 +140,7 @@
       ],
       "podSelector": {
         "matchLabels": {
-          "app": "jupyterhub",
-          "component": "hub"
+          "nublado.lsst.io/category": "lab"
         }
       },
       "policyTypes": [

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -123,6 +123,14 @@
         {
           "from": [
             {
+              "namespaceSelector": {
+                "matchLabels": {
+                  "nublado.lsst.io/category": "lab",
+                  "nublado.lsst.io/user": "rachel"
+                }
+              }
+            },
+            {
               "namespaceSelector": {},
               "podSelector": {
                 "matchLabels": {
@@ -140,7 +148,8 @@
       ],
       "podSelector": {
         "matchLabels": {
-          "nublado.lsst.io/category": "lab"
+          "nublado.lsst.io/category": "lab",
+          "nublado.lsst.io/user": "rachel"
         }
       },
       "policyTypes": [


### PR DESCRIPTION
The `NetworkPolicy` created for labs essentially did nothing: it tried to match JupyterHub or its proxy, which don't exist in the user namespace, and then created an ingress rule with no restrictions.

Fix the `NetworkPolicy` to behave as intended: Apply rules to the user lab and restrict access to only applications that are part of JupyterHub.