### PR TITLE
DM-52391: client - Instrument exceptions with Sentry metadata

### DIFF
--- a/changelog.d/20250917_155425_danfuchs_HEAD.md
+++ b/changelog.d/20250917_155425_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### New features
+
+- client: Instrument exceptions with Sentry metadata


### PR DESCRIPTION
Override the new `to_sentry` method on Slack exceptions:
https://safir.lsst.io/user-guide/sentry.html#special-sentry-exceptions