### PR TITLE
DM-51529: Add debugging for file server reconciliation

### DIFF
--- a/controller/src/controller/services/fileserver.py
+++ b/controller/src/controller/services/fileserver.py
@@ -231,8 +231,12 @@ class FileserverManager:
                 last_modified = self._servers[username].last_modified
                 if last_modified > start:
                     continue
-            msg = "Removing broken fileserver for user"
-            self._logger.warning(msg, user=username)
+            if username in to_delete:
+                msg = "Removing broken fileserver for user"
+                self._logger.warning(msg, user=username)
+            else:
+                msg = "No file server job for user, removing remnants"
+                self._logger.warning(msg, user=username)
             await self.delete(username)
         for username in invalid:
             if username in self._servers:

--- a/controller/src/controller/storage/kubernetes/fileserver.py
+++ b/controller/src/controller/storage/kubernetes/fileserver.py
@@ -178,6 +178,12 @@ class FileserverStorage:
         """
         search = "nublado.lsst.io/category=fileserver"
         jobs = await self._job.list(namespace, timeout, label_selector=search)
+        self._logger.debug(
+            f"Listed fileserver jobs matching {search}",
+            namespace=namespace,
+            names=[j.metadata.name for j in jobs],
+            count=len(jobs),
+        )
 
         # For each job, figure out the corresponding username from labels and
         # retrieve the additional objects we care about.
@@ -185,6 +191,12 @@ class FileserverStorage:
         for job in jobs:
             username = job.metadata.labels.get("nublado.lsst.io/user")
             if not username:
+                self._logger.warning(
+                    "File server job has no user set",
+                    namespace=namespace,
+                    name=job.metadata.name,
+                    labels=job.metadata.labels,
+                )
                 continue
 
             # Check if we already saw a Job for this user, and if so, complain


### PR DESCRIPTION
Log more details when retrieving the list of running file servers, since we seem to be missing file servers we should be finding. Distinguish between the invalid file server case and the case where we didn't detect a file server that we expected to be running.