### PR TITLE
Fix URL to WebDAV documentation

### DIFF
--- a/changelog.d/20250731_132550_rra_webdav_link.md
+++ b/changelog.d/20250731_132550_rra_webdav_link.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix the link to the WebDAV documentation in the HTML page returned after a user's file server was started.

--- a/controller/src/controller/templates/fileserver.html.jinja
+++ b/controller/src/controller/templates/fileserver.html.jinja
@@ -14,7 +14,7 @@ Connect your WebDAV client to this server with:
 <li><strong>Password:</strong> A security token with <tt>write:files</tt> scope.
 </ul>
 
-Consult <a href="https://rsp.lsst.io/guides/api/index.html#webdav">the RSP WebDAV docs</a> for more detailed instructions.
+Consult <a href="https://rsp.lsst.io/guides/webdav/index.html">the RSP WebDAV docs</a> for more detailed instructions.
 
 </body>
 </html>

--- a/controller/tests/data/fileserver/output/fileserver.html
+++ b/controller/tests/data/fileserver/output/fileserver.html
@@ -14,7 +14,7 @@ Connect your WebDAV client to this server with:
 <li><strong>Password:</strong> A security token with <tt>write:files</tt> scope.
 </ul>
 
-Consult <a href="https://rsp.lsst.io/guides/api/index.html#webdav">the RSP WebDAV docs</a> for more detailed instructions.
+Consult <a href="https://rsp.lsst.io/guides/webdav/index.html">the RSP WebDAV docs</a> for more detailed instructions.
 
 </body>
 </html>


### PR DESCRIPTION
Fix the URL to the WebDAV documentation included in the HTML page returned after the user's file server was started.