### PR TITLE
DM-49644: Start the event watcher before object creation

### DIFF
--- a/changelog.d/20250321_175028_rra_DM_49644.md
+++ b/changelog.d/20250321_175028_rra_DM_49644.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- During user lab creation, start the event watcher before creating the Kubernetes objects so that we can show the user events as they happened instead of in bulk once the pod has been created.

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -104,7 +104,7 @@ class ProcessContext:
         # This logger is used only by process-global singletons.  Everything
         # else will use a per-request logger that includes more context about
         # the request (such as the authenticated username).
-        logger = structlog.get_logger(__name__)
+        logger = structlog.get_logger("controller")
 
         slack_client = None
         if config.slack_webhook:

--- a/controller/src/controller/services/lab.py
+++ b/controller/src/controller/services/lab.py
@@ -1214,7 +1214,7 @@ class LabManager:
         """
         name = names.pod
         namespace = names.namespace
-        iterator = self._storage.watch_pod_events(name, namespace, timeout)
+        iterator = self._storage.watch_events(name, namespace, timeout)
         progress = 35
         try:
             async for msg in iterator:

--- a/controller/src/controller/storage/kubernetes/lab.py
+++ b/controller/src/controller/storage/kubernetes/lab.py
@@ -343,7 +343,7 @@ class LabStorage:
             timeout=timeout,
         )
 
-    async def watch_pod_events(
+    async def watch_events(
         self, name: str, namespace: str, timeout: Timeout
     ) -> AsyncIterator[str]:
         """Monitor the startup of a pod.
@@ -372,5 +372,5 @@ class LabStorage:
         TimeoutError
             Raised if the timeout expires.
         """
-        async for msg in self._pod.events_for_pod(name, namespace, timeout):
+        async for msg in self._namespace.events(namespace, timeout):
             yield msg

--- a/controller/src/controller/storage/kubernetes/lab.py
+++ b/controller/src/controller/storage/kubernetes/lab.py
@@ -73,9 +73,10 @@ class LabStorage:
         ------
         KubernetesError
             Raised if there is some failure in a Kubernetes API call.
+        TimeoutError
+            Raised if the lab object creation took longer than the timeout.
         """
         namespace = objects.namespace.metadata.name
-        await self._namespace.create(objects.namespace, timeout)
         for pvc in objects.pvcs:
             await self._pvc.create(namespace, pvc, timeout)
         await self._config_map.create(
@@ -99,6 +100,27 @@ class LabStorage:
             "default", namespace, timeout
         )
         await self._pod.create(namespace, objects.pod, timeout)
+
+    async def create_namespace(
+        self, objects: LabObjects, timeout: Timeout
+    ) -> None:
+        """Create the namespace for a user lab.
+
+        Parameters
+        ----------
+        objects
+            Lab objects.
+        timeout
+            Timeout on operation.
+
+        Raises
+        ------
+        KubernetesError
+            Raised if there is some failure in a Kubernetes API call.
+        TimeoutError
+            Raised if the namespace creation took longer than the timeout.
+        """
+        await self._namespace.create(objects.namespace, timeout)
 
     async def delete_namespace(self, name: str, timeout: Timeout) -> None:
         """Delete a namespace, waiting for deletion to finish.

--- a/controller/src/controller/storage/kubernetes/pod.py
+++ b/controller/src/controller/storage/kubernetes/pod.py
@@ -187,9 +187,11 @@ class PodStorage(KubernetesObjectDeleter[V1Pod]):
         # phase.
         pod = await self.read(name, namespace, timeout)
         if pod is None:
+            logger.debug("Cannot read status of pod (does not exist)")
             return None
         phase = PodPhase(pod.status.phase)
         if phase not in until_not:
+            logger.debug("Pod phase already %s", phase.value)
             return phase
 
         # The pod is not in a terminal phase. Start the watch and wait for it

--- a/controller/tests/services/lab_test.py
+++ b/controller/tests/services/lab_test.py
@@ -90,6 +90,7 @@ async def create_lab(
         user=user, lab=lab, image=image, secrets={}
     )
     timeout = Timeout("Creating lab", config.lab.spawn_timeout, user.username)
+    await lab_storage.create_namespace(objects, timeout)
     await lab_storage.create(objects, timeout)
 
     phase = PodPhase(mock_kubernetes.initial_pod_phase)


### PR DESCRIPTION
When creating a user's lab, start the event watcher immediately after creating the namespace and before creating any other objects. This will hopefully allow us to show the user more events as they happen instead of only displaying them in bulk after the pod has been created.