### PR TITLE
DM-52784: Remove entry point for controller

### DIFF
--- a/controller/pyproject.toml
+++ b/controller/pyproject.toml
@@ -38,9 +38,6 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.scripts]
-controller = "controller.cli:main"
-
 [project.urls]
 Homepage = "https://nublado.lsst.io"
 Source = "https://github.com/lsst-sqre/nublado"


### PR DESCRIPTION
The `pyproject.toml` file for the Nublado controller defined an entry point pointing to a non-existent module. Remove it.