### PR TITLE
DM-49624: Add configuration option for JupyterHub logout URL

### DIFF
--- a/authenticator/src/rubin/nublado/authenticator/_internals.py
+++ b/authenticator/src/rubin/nublado/authenticator/_internals.py
@@ -11,6 +11,7 @@ from jupyterhub.user import User
 from jupyterhub.utils import url_path_join
 from tornado.httputil import HTTPHeaders
 from tornado.web import HTTPError, RequestHandler
+from traitlets import Unicode
 
 type AuthInfo = dict[str, str | dict[str, str]]
 type Route = tuple[str, type[BaseHandler]]
@@ -45,7 +46,8 @@ class _GafaelfawrLogoutHandler(LogoutHandler):
         return True
 
     async def render_logout_page(self) -> None:
-        self.redirect("/logout", permanent=False)
+        url = self.authenticator.after_logout_redirect
+        self.redirect(url, permanent=False)
 
 
 class _GafaelfawrLoginHandler(BaseHandler):
@@ -125,6 +127,15 @@ class GafaelfawrAuthenticator(Authenticator):
     a few extra redirects is a small price to pay for staying within the
     supported and expected interface.
     """
+
+    after_logout_redirect = Unicode(
+        "/logout",
+        help="""
+        URL to redirect to after a JupyterHub logout.
+
+        This should point to the Gafaelfawr logout endpoint.
+        """,
+    ).tag(config=True)
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/changelog.d/20250321_115048_rra_DM_49624.md
+++ b/changelog.d/20250321_115048_rra_DM_49624.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add a configuration setting for where to redirect the user after logout from JupyterHub. When user subdomains are in use, this needs to point to `/logout` at the base URL for the Science Platform, not `/logout` at the current hostname, which may be the JupyterHub hostname and thus create an infinite redirect loop.


### PR DESCRIPTION
In the JupyterHub authenticator, once the user logs out, we want to redirect them to the Gafaelfawr logout handler. This previously was done with a relative redirect to `/logout`. This fails with per-user subdomains, since this redirect may be to the JupyterHub hostname, which will then redirect back to the JupyterHub logout URL and create an infinite redirect loop. Add a configuration option to the authenticator that we can set in Phalanx to the URL of the Gafaelfawr logout route.