### PR TITLE
DM-49735: Use released lsst-sqre/build-and-publish-to-pypi

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,7 +293,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Test building and publishing rubin-nublado-client
-        uses: lsst-sqre/build-and-publish-to-pypi@tickets/DM-49735
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
           upload: "false"
           working-directory: "client"
@@ -316,6 +316,6 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: lsst-sqre/build-and-publish-to-pypi@tickets/DM-49735
+      - uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
           working-directory: "client"

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -156,7 +156,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Test building and publishing rubin-nublado-client
-        uses: lsst-sqre/build-and-publish-to-pypi@tickets/DM-49735
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
         with:
           upload: "false"
           working-directory: "client"


### PR DESCRIPTION
Now that v3 of lsst-sqre/build-and-publish-to-pypi has been released, update the GitHub Actions workflows to reference it.