### PR TITLE
DM-51529: Add config options for refresh intervals

### DIFF
--- a/changelog.d/20250624_162631_rra_DM_51529a.md
+++ b/changelog.d/20250624_162631_rra_DM_51529a.md
@@ -1,0 +1,5 @@
+### New features
+
+- Add `controller.config.fileserver.reconcileInterval` configuration option to control the frequency with which file server state is reconciled with Kubernetes.
+- Add `controller.config.lab.reconcileInterval` configuration option to control the frequency with which lab state is reconciled with Kubernetes.
+- Add `controller.config.images.refreshInterval` configuration option to control how often the image source is checked for new images and the Kubernetes nodes are checked for the list of cached images.

--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -458,6 +458,14 @@ class EnabledFileserverConfig(FileserverConfig):
         ),
     ] = {}
 
+    reconcile_interval: Annotated[
+        HumanTimedelta,
+        Field(
+            title="Reconcile interval",
+            description="How often to reconcile file state against Kubernetes",
+        ),
+    ] = timedelta(minutes=60)
+
     resources: Annotated[
         LabResources | None,
         Field(
@@ -953,6 +961,19 @@ class LabConfig(BaseModel):
             ),
         ),
     ] = None
+
+    reconcile_interval: Annotated[
+        HumanTimedelta,
+        Field(
+            title="Reconcile interval",
+            description=(
+                "How often to reconcile lab state gainst Kubernetes. Consider"
+                " doing this more frequently than for file servers since,"
+                " unlike with file servers, we cannot use a Kubernetes watch"
+                " to monitor for user pod changes."
+            ),
+        ),
+    ] = timedelta(minutes=5)
 
     runtime_mounts_dir: Annotated[
         str,

--- a/controller/src/controller/constants.py
+++ b/controller/src/controller/constants.py
@@ -8,12 +8,9 @@ __all__ = [
     "CONFIGURATION_PATH",
     "DOCKER_CREDENTIALS_PATH",
     "DROPDOWN_SENTINEL_VALUE",
-    "FILE_SERVER_RECONCILE_INTERVAL",
     "GROUPNAME_REGEX",
-    "IMAGE_REFRESH_INTERVAL",
     "KUBERNETES_NAME_PATTERN",
     "KUBERNETES_REQUEST_TIMEOUT",
-    "LAB_RECONCILE_INTERVAL",
     "LIMIT_TO_REQUEST_RATIO",
     "MEMORY_TO_TMP_SIZE_RATIO",
     "METADATA_PATH",
@@ -44,16 +41,6 @@ DOCKER_CREDENTIALS_PATH = Path("/etc/secrets/.dockerconfigjson")
 DROPDOWN_SENTINEL_VALUE = "use_image_from_dropdown"
 """Used in the lab form for ``image_list`` when ``image_dropdown`` is used."""
 
-FILE_SERVER_RECONCILE_INTERVAL = timedelta(minutes=60)
-"""How frequently to refresh file server state from Kubernetes.
-
-This will detect when file servers disappear out from under us, such as being
-terminated by Kubernetes node replacements or upgrades.
-"""
-
-IMAGE_REFRESH_INTERVAL = timedelta(minutes=5)
-"""How frequently to refresh the list of remote and cached images."""
-
 KUBERNETES_NAME_PATTERN = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
 """Pattern matching valid Kubernetes names."""
 
@@ -68,14 +55,6 @@ the control plane is nonresponsive.
 
 JUPYTERLAB_DIR = "/usr/local/share/jupyterlab"
 """Location where our RSP Jupyterlab configuration is rooted."""
-
-LAB_RECONCILE_INTERVAL = timedelta(minutes=5)
-"""How frequently to refresh user lab state from Kubernetes.
-
-This will detect when user labs disappear out from under us without user
-action, such as labs being terminated by Kubernetes node replacements or
-upgrades.
-"""
 
 LAB_STOP_GRACE_PERIOD = timedelta(seconds=1)
 """How long to wait for a lab to shut down before SIGKILL.

--- a/controller/src/controller/factory.py
+++ b/controller/src/controller/factory.py
@@ -196,6 +196,7 @@ class ProcessContext:
             lab_manager=lab_manager,
             _fileserver_manager=fileserver_manager,
             background=BackgroundTaskManager(
+                config=config,
                 image_service=image_service,
                 prepuller=prepuller,
                 lab_manager=lab_manager,

--- a/controller/src/controller/models/v1/prepuller.py
+++ b/controller/src/controller/models/v1/prepuller.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from typing import Annotated, Literal, Self
 
 from pydantic import BaseModel, Field
+from safir.pydantic import HumanTimedelta
 
 from ...constants import DOCKER_CREDENTIALS_PATH
 from ..domain.rspimage import RSPImage
@@ -158,6 +160,17 @@ class PrepullerOptions(BaseModel):
     source: Annotated[
         DockerSourceOptions | GARSourceOptions, Field(title="Source of images")
     ]
+
+    refresh_interval: Annotated[
+        HumanTimedelta,
+        Field(
+            title="Image refresh interval",
+            description=(
+                "How frequently to refresh the list of remote and cached"
+                " images"
+            ),
+        ),
+    ] = timedelta(minutes=5)
 
     recommended_tag: Annotated[
         str,

--- a/controller/tests/data/prepuller/output/status.json
+++ b/controller/tests/data/prepuller/output/status.json
@@ -5,6 +5,7 @@
       "registry": "lighthouse.ceres",
       "repository": "library/sketchbook"
     },
+    "refresh_interval": 300.0,
     "recommended_tag": "recommended",
     "num_releases": 1,
     "num_weeklies": 2,

--- a/controller/tests/data/standard/output/prepulls.json
+++ b/controller/tests/data/standard/output/prepulls.json
@@ -5,6 +5,7 @@
       "repository": "library/sketchbook",
       "type": "docker"
     },
+    "refresh_interval": 300.0,
     "recommended_tag": "recommended",
     "num_releases": 1,
     "num_weeklies": 2,

--- a/controller/tests/handlers/files_test.py
+++ b/controller/tests/handlers/files_test.py
@@ -139,7 +139,7 @@ async def test_cleanup_on_pod_exit(
 
     # On a regular cluster, the fileserver takes a timeout as an argument and
     # exits after it's been idle that long. Simulate this by finding the pod
-    # and telling it to exit.
+    # and changing its status to indicate it exited.
     pods = await mock_kubernetes.list_namespaced_pod(
         namespace, label_selector=f"job-name={username}-fs"
     )

--- a/docs/admin/config/fileserver.rst
+++ b/docs/admin/config/fileserver.rst
@@ -64,6 +64,12 @@ Kubernetes
     Resource limits and requests for user file server pods.
     The defaults are chosen based on observed metrics from Google Kubernetes Engine.
 
+``controller.config.fileserver.reconcileInterval``
+    How frequently to reconcile file server state with Kubernetes.
+    This will detect when file servers or their supporting Kubernetes resources disappear unexpectedly, such as by manual deletions.
+    This can be safely set to a long interval since normal file server pod terminations should be caught by a separate Kubernetes watch.
+    The default is one hour.
+
 None of the following are set by default.
 They can be used to add additional Kubernetes configuration to all lab pods if, for example, you want them to run on specific nodes or tag them with annotations that have some external meaning for your environment.
 

--- a/docs/admin/config/images.rst
+++ b/docs/admin/config/images.rst
@@ -95,6 +95,12 @@ All other available images are collected into a drop-down list with a caution th
 
 See :sqr:`059` for the definition of release, weekly, and daily images.
 
+The frequency with which the image source is checked for new images and the Kubernetes nodes are checked for what images they have cached is controlled by the following setting.
+
+``controller.config.images.refreshInterval``
+    How frequently to refresh the list of remote and cached images.
+    The default is five minutes.
+
 What images to prepull and display as radio button selections are controlled by the following settings.
 
 ``controller.config.images.recommendedTag``

--- a/docs/admin/config/lab.rst
+++ b/docs/admin/config/lab.rst
@@ -340,6 +340,11 @@ Kubernetes
 
     See `the Phalanx documentation <https://phalanx.lsst.io/admin/update-pull-secret.html>`__ for more details about managing a pull secret in Phalanx.
 
+``controller.config.lab.reconcileInterval``
+    How frequently to reconcile lab state with Kubernetes.
+    This will detect when user labs disappear without user action, such as when they are terminated by Kubernetes node replacement or upgrades.
+    The default is five minutes.
+
 None of the following are set by default.
 They can be used to add additional Kubernetes configuration to all lab pods if, for example, you want them to run on specific nodes or tag them with annotations that have some external meaning for your environment.
 


### PR DESCRIPTION
Move the constants that controlled the refresh interval for image sources and node image caches and the reconcile intervals for file servers and labs into configuration options. This allows reducing the intervals when debugging and more easily overriding the intervals in the test suite.