### PR TITLE
DM-54523: Refactor Docker tag retrieval to use Safir

### DIFF
--- a/src/nublado/controller/exceptions.py
+++ b/src/nublado/controller/exceptions.py
@@ -24,9 +24,9 @@ from .models.v1.lab import LabSize
 
 __all__ = [
     "ControllerTimeoutError",
-    "DockerRegistryError",
+    "DockerError",
+    "DockerInvalidUrlError",
     "DuplicateObjectError",
-    "DuplicateUrlError",
     "GafaelfawrParseError",
     "GafaelfawrWebError",
     "InsufficientQuotaError",
@@ -217,8 +217,17 @@ class ControllerTimeoutError(SlackException):
         return info
 
 
-class DockerRegistryError(SlackWebException):
+class DockerError(SlackWebException):
     """An API call to a Docker Registry failed."""
+
+
+class DockerInvalidUrlError(DockerError):
+    """An invalid link was encountered while retrieving tag results."""
+
+    def __init__(
+        self, error: str, url: str, next_url: str, *, method: str
+    ) -> None:
+        super().__init__(f"{error}: {next_url}", method=method, url=url)
 
 
 class DuplicateObjectError(SlackException):
@@ -278,10 +287,6 @@ class DuplicateObjectError(SlackException):
         if self.namespace:
             info.tags["namespace"] = self.namespace
         return info
-
-
-class DuplicateUrlError(SlackException):
-    """A duplicate link was encountered while paginating tag results."""
 
 
 class GafaelfawrParseError(SlackException):

--- a/src/nublado/controller/storage/docker.py
+++ b/src/nublado/controller/storage/docker.py
@@ -1,74 +1,31 @@
 """Client for the Docker v2 API."""
 
 import json
-import re
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
-from urllib.parse import urlparse
+from urllib.parse import urljoin
 
 from httpx import AsyncClient, HTTPError, Response
+from safir.http import PaginationLinkData
 from structlog.stdlib import BoundLogger
 
-from ..exceptions import DockerRegistryError, DuplicateUrlError
+from ..exceptions import DockerError, DockerInvalidUrlError
 from ..models.domain.docker import DockerCredentials
 from ..models.v1.prepuller import DockerSourceOptions
+
+_MANIFEST_ACCEPT_TYPES = [
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.oci.image.index.v1+json",
+    "application/json;q=0.5",
+]
+"""Possible MIME types for an image manifest for the ``Accept`` header."""
 
 __all__ = [
     "DockerCredentialStore",
     "DockerStorageClient",
 ]
-
-
-# _LINK_REGEX and _PaginationLinkData are adapted from Safir:
-# src/database/_pagination.py
-
-_LINK_REGEX = re.compile(
-    r'\s*<(?P<target>[^>]+)>;\s*rel=(?P<maybe_quote>"?)(?P<type>[^"]+)\2'
-)
-
-
-@dataclass
-class _PaginationLinkData:
-    """Holds the data returned in an :rfc:`8288` ``Link`` header."""
-
-    prev_url: str | None
-    """URL of the previous page, or `None` for the first page."""
-
-    next_url: str | None
-    """URL of the next page, or `None` for the last page."""
-
-    first_url: str | None
-    """URL of the first page."""
-
-    @classmethod
-    def from_header(cls, header: str | None) -> Self:
-        """Parse an :rfc:`8288` ``Link`` with pagination URLs.
-
-        Parameters
-        ----------
-        header
-            Contents of an RFC 8288 ``Link`` header.
-
-        Returns
-        -------
-        PaginationLinkData
-            Parsed form of that header.
-        """
-        links = {}
-        if header:
-            for element in header.split(","):
-                if m := re.match(_LINK_REGEX, element):
-                    if m.group("type") in ("prev", "next", "first"):
-                        links[m.group("type")] = m.group("target")
-                    elif m.group("type") == "previous":
-                        links["prev"] = m.group("target")
-
-        return cls(
-            prev_url=links.get("prev"),
-            next_url=links.get("next"),
-            first_url=links.get("first"),
-        )
 
 
 class DockerCredentialStore:
@@ -199,13 +156,13 @@ class DockerStorageClient:
 
         Raises
         ------
-        DockerRegistryError
+        DockerError
             Unable to retrieve the digest from the Docker Registry.
         """
         url = (
             f"https://{config.registry}/v2/{config.repository}/manifests/{tag}"
         )
-        headers = self._build_manifest_headers(config.registry)
+        headers = self._build_headers(config.registry, manifest=True)
         try:
             r = await self._client.head(url, headers=headers)
             if r.status_code == 401:
@@ -214,11 +171,11 @@ class DockerStorageClient:
             r.raise_for_status()
             digest = r.headers["Docker-Content-Digest"]
         except HTTPError as e:
-            raise DockerRegistryError.from_exception(e) from e
+            raise DockerError.from_exception(e) from e
         except Exception as e:
             error = f"{type(e).__name__}: {e!s}"
             msg = f"Cannot get image digest from Docker registry: {error}"
-            raise DockerRegistryError(msg, method="GET", url=url) from e
+            raise DockerError(msg, method="GET", url=url) from e
         else:
             self._logger.debug(
                 "Retrieved image digest for tag",
@@ -266,46 +223,30 @@ class DockerStorageClient:
                 r.raise_for_status()
                 tags = r.json()["tags"]
             except HTTPError as e:
-                raise DockerRegistryError.from_exception(e) from e
+                raise DockerError.from_exception(e) from e
             except Exception as e:
                 error = f"{type(e).__name__}: {e!s}"
                 msg = f"Cannot parse response from Docker registry: {error}"
-                raise DockerRegistryError(msg, method="GET", url=url) from e
+                raise DockerError(msg, method="GET", url=url) from e
 
             # Add the seen tags to the set.
             logger.debug(f"Retrieved {len(tags)} image tags")
             all_tags.update(tags)
 
             # Check for a continuation.
-            if link_url := self._parse_next_link_header(r):
-                url = self._canonicalize_url(link_url, config)
-                if url in seen_urls:
-                    raise DuplicateUrlError(f"Repeated tag page URL: {url}")
-                logger.debug("Following Link header", url=link_url)
+            if next_url := self._parse_next_link_header(config, r, url):
+                if next_url in seen_urls:
+                    raise DockerInvalidUrlError(
+                        "Repeated tag page URL", url, next_url, method="GET"
+                    )
+                url = next_url
+                logger.debug("Following Link header", url=url)
             else:
                 break
 
         # All done, return the results.
         logger.debug("Listed all tags", count=len(all_tags))
         return all_tags
-
-    @staticmethod
-    def _canonicalize_url(link_url: str, config: DockerSourceOptions) -> str:
-        parsed = urlparse(link_url)
-        if parsed.netloc:
-            # It specified a netloc, so use it as is.
-            return link_url
-        # Relative to the current netloc (this is how GHCR does it).
-        if link_url[0] != "/":
-            link_url = f"/{link_url}"
-        return f"https://{config.registry}{link_url}"
-
-    def _parse_next_link_header(self, response: Response) -> str | None:
-        """Parse the response for a ``Link`` header with a next URL."""
-        link = response.headers.get("Link")
-        if not link:
-            return None
-        return _PaginationLinkData.from_header(link).next_url
 
     async def _authenticate(
         self, host: str, response: Response
@@ -330,22 +271,22 @@ class DockerStorageClient:
 
         Raises
         ------
-        DockerRegistryError
+        DockerError
             Some failure in talking to the Docker registry API server.
         """
         if host in self._authorization:
             msg = f"Authentication credentials for {host} rejected"
-            raise DockerRegistryError(msg)
+            raise DockerError(msg)
 
         credentials = self._credentials.get(host)
         if not credentials:
             msg = f"No Docker API credentials available for {host}"
-            raise DockerRegistryError(msg)
+            raise DockerError(msg)
 
         challenge = response.headers.get("WWW-Authenticate")
         if not challenge:
             msg = f"Docker API 401 response from {host} contains no challenge"
-            raise DockerRegistryError(msg)
+            raise DockerError(msg)
         challenge_type, params = challenge.split(None, 1)
         challenge_type = challenge_type.lower()
 
@@ -367,25 +308,13 @@ class DockerStorageClient:
             )
         else:
             msg = f'Unknown Docker authentication challenge "{challenge_type}"'
-            raise DockerRegistryError(msg)
+            raise DockerError(msg)
 
         return self._build_headers(host)
 
-    def _build_manifest_headers(self, host: str) -> dict[str, str]:
-        """Construct the headers we need for a query to a given host to
-        inspect a manifest. This requires additional media types.
-        """
-        headers = self._build_headers(host)
-        headers["Accept"] = (
-            "application/vnd.docker.distribution.manifest.v2+json, "
-            "application/vnd.docker.distribution.manifest.list.v2+json, "
-            "application/vnd.oci.image.manifest.v1+json, "
-            "application/vnd.oci.image.index.v1+json, "
-            "application/json;q=0.5"
-        )
-        return headers
-
-    def _build_headers(self, host: str) -> dict[str, str]:
+    def _build_headers(
+        self, host: str, *, manifest: bool = False
+    ) -> dict[str, str]:
         """Construct the headers used for a query to a given host.
 
         Adds the ``Authorization`` header if we have discovered that this host
@@ -395,13 +324,18 @@ class DockerStorageClient:
         ----------
         host
             Docker registry API host.
+        manifest
+            Whether to construct the headers for retrieving a manifest.
 
         Returns
         -------
         dict of str to str
             Headers to pass to this host.
         """
-        headers = {"Accept": "application/json"}
+        if manifest:
+            headers = {"Accept": ", ".join(_MANIFEST_ACCEPT_TYPES)}
+        else:
+            headers = {"Accept": "application/json"}
         if host in self._authorization:
             headers["Authorization"] = self._authorization[host]
         return headers
@@ -427,7 +361,7 @@ class DockerStorageClient:
 
         Raises
         ------
-        DockerRegistryError
+        DockerError
             Some failure in talking to the Docker registry API server.
         """
         # We need to reflect the challenge parameters back as query
@@ -456,8 +390,45 @@ class DockerStorageClient:
             r.raise_for_status()
             return r.json()["token"]
         except HTTPError as e:
-            raise DockerRegistryError.from_exception(e) from e
+            raise DockerError.from_exception(e) from e
         except Exception as e:
             error = f"{type(e).__name__}: {e!s}"
             msg = f"Cannot parse Docker registry login response: {error}"
-            raise DockerRegistryError(msg, method="GET", url=url) from e
+            raise DockerError(msg, method="GET", url=url) from e
+
+    def _parse_next_link_header(
+        self, config: DockerSourceOptions, response: Response, base_url: str
+    ) -> str | None:
+        """Parse the response for a ``Link`` header with a next URL.
+
+        Parameters
+        ----------
+        config
+            Configuration for the registry and repository to use.
+        response
+            HTTP response, which may contain a ``Link`` header.
+        base_url
+            URL retrieved to create that response, used for relative link
+            following.
+
+        Raises
+        ------
+        DockerInvalidUrlError
+            Raised if the next URL is not relative to the expected registry.
+        """
+        link = response.headers.get("Link")
+        if not link:
+            return None
+        link_data = PaginationLinkData.from_header(link)
+        if link_data.next_url:
+            next_url = urljoin(base_url, link_data.next_url)
+            if not next_url.startswith(f"https://{config.registry}/"):
+                raise DockerInvalidUrlError(
+                    f"Docker Link URL not relative to {config.registry}",
+                    base_url,
+                    next_url,
+                    method="GET",
+                )
+            return next_url
+        else:
+            return None

--- a/tests/controller/storage/docker_test.py
+++ b/tests/controller/storage/docker_test.py
@@ -9,17 +9,11 @@ import pytest
 import respx
 
 from nublado.controller.config import Config
-from nublado.controller.exceptions import (
-    DockerRegistryError,
-    DuplicateUrlError,
-)
+from nublado.controller.exceptions import DockerInvalidUrlError
 from nublado.controller.factory import Factory
 from nublado.controller.models.domain.docker import DockerCredentials
 from nublado.controller.models.v1.prepuller import DockerSourceOptions
-from nublado.controller.storage.docker import (
-    DockerCredentialStore,
-    DockerStorageClient,
-)
+from nublado.controller.storage.docker import DockerCredentialStore
 
 from ...support.docker import register_mock_docker
 
@@ -76,41 +70,6 @@ async def test_api_nonpaginated(
     assert digest == tags["w_2021_21"]
     digest = await docker.get_image_digest(config.images.source, "w_2021_22")
     assert digest == tags["w_2021_22"]
-
-
-@pytest.mark.asyncio
-async def test_bad_accept(
-    config: Config,
-    factory: Factory,
-    respx_mock: respx.Router,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    tag_names = {"w_2021_21", "w_2021_22", "d_2021_06_14", "d_2021_06_15"}
-    tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
-    assert isinstance(config.images.source, DockerSourceOptions)
-    register_mock_docker(
-        respx_mock,
-        host=config.images.source.registry,
-        repository=config.images.source.repository,
-        credentials_path=config.images.source.credentials_path,
-        tags=tags,
-        paginate=True,
-    )
-
-    def _bad_manifest_headers(
-        d_obj: DockerStorageClient, host: str
-    ) -> dict[str, str]:
-        # Don't send the right Accept: header, just "application/json".
-        return d_obj._build_headers(host)
-
-    monkeypatch.setattr(
-        DockerStorageClient, "_build_manifest_headers", _bad_manifest_headers
-    )
-    docker = factory.create_docker_storage()
-
-    assert await docker.list_tags(config.images.source) == tag_names
-    with pytest.raises(DockerRegistryError):
-        await docker.get_image_digest(config.images.source, "w_2021_21")
 
 
 @pytest.mark.asyncio
@@ -189,5 +148,5 @@ async def test_duplicate_url(
         duplicate_url=True,
     )
     docker = factory.create_docker_storage()
-    with pytest.raises(DuplicateUrlError):
+    with pytest.raises(DockerInvalidUrlError):
         await docker.list_tags(config.images.source)

--- a/tests/support/docker.py
+++ b/tests/support/docker.py
@@ -29,16 +29,15 @@ class MockDockerRegistry:
         Whether to require bearer token authentication, which requires another
         round trip to exchange the username and password for a bearer token.
     paginate
-        Whether to paginate responses with Link header (GHCR does, but
-        Docker Hub does not).
+        Whether to paginate responses with ``Link`` header.
     duplicate_url
-        Whether to (incorrectly) return the same "next" tag multiple times when
-        paginating.  This is only used to test error-handling functionality
-        in the tag-handling code, and only makes sense with paginate.
+        Whether to (incorrectly) return the same ``next`` tag multiple times
+        when paginating. This is only used to test error-handling
+        functionality in the tag-handling code, and only makes sense with
+        paginate.
     netloc_paginate
-        Whether to return a URL with a scheme and netloc when paginating
-        (GHCR does not).  This only makes sense with paginate.
-
+        Whether to return a URL with a scheme and netloc when paginating (GHCR
+        does not). This only makes sense with paginate.
 
     Attributes
     ----------
@@ -69,7 +68,7 @@ class MockDockerRegistry:
 
         # The token authentication protocol for the Docker API returns
         # parameters in the WWW-Authenticate header that should be passed into
-        # the authentication route.  These are the parameters that we return
+        # the authentication route. These are the parameters that we return
         # and then expect.
         self._challenge = {
             "realm": realm,
@@ -118,9 +117,10 @@ class MockDockerRegistry:
         """
         if not self._check_auth(request):
             return self._make_auth_challenge()
-        if not self._paginate:
+        if self._paginate:
+            return self._return_paginated_response(request)
+        else:
             return Response(200, json={"tags": list(self.tags.keys())})
-        return self._return_paginated_response(request)
 
     def _return_paginated_response(self, request: Request) -> Response:
         #
@@ -194,25 +194,14 @@ class MockDockerRegistry:
         """
         if not self._check_auth(request):
             return self._make_auth_challenge()
-        if not self._check_appropriate_accept(request):
-            return Response(404)
+        types = request.headers.get("Accept").split(", ")
+        assert "application/vnd.docker.distribution.manifest.v2+json" in types
         if tag in self.tags:
             return Response(
                 200, headers={"Docker-Content-Digest": self.tags[tag]}
             )
         else:
             return Response(404)
-
-    @staticmethod
-    def _check_appropriate_accept(request: Request) -> bool:
-        """Make sure that an Accept header allowing multi-architecture
-        manifests is present.
-
-        Our client actually sends several of these, comma-separated.  This
-        is the first.
-        """
-        accept = request.headers.get("Accept").split(",")[0].strip()
-        return accept == "application/vnd.docker.distribution.manifest.v2+json"
 
     def _check_auth(self, request: Request) -> bool:
         """Check whether the request is authenticated."""


### PR DESCRIPTION
Now that Safir exposes `PaginationLinkData` from the safir.http module, use it for Docker tag retrieval. Refactor and simplify and improve the exception names. Remove a test that only tests the test support code rather than the actual controller code.