### PR TITLE
DM-52090: Bump safir max version

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pydantic>2,<3",
     "pydantic-settings<3",
     "pyyaml<7",
-    "safir<12",
+    "safir<13",
     "structlog",
     "websockets>=14,<16",
 ]


### PR DESCRIPTION
Safir 12.0.0 was just released, and is compatible with the Nublado client without any changes. Bump the max version so that apps that need Safir 12.0.0 and the client can resolve their deps.