### PR TITLE
DM-51556: Allow configuring the default lab size

### DIFF
--- a/changelog.d/20250625_151618_rra_DM_51556.md
+++ b/changelog.d/20250625_151618_rra_DM_51556.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new `controller.config.lab.defaultSize` configuration option that determines the default lab size in the spawner menu. If not set, or set to a lab size the user does not have sufficient quota to spawn, the default continues to be the first size the user is allowed to spawn.

--- a/controller/src/controller/config.py
+++ b/controller/src/controller/config.py
@@ -785,6 +785,15 @@ class LabConfig(BaseModel):
         ),
     ] = None
 
+    default_size: Annotated[
+        LabSize | None,
+        Field(
+            title="Default lab size",
+            description="If not given, the first size will be the default",
+            examples=[LabSize.LARGE],
+        ),
+    ] = None
+
     delete_timeout: Annotated[
         HumanTimedelta,
         Field(
@@ -1098,6 +1107,15 @@ class LabConfig(BaseModel):
                 raise ValueError(f"Duplicate lab size {definition.size.value}")
             seen.add(definition.size)
         return v
+
+    @model_validator(mode="after")
+    def _validate_default_size(self) -> Self:
+        if self.default_size is None:
+            return self
+        for size in self.sizes:
+            if size.size == self.default_size:
+                return self
+        raise ValueError(f"Default size {self.default_size!s} not defined")
 
     @model_validator(mode="after")
     def _validate_volumes(self) -> Self:

--- a/controller/src/controller/handlers/form.py
+++ b/controller/src/controller/handlers/form.py
@@ -56,6 +56,16 @@ async def get_user_lab_form(
     else:
         sizes = config.lab.sizes
 
+    # Determine the default size.
+    default_size = None
+    if config.lab.default_size:
+        for size in sizes:
+            if size.size == config.lab.default_size:
+                default_size = config.lab.default_size
+                break
+    if not default_size:
+        default_size = sizes[0].size
+
     # Construct and return the spawner form.
     return templates.TemplateResponse(
         context.request,
@@ -65,5 +75,6 @@ async def get_user_lab_form(
             "cached_images": images.menu,
             "all_images": images.dropdown,
             "sizes": sizes,
+            "default_size": default_size,
         },
     )

--- a/controller/src/controller/templates/spawner.html.jinja
+++ b/controller/src/controller/templates/spawner.html.jinja
@@ -42,7 +42,7 @@ function selectDropdown() {
 <td width="50%">
   <div class="radio radio-inline">
 {%- for definition in sizes %}
-    <input type="radio" name="size" id="{{ definition.size.value }}" value="{{ definition.size.value }}"{% if loop.first %} checked{% endif %}>
+    <input type="radio" name="size" id="{{ definition.size.value }}" value="{{ definition.size.value }}"{% if definition.size == default_size %} checked{% endif %}>
     <label for="{{ definition.size.value }}">
       {{ definition }}
     </label><br />

--- a/controller/tests/data/sizes/input/config.yaml
+++ b/controller/tests/data/sizes/input/config.yaml
@@ -1,0 +1,20 @@
+logLevel: DEBUG
+lab:
+  namespacePrefix: userlabs
+  defaultSize: large
+  sizes:
+    - size: small
+      cpu: 1.0
+      memory: 3Gi
+    - size: large
+      cpu: 9.0
+      memory: 27Gi
+images:
+  source:
+    type: docker
+    registry: lighthouse.ceres
+    repository: library/sketchbook
+  recommendedTag: recommended
+  numReleases: 1
+  numWeeklies: 2
+  numDailies: 3

--- a/controller/tests/data/sizes/output/lab-form.html
+++ b/controller/tests/data/sizes/output/lab-form.html
@@ -1,0 +1,70 @@
+<script>
+function selectDropdown() {
+  document.getElementById('use_image_from_dropdown').checked = true;
+}
+</script>
+<style>
+  td {
+    border: 1px solid black;
+    padding: 2%;
+    vertical-align: top;
+  }
+  .radio label,
+  .checkbox label {
+    padding-left: 0px;
+  }
+</style>
+<table width="100%">
+<tr>
+  <th>Image</th>
+  <th>Options</th>
+</tr>
+<tr>
+<td width="50%">
+  <div class="radio radio-inline">
+    <input type="radio" name="image_list" id="image1" value="lighthouse.ceres/library/sketchbook:recommended@sha256:5678" checked>
+    <label for="image1">Recommended (Weekly 2077_43)</label><br />
+
+    <input type="radio" name="image_list" id="use_image_from_dropdown" value="use_image_from_dropdown">
+    <label for="use_image_from_dropdown">
+      Select uncached image (slower start):
+    </label><br />
+
+    <select name="image_dropdown" onchange="selectDropdown()">
+      <option value="lighthouse.ceres/library/sketchbook:recommended@sha256:5678">Recommended (Weekly 2077_43)</option>
+      <option value="lighthouse.ceres/library/sketchbook:w_2077_43@sha256:5678">Weekly 2077_43</option>
+      <option value="lighthouse.ceres/library/sketchbook:d_2077_10_23@sha256:1234">Daily 2077_10_23</option>
+      <option value="lighthouse.ceres/library/sketchbook:latest_weekly">latest_weekly</option>
+      <option value="lighthouse.ceres/library/sketchbook:latest_daily">latest_daily</option>
+    </select>
+  </div>
+</td>
+<td width="50%">
+  <div class="radio radio-inline">
+    <input type="radio" name="size" id="small" value="small">
+    <label for="small">
+      Small (1.0 CPU, 3Gi RAM)
+    </label><br />
+    <input type="radio" name="size" id="large" value="large" checked>
+    <label for="large">
+      Large (9.0 CPU, 27Gi RAM)
+    </label><br />
+  </div>
+  <br />
+  <br />
+  <div class="checkbox checkbox-inline">
+    <label for="enable_debug">
+      <input type="checkbox" id="enable_debug"
+       name="enable_debug" value="true">
+      Enable debug logs
+    </label><br />
+    <label for="reset_user_env">
+      <input type="checkbox" id="reset_user_env"
+       name="reset_user_env" value="true">
+      Reset user environment: relocate .cache, .conda, .eups, .jupyter,
+      .local, and .user_setups
+    </label><br />
+  </div>
+</td>
+</tr>
+</table>

--- a/controller/tests/handlers/form_test.py
+++ b/controller/tests/handlers/form_test.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 
 from controller.models.domain.gafaelfawr import GafaelfawrUser
 
+from ..support.config import configure
 from ..support.data import read_output_data
 from ..support.gafaelfawr import get_no_spawn_user
 
@@ -21,6 +22,18 @@ async def test_lab_form(client: AsyncClient, user: GafaelfawrUser) -> None:
     assert r.headers["Content-Type"] == "text/html; charset=utf-8"
 
     expected = read_output_data("standard", "lab-form.html").strip()
+    assert r.text == expected
+
+
+@pytest.mark.asyncio
+async def test_default_size(client: AsyncClient, user: GafaelfawrUser) -> None:
+    await configure("sizes")
+    r = await client.get(
+        f"/nublado/spawner/v1/lab-form/{user.username}",
+        headers=user.to_headers(),
+    )
+    assert r.status_code == 200
+    expected = read_output_data("sizes", "lab-form.html").strip()
     assert r.text == expected
 
 

--- a/docs/admin/config/lab.rst
+++ b/docs/admin/config/lab.rst
@@ -294,7 +294,7 @@ See the `Kubernetes documentation <https://kubernetes.io/docs/concepts/configura
 ``controller.config.lab.sizes``
     The list of available lab sizes from which the user can choose.
     If the user has a notebook quota set (see `quota settings in Gafaelfawr <https://gafaelfawr.lsst.io/user-guide/helm.html#quotas>`__), only sizes that fit within that quota will be shown.
-    The order in which the sizes are listed will be preserved in the menu, and the first size listed will be the default.
+    The order in which the sizes are listed will be preserved in the menu.
 
     The default setting defines three sizes: ``small`` with 1 CPU unit and 4GiB of memory, ``medium`` with 2 CPU units and 8GiB of memory, and ``large`` with 4 CPU units and 16GiB of memory.
 
@@ -315,6 +315,11 @@ See the `Kubernetes documentation <https://kubernetes.io/docs/concepts/configura
 
     The ``cpu`` and ``memory`` for a given lab size define the Kubernetes limits.
     The Kubernetes requests are automatically set to 25% of the limits.
+
+``controller.config.lab.defaultSize``
+    The default size.
+    This is the size that will be selected by default on the spawner form.
+    If this is not set, or if it is set to a size that the user does not have sufficient quota to spawn, the first listed size the user is allowed to spawn will be the default.
 
 .. _config-lab-kubernetes:
 


### PR DESCRIPTION
Add a new `controller.config.lab.defaultSize` configuration option that sets the default lab size explicitly. If it is not set, or is set to a size the user's quota does not allow them to spawn, the default remains the first-listed size that the user's quota allows them to spawn.