### PR TITLE
DM-49735: Add do not upload markers to non-PyPI packages

### DIFF
--- a/authenticator/pyproject.toml
+++ b/authenticator/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Private :: Do Not Upload",
     "Typing :: Typed",
 ]
 requires-python = ">=3.12"

--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Private :: Do Not Upload",
     "Typing :: Typed",
 ]
 requires-python = ">=3.13"

--- a/inithome/pyproject.toml
+++ b/inithome/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Private :: Do Not Upload",
     "Typing :: Typed",
 ]
 requires-python = ">=3.13"

--- a/spawner/pyproject.toml
+++ b/spawner/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Private :: Do Not Upload",
     "Typing :: Typed",
 ]
 requires-python = ">=3.12"


### PR DESCRIPTION
Some defense in depth against mistakes where we might upload packages that are not meant to be published on PyPI.