### PR TITLE
DM-49662: Support setting JUPYTERHUB_ACTIVITY_INTERVAL

### DIFF
--- a/changelog.d/20250324_174634_rra_DM_49662.md
+++ b/changelog.d/20250324_174634_rra_DM_49662.md
@@ -1,0 +1,3 @@
+### New features
+
+- Support setting the interval for activity reporting from JupyterLab in the Nubaldo controller configuration.

--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -751,6 +751,16 @@ class LabConfig(BaseModel):
         alias_generator=to_camel, extra="forbid", populate_by_name=True
     )
 
+    activity_interval: Annotated[
+        HumanTimedelta,
+        Field(
+            title="Activity reporting interval",
+            description=(
+                "How frequently the lab should report activity to JupyterHub"
+            ),
+        ),
+    ] = timedelta(hours=1)
+
     application: Annotated[
         str | None,
         Field(

--- a/controller/src/controller/services/builder/lab.py
+++ b/controller/src/controller/services/builder/lab.py
@@ -325,6 +325,7 @@ class LabBuilder:
 
         # Add standard environment variables.
         size = self._config.get_size_definition(lab.options.size)
+        activity = str(int(self._config.activity_interval.total_seconds()))
         resources = size.to_lab_resources()
         env.update(
             {
@@ -342,6 +343,8 @@ class LabBuilder:
                 "CPU_LIMIT": str(resources.limits.cpu),
                 "MEM_GUARANTEE": str(resources.requests.memory),
                 "MEM_LIMIT": str(resources.limits.memory),
+                # Activity reporting interval.
+                "JUPYTERHUB_ACTIVITY_INTERVAL": activity,
                 # Used by code running in the lab to find other services.
                 "EXTERNAL_INSTANCE_URL": self._base_url,
                 # Information about where our Lab config, runtime-info

--- a/controller/tests/data/standard/input/config.yaml
+++ b/controller/tests/data/standard/input/config.yaml
@@ -1,6 +1,7 @@
 logLevel: DEBUG
 profile: development
 lab:
+  activityInterval: 2h
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/controller/tests/data/standard/output/lab-objects.json
+++ b/controller/tests/data/standard/output/lab-objects.json
@@ -3,6 +3,7 @@
     "apiVersion": "v1",
     "data": {
       "CONTAINER_SIZE": "Small (1.0 CPU, 3Gi RAM)",
+      "JUPYTERHUB_ACTIVITY_INTERVAL": "7200",
       "JUPYTERHUB_SERVICE_PREFIX": "/nb/user/rachel/",
       "JUPYTERLAB_CONFIG_DIR": "/opt/lsst/software/jupyterlab",
       "JUPYTERLAB_START_COMMAND": "/opt/lsst/software/jupyterlab/runlab.sh",


### PR DESCRIPTION
Add a new Nublado controller setting (`lab.activityInterval`) that controls `JUPYTERHUB_ACTIVITY_INTERVAL` in the lab environment. This should be read by JupyterHub and used to configure how frequently user activity is reported back to JupyterHub.