### PR TITLE
DM-49644: Fix the logger name in the Nublado controller

### DIFF
--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -104,7 +104,7 @@ class ProcessContext:
         # This logger is used only by process-global singletons.  Everything
         # else will use a per-request logger that includes more context about
         # the request (such as the authenticated username).
-        logger = structlog.get_logger(__name__)
+        logger = structlog.get_logger("controller")
 
         slack_client = None
         if config.slack_webhook:


### PR DESCRIPTION
When creating a stand-alone factory in the Nublado controller, use `controller` as the name of the logger instead of `controller.factory`. This makes a little more sense.