### PR TITLE
DM-52657: Fix username logging in the controller

### DIFF
--- a/changelog.d/20250930_111702_rra_DM_52657a.md
+++ b/changelog.d/20250930_111702_rra_DM_52657a.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Always use `user` for the username in logging contexts, and include username in more log messages.


### PR DESCRIPTION
Fix a couple of places where usernames were logged in the field `username` instead of `user`, and many more places where the username was not included in the log context.