### PR TITLE
DM-54523: Simplify the API to the mock Docker service

### DIFF
--- a/changelog.d/20260327_101637_rra_DM_54440.md
+++ b/changelog.d/20260327_101637_rra_DM_54440.md
@@ -1,6 +1,6 @@
 ### Backwards-incompatible changes
 
-- Change the default runtime mount location to `/etc/nublado` from `/opt/lsst/software/jupyaterlab`. This change should be invisible to users since all code that relies on its location should be using the `NUBLADO_RUNTIME_MOUNTS_DIR` environment variable to find it.
+- Change the default runtime mount location to `/etc/nublado` from `/opt/lsst/software/jupyterlab`. This change should be invisible to users since all code that relies on its location should be using the `NUBLADO_RUNTIME_MOUNTS_DIR` environment variable to find it.
 
 ### New features
 

--- a/tests/controller/conftest.py
+++ b/tests/controller/conftest.py
@@ -108,9 +108,7 @@ def mock_docker(
     assert isinstance(config.images.source, DockerSourceOptions)
     return register_mock_docker(
         respx_mock,
-        host=config.images.source.registry,
-        repository=config.images.source.repository,
-        credentials_path=config.images.source.credentials_path,
+        config.images.source,
         tags=data.read_json("controller/tags/docker"),
         require_bearer=True,
     )

--- a/tests/controller/storage/docker_test.py
+++ b/tests/controller/storage/docker_test.py
@@ -33,14 +33,7 @@ async def test_api(
     }
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
     assert isinstance(config.images.source, DockerSourceOptions)
-    register_mock_docker(
-        respx_mock,
-        host=config.images.source.registry,
-        repository=config.images.source.repository,
-        credentials_path=config.images.source.credentials_path,
-        tags=tags,
-        paginate=True,
-    )
+    register_mock_docker(respx_mock, config.images.source, tags, paginate=True)
     docker = factory.create_docker_storage()
     assert await docker.list_tags(config.images.source) == tag_names
     digest = await docker.get_image_digest(config.images.source, "w_2021_21")
@@ -57,12 +50,7 @@ async def test_api_nonpaginated(
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
     assert isinstance(config.images.source, DockerSourceOptions)
     register_mock_docker(
-        respx_mock,
-        host=config.images.source.registry,
-        repository=config.images.source.repository,
-        credentials_path=config.images.source.credentials_path,
-        tags=tags,
-        paginate=False,
+        respx_mock, config.images.source, tags, paginate=False
     )
     docker = factory.create_docker_storage()
     assert await docker.list_tags(config.images.source) == tag_names
@@ -79,12 +67,7 @@ async def test_bearer_auth(
     assert isinstance(config.images.source, DockerSourceOptions)
     tags = {"r23_0_4": "sha256:" + os.urandom(32).hex()}
     register_mock_docker(
-        respx_mock,
-        host=config.images.source.registry,
-        repository=config.images.source.repository,
-        credentials_path=config.images.source.credentials_path,
-        tags=tags,
-        require_bearer=True,
+        respx_mock, config.images.source, tags, require_bearer=True
     )
     docker = factory.create_docker_storage()
     assert await docker.list_tags(config.images.source) == {"r23_0_4"}
@@ -140,10 +123,8 @@ async def test_duplicate_url(
     assert isinstance(config.images.source, DockerSourceOptions)
     register_mock_docker(
         respx_mock,
-        host=config.images.source.registry,
-        repository=config.images.source.repository,
-        credentials_path=config.images.source.credentials_path,
-        tags=tags,
+        config.images.source,
+        tags,
         paginate=True,
         duplicate_url=True,
     )

--- a/tests/support/docker.py
+++ b/tests/support/docker.py
@@ -2,13 +2,13 @@
 
 import os
 from base64 import b64decode, b64encode
-from pathlib import Path
 from urllib.parse import parse_qsl
 
 import respx
 from httpx import Request, Response
 
 from nublado.controller.models.domain.docker import DockerCredentials
+from nublado.controller.models.v1.prepuller import DockerSourceOptions
 from nublado.controller.storage.docker import DockerCredentialStore
 
 __all__ = ["MockDockerRegistry", "register_mock_docker"]
@@ -231,11 +231,9 @@ class MockDockerRegistry:
 
 def register_mock_docker(
     respx_mock: respx.Router,
-    *,
-    host: str,
-    repository: str,
-    credentials_path: Path,
+    config: DockerSourceOptions,
     tags: dict[str, str],
+    *,
     require_bearer: bool = False,
     paginate: bool = True,
     duplicate_url: bool = False,
@@ -247,13 +245,8 @@ def register_mock_docker(
     ----------
     respx_mock
         Mock router.
-    host
-        The hostname on which the mock API should appear to listen.
-    repository
-        The name of the repository (like ``lsstsqre/sciplat-lab``) for which
-        to register the mocks.
-    credentials_path
-        Path to a Docker credentials store.
+    config
+        Configuration for the Docker image source.
     tags
         A mapping of tags to image digests that should appear on that
         registry.
@@ -275,13 +268,13 @@ def register_mock_docker(
     MockDockerRegistry
         The mock Docker API object.
     """
-    base_url = f"https://{host}"
+    base_url = f"https://{config.registry}"
     auth_url = f"{base_url}/auth"
-    tags_url = f"{base_url}/v2/{repository}/tags/list"
-    digest_url = f"{base_url}/v2/{repository}/manifests/(?P<tag>.*)"
+    tags_url = f"{base_url}/v2/{config.repository}/tags/list"
+    digest_url = f"{base_url}/v2/{config.repository}/manifests/(?P<tag>.*)"
 
-    store = DockerCredentialStore.from_path(credentials_path)
-    credentials = store.get(host)
+    store = DockerCredentialStore.from_path(config.credentials_path)
+    credentials = store.get(config.registry)
     assert credentials
     mock = MockDockerRegistry(
         tags,


### PR DESCRIPTION
Pass in the full configuration to `register_mock_docker` instead of the individual components of the configuration.