### PR TITLE
DM-52657: Fix JupyterHub plugin installation

### DIFF
--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -34,7 +34,8 @@ ENV UV_LINK_MODE=copy
 # Install the dependencies.
 ADD . /app
 WORKDIR /app/hub
-RUN uv export --frozen --no-default-groups --no-emit-project -o requirements.txt
+RUN uv export --frozen --no-default-groups --no-emit-project --no-editable \
+    -o requirements.txt
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --compile-bytecode -r requirements.txt
 WORKDIR /


### PR DESCRIPTION
Force JupyterHub plugins to not be installed in editable mode when building the JupyterHub container, since then they point to a tree that is deleted in the final container image.