### PR TITLE
DM-52657: Fix Docker build for controller

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 ENV UV_LINK_MODE=copy
 
 # Install the dependencies.
-WORKDIR /app
+WORKDIR /app/controller
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=controller/uv.lock,target=uv.lock \
     --mount=type=bind,source=controller/pyproject.toml,target=pyproject.toml \
@@ -46,9 +46,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Install the application itself.
 ADD . /app
-WORKDIR /app/controller
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-editable --compile-bytecode
+    uv sync --frozen --no-editable --no-default-groups --compile-bytecode
 
 FROM base-image AS runtime-image
 
@@ -56,7 +55,7 @@ FROM base-image AS runtime-image
 RUN useradd --create-home appuser
 
 # Copy the virtualenv.
-COPY --from=install-image /app/.venv /app/.venv
+COPY --from=install-image /app/controller/.venv /app/controller/.venv
 
 # Switch to the non-root user.
 USER appuser
@@ -66,7 +65,7 @@ EXPOSE 8080
 
 # Make sure we use the virtualenv.
 WORKDIR /app
-ENV PATH="/app/.venv/bin:$PATH"
+ENV PATH="/app/controller/.venv/bin:$PATH"
 
 # Run the application.
 CMD ["uvicorn", "--factory", "controller.main:create_app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
The Docker build for the Nublado controller had some confusion between top-level and subdirectory virtualenvs and was using the wrong one for the running container. Consistently use the virtual environment for the controller and copy only it over to the final container.