### PR TITLE
DM-52657: Update Docker images to latest Debian release

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.13.7-slim-bookworm AS base-image
+FROM python:3.13.7-slim-trixie AS base-image
 
 # Update system packages.
 COPY scripts/update-os-packages.sh .

--- a/Dockerfile.fsadmin
+++ b/Dockerfile.fsadmin
@@ -1,4 +1,4 @@
-FROM python:3.13.7-slim-bookworm
+FROM python:3.13.7-slim-trixie
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:0.7.15 /uv /bin/uv
 

--- a/Dockerfile.inithome
+++ b/Dockerfile.inithome
@@ -21,7 +21,7 @@
 #   - Sets up the entrypoint and port.
 
 # This is just an alias to avoid repeating the base image.
-FROM python:3.13.7-slim-bookworm AS base-image
+FROM python:3.13.7-slim-trixie AS base-image
 
 # Update system packages.
 COPY scripts/update-os-packages.sh .

--- a/Dockerfile.purger
+++ b/Dockerfile.purger
@@ -16,7 +16,7 @@
 # The purger will typically run as root. Its job is to use its privilege
 # to clean up after people who did not clean up after themselves.
 
-FROM python:3.13.7-slim-bookworm AS base-image
+FROM python:3.13.7-slim-trixie AS base-image
 
 # Update system packages.
 COPY scripts/update-os-packages.sh .


### PR DESCRIPTION
Update the base image for all of the Docker containers that use Debian to the latest Debian stable release.