### PR TITLE
DM-49662: Use configured delete timeout for invalid labs

### DIFF
--- a/changelog.d/20250324_105714_rra_DM_49662.md
+++ b/changelog.d/20250324_105714_rra_DM_49662.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Use the configured delete timeout when deleting invalid labs instead of a hard-coded 30s timeout.

--- a/controller/src/controller/services/lab.py
+++ b/controller/src/controller/services/lab.py
@@ -771,7 +771,7 @@ class LabManager:
             elif not lab or not lab.modified_since(cutoff):
                 msg = "Deleting incomplete namespace"
                 self._logger.warning(msg, user=username, namespace=namespace)
-                timeout = Timeout(msg, KUBERNETES_REQUEST_TIMEOUT)
+                timeout = Timeout(msg, self._config.delete_timeout)
                 await self._storage.delete_namespace(namespace, timeout)
         return observed
 


### PR DESCRIPTION
When cleaning up invalid labs found during state reconciliation, use the configured delete timeout instead of the Kubernetes request timeout.