### PR TITLE
DM-52657: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,15 @@ repos:
       - id: check-yaml
       - id: trailing-whitespace
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.8.22
+    hooks:
+      - id: uv-lock
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
@@ -18,5 +23,5 @@ repos:
     rev: 1.20.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.10.0]
-        args: [-l, '79', -t, py312]
+        additional_dependencies: [black==25.9.0]
+        args: [-l, '79', -t, py313]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ typing = [
 
 [tool.black]
 line-length = 79
-target-version = ["py312"]
+target-version = ["py313"]
 
 [tool.mypy]
 disallow_untyped_defs = true


### PR DESCRIPTION
Add the uv-lock pre-commit hook now that the project is using `uv.lock` files. Fix the legacy name of the `ruff-check` hook. Update the version of black used by blacken-docs.