### PR TITLE
DM-49774: Push inithome containers to Google

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,6 +237,32 @@ jobs:
           image: ${{ github.repository }}-inithome
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Google Artifact Repository
+        uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: "_json_key_base64"
+          password: ${{ secrets.GAR_PUSH_TOKEN }}
+
+      - name: Docker meta
+        id: inithome-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            us-central1-docker.pkg.dev/rubin-shared-services-71ec/sciplat/inithome
+          tags: |
+            type=raw,${{ steps.build-inithome.outputs.tag }}
+
+      - name: Build and push inithome to GAR
+        uses: docker/build-push-action@v6
+        with:
+          context: "."
+          file: Dockerfile.inithome
+          push: "true"
+          tags: ${{ steps.inithome-meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Report result
         run: |
           echo Pushed ghcr.io/${{ github.repository }}-inithome:${{ steps.build-inithome.outputs.tag }}

--- a/changelog.d/20250328_150749_rra_DM_49774.md
+++ b/changelog.d/20250328_150749_rra_DM_49774.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Push inithome containers to Google as well as GitHub since GitHub has a low rate limit on anonymous API requests.


### PR DESCRIPTION
GitHub is rate-limiting fetches of the inithome container during scaling tests. Also push it to Google so that we can hopefully get the benefit of a higher rate limit.