### PR TITLE
DM-54523: Set skip-magic-trailing-comma to true for Ruff

### DIFF
--- a/client/src/rubin/nublado/client/_http.py
+++ b/client/src/rubin/nublado/client/_http.py
@@ -238,11 +238,7 @@ class JupyterAsyncClient:
 
     @_convert_exception
     async def open_websocket(
-        self,
-        route: str,
-        *,
-        open_timeout: timedelta,
-        max_size: int | None,
+        self, route: str, *, open_timeout: timedelta, max_size: int | None
     ) -> AbstractAsyncContextManager[ClientConnection]:
         """Open a WebSocket connection.
 

--- a/client/src/rubin/nublado/client/_models.py
+++ b/client/src/rubin/nublado/client/_models.py
@@ -176,10 +176,7 @@ class NubladoImageByReference(NubladoImage):
 
     @override
     def to_spawn_form(self) -> dict[str, str]:
-        result = {
-            "image_list": self.reference,
-            "size": self.size.value,
-        }
+        result = {"image_list": self.reference, "size": self.size.value}
         if self.debug:
             result["enable_debug"] = "true"
         return result

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -39,10 +39,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.fixture
 def client(
-    logger: BoundLogger,
-    username: str,
-    token: str,
-    mock_jupyter: MockJupyter,
+    logger: BoundLogger, username: str, token: str, mock_jupyter: MockJupyter
 ) -> NubladoClient:
     return NubladoClient(username, token, logger=logger)
 

--- a/hub/plugins/spawner/src/rubin/nublado/spawner/_internals.py
+++ b/hub/plugins/spawner/src/rubin/nublado/spawner/_internals.py
@@ -22,10 +22,7 @@ from ._exceptions import (
 )
 from ._models import LabStatus, SpawnEvent
 
-__all__ = [
-    "LabStatus",
-    "NubladoSpawner",
-]
+__all__ = ["LabStatus", "NubladoSpawner"]
 
 _CLIENT: AsyncClient | None = None
 """Cached global HTTP client so that we can share a connection pool."""
@@ -95,7 +92,7 @@ class NubladoSpawner(Spawner):
     repertoire_base_url = Unicode(
         help="""
         Base URL of service discovery service, used to get the controller URL.
-        """,
+        """
     ).tag(config=True)
 
     # Do not preserve any of JupyterHub's environment variables in the default

--- a/hub/tests/support/controller.py
+++ b/hub/tests/support/controller.py
@@ -9,10 +9,7 @@ from httpx import AsyncByteStream, Request, Response
 
 from rubin.nublado.spawner._models import LabStatus
 
-__all__ = [
-    "MockLabController",
-    "register_mock_lab_controller",
-]
+__all__ = ["MockLabController", "register_mock_lab_controller"]
 
 
 class MockProgress(AsyncByteStream):

--- a/jupyterlab-base/jupyter_server/jupyter_server_config.py
+++ b/jupyterlab-base/jupyter_server/jupyter_server_config.py
@@ -19,10 +19,5 @@ c.Application.logging_config = {
             "stream": "ext://sys.stdout",
         }
     },
-    "loggers": {
-        "stdout": {
-            "level": level,
-            "handlers": ["stdout"],
-        }
-    },
+    "loggers": {"stdout": {"level": level, "handlers": ["stdout"]}},
 }

--- a/jupyterlab-base/src/rubin/nublado/startup/_constants.py
+++ b/jupyterlab-base/src/rubin/nublado/startup/_constants.py
@@ -2,10 +2,7 @@
 
 from pathlib import Path
 
-__all__ = [
-    "ARGS_PATH",
-    "ENV_PATH",
-]
+__all__ = ["ARGS_PATH", "ENV_PATH"]
 
 ARGS_PATH = Path("/etc/nublado/startup/args.json")
 """Path to JSON file containing a list of additional JupyterLab arguments."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -177,12 +177,7 @@ def test(session: nox.Session) -> None:
                 "--cov-branch",
                 "--cov-report=",
             ]
-        session.run(
-            "pytest",
-            *cov_args,
-            *args.generic,
-            *args.parent_tests,
-        )
+        session.run("pytest", *cov_args, *args.generic, *args.parent_tests)
 
     # Run in a subdirectory if a test in that subdirectory was specified, or
     # if no tests were specified.
@@ -198,13 +193,7 @@ def test(session: nox.Session) -> None:
 @session(uv_groups=["dev", "nox", "typing"])
 def typing(session: nox.Session) -> None:
     """Run mypy."""
-    session.run(
-        "mypy",
-        *session.posargs,
-        "noxfile.py",
-        "src",
-        "tests",
-    )
+    session.run("mypy", *session.posargs, "noxfile.py", "src", "tests")
     session.run(
         "mypy",
         *session.posargs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,9 @@ python_files = ["tests/*.py", "tests/*/*.py", "tests/*/*/*.py"]
 [tool.ruff]
 extend = "ruff-shared.toml"
 
+[tool.ruff.format]
+skip-magic-trailing-comma = true
+
 [tool.ruff.lint.extend-per-file-ignores]
 "*/noxfile.py" = [
     "INP001",  # subdirectory nox configuration isn't in a package

--- a/src/nublado/cli.py
+++ b/src/nublado/cli.py
@@ -25,13 +25,7 @@ from .purger.constants import CONFIG_FILE_ENV_VAR as PURGER_CONFIG_FILE_ENV_VAR
 from .purger.purger import Purger
 from .startup.services.preparer import Preparer
 
-__all__ = [
-    "inithome",
-    "landingpage",
-    "main",
-    "purger",
-    "startup",
-]
+__all__ = ["inithome", "landingpage", "main", "purger", "startup"]
 
 # Do this at the very beginning so that Sentry gets all exceptions.
 initialize_sentry(release=__version__)
@@ -81,9 +75,7 @@ def _purger_common[**P, R](
         logger = get_logger(ROOT_LOGGER)
         if alert_hook := os.environ.get(ALERT_HOOK_ENV_VAR):
             slack_client = SlackWebhookClient(
-                alert_hook,
-                "Nublado File Purger",
-                logger=logger,
+                alert_hook, "Nublado File Purger", logger=logger
             )
         else:
             slack_client = None
@@ -150,11 +142,7 @@ def _make_purger(
 @main.group()
 @_purger_common
 async def purger(
-    *,
-    config_file: Path,
-    policy_file: Path | None,
-    dry_run: bool,
-    debug: bool,
+    *, config_file: Path, policy_file: Path | None, dry_run: bool, debug: bool
 ) -> None:
     """Purge files, or plan future purge."""
 
@@ -162,11 +150,7 @@ async def purger(
 @purger.command()
 @_purger_common
 async def report(
-    *,
-    config_file: Path,
-    policy_file: Path | None,
-    dry_run: bool,
-    debug: bool,
+    *, config_file: Path, policy_file: Path | None, dry_run: bool, debug: bool
 ) -> None:
     """Report what files would be purged."""
     purger = _make_purger(
@@ -182,11 +166,7 @@ async def report(
 @purger.command()
 @_purger_common
 async def execute(
-    *,
-    config_file: Path,
-    policy_file: Path | None,
-    dry_run: bool,
-    debug: bool,
+    *, config_file: Path, policy_file: Path | None, dry_run: bool, debug: bool
 ) -> None:
     """Make a plan, report, and purge files."""
     purger = _make_purger(

--- a/src/nublado/controller/config.py
+++ b/src/nublado/controller/config.py
@@ -1404,8 +1404,7 @@ class Config(BaseSettings):
     ] = DisabledFileserverConfig()
 
     fsadmin: Annotated[
-        FSAdminConfig,
-        Field(title="Filesystem admin configuration"),
+        FSAdminConfig, Field(title="Filesystem admin configuration")
     ]
 
     images: Annotated[

--- a/src/nublado/controller/dependencies/config.py
+++ b/src/nublado/controller/dependencies/config.py
@@ -5,10 +5,7 @@ from pathlib import Path
 from ..config import Config
 from ..constants import CONFIGURATION_PATH
 
-__all__ = [
-    "ConfigDependency",
-    "config_dependency",
-]
+__all__ = ["ConfigDependency", "config_dependency"]
 
 
 class ConfigDependency:

--- a/src/nublado/controller/dependencies/context.py
+++ b/src/nublado/controller/dependencies/context.py
@@ -22,11 +22,7 @@ from ..services.fsadmin import FSAdminManager
 from ..services.image import ImageService
 from ..services.lab import LabManager
 
-__all__ = [
-    "ContextDependency",
-    "RequestContext",
-    "context_dependency",
-]
+__all__ = ["ContextDependency", "RequestContext", "context_dependency"]
 
 
 @dataclass(slots=True)

--- a/src/nublado/controller/dependencies/user.py
+++ b/src/nublado/controller/dependencies/user.py
@@ -9,10 +9,7 @@ from ..exceptions import InvalidTokenError, PermissionDeniedError
 from ..models.domain.gafaelfawr import GafaelfawrUser
 from .context import RequestContext, context_dependency
 
-__all__ = [
-    "user_dependency",
-    "username_path_dependency",
-]
+__all__ = ["user_dependency", "username_path_dependency"]
 
 
 async def user_dependency(

--- a/src/nublado/controller/factory.py
+++ b/src/nublado/controller/factory.py
@@ -39,10 +39,7 @@ from .storage.kubernetes.node import NodeStorage
 from .storage.kubernetes.pod import PodStorage
 from .storage.metadata import MetadataStorage
 
-__all__ = [
-    "Factory",
-    "ProcessContext",
-]
+__all__ = ["Factory", "ProcessContext"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nublado/controller/handlers/fsadmin.py
+++ b/src/nublado/controller/handlers/fsadmin.py
@@ -21,7 +21,7 @@ __all__ = ["router"]
         404: {
             "description": "Filesystem admin instance not running",
             "model": ErrorModel,
-        },
+        }
     },
     description=(
         "On successful return, the fsadmin instance is operational."
@@ -44,7 +44,7 @@ async def get_fsadmin_status(
         404: {
             "description": "Filesystem admin instance not running",
             "model": ErrorModel,
-        },
+        }
     },
     description="On successful return, the fsadmin instance is operational.",
     summary="Create fsadmin instance",

--- a/src/nublado/controller/models/domain/docker.py
+++ b/src/nublado/controller/models/domain/docker.py
@@ -5,10 +5,7 @@ import re
 from dataclasses import dataclass
 from typing import Self, override
 
-__all__ = [
-    "DockerCredentials",
-    "DockerReference",
-]
+__all__ = ["DockerCredentials", "DockerReference"]
 
 # Regex fragments used for Docker reference parsing.
 _REGISTRY = r"(?P<registry>[^/]+)"

--- a/src/nublado/controller/models/domain/fileserver.py
+++ b/src/nublado/controller/models/domain/fileserver.py
@@ -11,10 +11,7 @@ from kubernetes_asyncio.client import (
     V1Service,
 )
 
-__all__ = [
-    "FileserverObjects",
-    "FileserverStateObjects",
-]
+__all__ = ["FileserverObjects", "FileserverStateObjects"]
 
 
 @dataclass

--- a/src/nublado/controller/models/domain/image.py
+++ b/src/nublado/controller/models/domain/image.py
@@ -7,11 +7,7 @@ from pydantic import BaseModel, Field
 
 from .rspimage import RSPImage, RSPImageCollection
 
-__all__ = [
-    "MenuImage",
-    "MenuImages",
-    "NodeData",
-]
+__all__ = ["MenuImage", "MenuImages", "NodeData"]
 
 
 class MenuImage(BaseModel):

--- a/src/nublado/controller/models/domain/imagefilterpolicy.py
+++ b/src/nublado/controller/models/domain/imagefilterpolicy.py
@@ -49,18 +49,13 @@ class ImageFilterPolicy(BaseModel):
     number: Annotated[
         int | None,
         Field(
-            title="Number",
-            description="Number of images to display.",
-            ge=0,
+            title="Number", description="Number of images to display.", ge=0
         ),
     ] = None
 
     age: Annotated[
         HumanTimedelta | None,
-        Field(
-            title="Age",
-            description="Maximum age of image to display.",
-        ),
+        Field(title="Age", description="Maximum age of image to display."),
     ] = None
 
     cutoff_version: Annotated[

--- a/src/nublado/controller/models/domain/kubernetes.py
+++ b/src/nublado/controller/models/domain/kubernetes.py
@@ -216,8 +216,7 @@ class NodeSelectorTerm(BaseModel):
         expressions = [e.to_kubernetes() for e in self.match_expressions]
         fields = [e.to_kubernetes() for e in self.match_fields]
         return V1NodeSelectorTerm(
-            match_expressions=expressions or None,
-            match_fields=fields or None,
+            match_expressions=expressions or None, match_fields=fields or None
         )
 
 
@@ -565,10 +564,7 @@ class Affinity(BaseModel):
     )
 
     node_affinity: Annotated[
-        NodeAffinity | None,
-        Field(
-            title="Node affinity rules",
-        ),
+        NodeAffinity | None, Field(title="Node affinity rules")
     ] = None
 
     pod_affinity: Annotated[

--- a/src/nublado/controller/models/domain/rspimage.py
+++ b/src/nublado/controller/models/domain/rspimage.py
@@ -9,10 +9,7 @@ from typing import Self
 from .imagefilterpolicy import RSPImageFilterPolicy
 from .rsptag import RSPImageTag, RSPImageTagCollection, RSPImageType
 
-__all__ = [
-    "RSPImage",
-    "RSPImageCollection",
-]
+__all__ = ["RSPImage", "RSPImageCollection"]
 
 _ALIAS_TYPES = (RSPImageType.ALIAS, RSPImageType.UNKNOWN)
 """Image types that may be aliases and can be resolved."""

--- a/src/nublado/controller/models/v1/lab.py
+++ b/src/nublado/controller/models/v1/lab.py
@@ -577,8 +577,7 @@ class LabState(BaseModel):
     user: Annotated[
         UserInfo,
         Field(
-            title="Owner",
-            description="Metadata for the user who owns the lab",
+            title="Owner", description="Metadata for the user who owns the lab"
         ),
     ]
 

--- a/src/nublado/controller/models/v1/prepuller.py
+++ b/src/nublado/controller/models/v1/prepuller.py
@@ -437,8 +437,7 @@ class PrepullerImageStatus(BaseModel):
     """Status of the images being prepulled."""
 
     prepulled: Annotated[
-        list[NodeImage],
-        Field(title="Successfully cached images"),
+        list[NodeImage], Field(title="Successfully cached images")
     ] = []
 
     pending: Annotated[

--- a/src/nublado/controller/services/builder/fsadmin.py
+++ b/src/nublado/controller/services/builder/fsadmin.py
@@ -73,9 +73,7 @@ class FSAdminBuilder:
         labels = {"nublado.lsst.io/category": "fsadmin"}
         annotations = ARGO_CD_ANNOTATIONS.copy()
         return V1ObjectMeta(
-            name=name + suffix,
-            labels=labels,
-            annotations=annotations,
+            name=name + suffix, labels=labels, annotations=annotations
         )
 
     def _build_pod(self) -> V1Pod:
@@ -133,9 +131,7 @@ class FSAdminBuilder:
                 containers=[container],
                 node_selector=node_selector,
                 restart_policy="Never",
-                security_context=V1PodSecurityContext(
-                    run_as_non_root=False,
-                ),
+                security_context=V1PodSecurityContext(run_as_non_root=False),
                 tolerations=tolerations,
                 volumes=volume_list,
             ),

--- a/src/nublado/controller/services/builder/lab.py
+++ b/src/nublado/controller/services/builder/lab.py
@@ -249,8 +249,7 @@ class LabBuilder:
         try:
             resources = LabResources(
                 limits=ResourceQuantity(
-                    cpu=float(env["CPU_LIMIT"]),
-                    memory=int(env["MEM_LIMIT"]),
+                    cpu=float(env["CPU_LIMIT"]), memory=int(env["MEM_LIMIT"])
                 ),
                 requests=ResourceQuantity(
                     cpu=float(env["CPU_GUARANTEE"]),
@@ -460,8 +459,7 @@ class LabBuilder:
         ingress_rules = [
             V1NetworkPolicyPeer(namespace_selector=lab_selector),
             V1NetworkPolicyPeer(
-                namespace_selector=V1LabelSelector(),
-                pod_selector=hub_selector,
+                namespace_selector=V1LabelSelector(), pod_selector=hub_selector
             ),
         ]
         return V1NetworkPolicy(
@@ -473,7 +471,7 @@ class LabBuilder:
                     V1NetworkPolicyIngressRule(
                         _from=ingress_rules,
                         ports=[V1NetworkPolicyPort(port=8888)],
-                    ),
+                    )
                 ],
             ),
         )
@@ -692,10 +690,7 @@ class LabBuilder:
                 ),
             ),
             volume_mount=V1VolumeMount(
-                mount_path=path,
-                name=name,
-                read_only=True,
-                sub_path=subpath,
+                mount_path=path, name=name, read_only=True, sub_path=subpath
             ),
         )
 
@@ -850,9 +845,7 @@ class LabBuilder:
                 downward_api=V1DownwardAPIVolumeSource(items=files),
             ),
             volume_mount=V1VolumeMount(
-                mount_path=runtime_path,
-                name="runtime",
-                read_only=True,
+                mount_path=runtime_path, name="runtime", read_only=True
             ),
         )
 

--- a/src/nublado/controller/services/lab.py
+++ b/src/nublado/controller/services/lab.py
@@ -1164,10 +1164,7 @@ class LabManager:
         await self._watch_lab_spawn(state, events, timeout)
 
     async def _watch_lab_spawn(
-        self,
-        state: LabState,
-        events: AsyncMultiQueue[Event],
-        timeout: Timeout,
+        self, state: LabState, events: AsyncMultiQueue[Event], timeout: Timeout
     ) -> None:
         """Wait for a lab spawn to complete, reflecting Kubernetes events.
 

--- a/src/nublado/controller/services/source/docker.py
+++ b/src/nublado/controller/services/source/docker.py
@@ -86,7 +86,7 @@ class DockerImageSource(ImageSource):
 
         Raises
         ------
-        DockerRegistryError
+        DockerError
             Raised if retrieving the digest from the Docker Registry failed.
         InvalidDockerReferenceError
             Raised if the Docker reference doesn't contain a tag. References
@@ -161,9 +161,9 @@ class DockerImageSource(ImageSource):
         Raises
         ------
         UnknownDockerImageError
-            The requested tag is not found.
-        DockerRegistryError
-            Unable to retrieve the digest from the Docker Registry.
+            Raised if the requested tag was not found.
+        DockerError
+            Raised if retrieving the digest from the Docker Registry failed.
         """
         image = self._images.image_for_tag_name(tag_name)
         if image:

--- a/src/nublado/controller/storage/docker.py
+++ b/src/nublado/controller/storage/docker.py
@@ -22,10 +22,7 @@ _MANIFEST_ACCEPT_TYPES = [
 ]
 """Possible MIME types for an image manifest for the ``Accept`` header."""
 
-__all__ = [
-    "DockerCredentialStore",
-    "DockerStorageClient",
-]
+__all__ = ["DockerCredentialStore", "DockerStorageClient"]
 
 
 class DockerCredentialStore:

--- a/src/nublado/controller/storage/kubernetes/custom.py
+++ b/src/nublado/controller/storage/kubernetes/custom.py
@@ -13,10 +13,7 @@ from ...models.domain.kubernetes import PropagationPolicy, WatchEventType
 from ...timeout import Timeout
 from .watcher import KubernetesWatcher
 
-__all__ = [
-    "CustomStorage",
-    "GafaelfawrIngressStorage",
-]
+__all__ = ["CustomStorage", "GafaelfawrIngressStorage"]
 
 
 class CustomStorage:
@@ -264,10 +261,7 @@ class CustomStorage:
             ) from e
 
     async def wait_for_deletion(
-        self,
-        name: str,
-        namespace: str,
-        timeout: Timeout,
+        self, name: str, namespace: str, timeout: Timeout
     ) -> None:
         """Wait for a custom object deletion to complete.
 

--- a/src/nublado/controller/storage/kubernetes/ingress.py
+++ b/src/nublado/controller/storage/kubernetes/ingress.py
@@ -11,10 +11,7 @@ from ...timeout import Timeout
 from .deleter import KubernetesObjectDeleter
 from .watcher import KubernetesWatcher
 
-__all__ = [
-    "IngressStorage",
-    "ingress_has_ip_address",
-]
+__all__ = ["IngressStorage", "ingress_has_ip_address"]
 
 
 def ingress_has_ip_address(ingress: V1Ingress) -> bool:

--- a/src/nublado/controller/storage/kubernetes/watcher.py
+++ b/src/nublado/controller/storage/kubernetes/watcher.py
@@ -14,10 +14,7 @@ from ...exceptions import KubernetesError
 from ...models.domain.kubernetes import WatchEventType
 from ...timeout import Timeout
 
-__all__ = [
-    "KubernetesWatcher",
-    "WatchEvent",
-]
+__all__ = ["KubernetesWatcher", "WatchEvent"]
 
 
 @dataclass

--- a/src/nublado/controller/templates.py
+++ b/src/nublado/controller/templates.py
@@ -15,7 +15,7 @@ templates = Jinja2Templates(
     env=Environment(
         loader=PackageLoader("nublado.controller", package_path="templates"),
         autoescape=True,
-    ),
+    )
 )
 """The template manager."""
 

--- a/src/nublado/purger/purger.py
+++ b/src/nublado/purger/purger.py
@@ -21,9 +21,7 @@ class Purger:
     """Object to plan and execute filesystem purges."""
 
     def __init__(
-        self,
-        config: Config,
-        logger: BoundLogger | None = None,
+        self, config: Config, logger: BoundLogger | None = None
     ) -> None:
         self._config = config
         self._logger = logger or get_logger(ROOT_LOGGER)

--- a/src/nublado/startup/exceptions.py
+++ b/src/nublado/startup/exceptions.py
@@ -35,9 +35,7 @@ class CommandFailedError(Exception):
     """
 
     def __init__(
-        self,
-        args: Iterable[str],
-        exc: subprocess.CalledProcessError,
+        self, args: Iterable[str], exc: subprocess.CalledProcessError
     ) -> None:
         args_str = join(args)
         msg = f"'{args_str}' failed with status {exc.returncode}"
@@ -65,9 +63,7 @@ class CommandTimedOutError(Exception):
     """
 
     def __init__(
-        self,
-        args: Iterable[str],
-        exc: subprocess.TimeoutExpired,
+        self, args: Iterable[str], exc: subprocess.TimeoutExpired
     ) -> None:
         args_str = join(args)
         msg = f"'{args_str}' timed out after {exc.timeout}s"

--- a/src/nublado/startup/utils.py
+++ b/src/nublado/startup/utils.py
@@ -3,11 +3,7 @@
 import os
 from pathlib import Path
 
-__all__ = [
-    "get_digest",
-    "get_jupyterlab_config_dir",
-    "get_runtime_mounts_dir",
-]
+__all__ = ["get_digest", "get_jupyterlab_config_dir", "get_runtime_mounts_dir"]
 
 
 def get_digest() -> str:

--- a/tests/controller/exceptions_test.py
+++ b/tests/controller/exceptions_test.py
@@ -80,10 +80,7 @@ def test_controller_timeout_error_sentry() -> None:
 
 def test_duplicate_object_error_slack() -> None:
     error = DuplicateObjectError(
-        message="whatever",
-        user="whomever",
-        kind="kind",
-        namespace="namespace",
+        message="whatever", user="whomever", kind="kind", namespace="namespace"
     )
 
     slack = error.to_slack().to_slack()
@@ -133,10 +130,7 @@ def test_duplicate_object_error_slack() -> None:
 
 def test_duplicate_object_error_sentry() -> None:
     error = DuplicateObjectError(
-        message="whatever",
-        user="whomever",
-        kind="kind",
-        namespace="namespace",
+        message="whatever", user="whomever", kind="kind", namespace="namespace"
     )
 
     sentry = error.to_sentry()

--- a/tests/controller/handlers/files_test.py
+++ b/tests/controller/handlers/files_test.py
@@ -382,21 +382,13 @@ async def test_start_errors(
             "GafaelfawrIngress",
             f"{namespace}/{username}-fs",
         ),
-        (
-            "create_namespaced_job",
-            "Job",
-            f"{namespace}/{username}-fs",
-        ),
+        ("create_namespaced_job", "Job", f"{namespace}/{username}-fs"),
         (
             "create_namespaced_persistent_volume_claim",
             "PersistentVolumeClaim",
             f"{namespace}/{username}-fs-pvc-scratch",
         ),
-        (
-            "create_namespaced_service",
-            "Service",
-            f"{namespace}/{username}-fs",
-        ),
+        ("create_namespaced_service", "Service", f"{namespace}/{username}-fs"),
     ]
     for api, kind, obj in possible_errors:
         apis_to_fail = {api}
@@ -463,7 +455,7 @@ async def test_start_errors(
                     },
                     {"type": "divider"},
                 ]
-            },
+            }
         ]
         mock_slack.messages = []
         r = await client.get("/nublado/fileserver/v1/users")

--- a/tests/controller/handlers/labs_test.py
+++ b/tests/controller/handlers/labs_test.py
@@ -791,7 +791,7 @@ async def test_spawn_errors(
                     },
                     {"type": "divider"},
                 ]
-            },
+            }
         ]
         mock_slack.messages = []
         r = await client.get(f"/nublado/spawner/v1/labs/{user.username}")
@@ -877,8 +877,7 @@ async def test_tmp_on_disk(
     await asyncio.sleep(0)
 
     pod = await mock_kubernetes.read_namespaced_pod(
-        f"{user.username}-nb",
-        f"{config.lab.namespace_prefix}-{user.username}",
+        f"{user.username}-nb", f"{config.lab.namespace_prefix}-{user.username}"
     )
     for vol in pod.spec.volumes:
         if vol.empty_dir and vol.name != "lab-startup":
@@ -907,8 +906,7 @@ async def test_alternate_paths(
     assert r.status_code == 201
     await asyncio.sleep(0)
     pod = await mock_kubernetes.read_namespaced_pod(
-        f"{user.username}-nb",
-        f"{config.lab.namespace_prefix}-{user.username}",
+        f"{user.username}-nb", f"{config.lab.namespace_prefix}-{user.username}"
     )
     container = pod.spec.containers[0]
     assert container.args == ["/usr/local/share/jupyterlab/runlab"]
@@ -1042,8 +1040,7 @@ async def test_init_container_command(
     await asyncio.sleep(0)
 
     pod = await mock_kubernetes.read_namespaced_pod(
-        f"{user.username}-nb",
-        f"{config.lab.namespace_prefix}-{user.username}",
+        f"{user.username}-nb", f"{config.lab.namespace_prefix}-{user.username}"
     )
     ic = pod.spec.init_containers[0]
     assert ic.command == ["nublado", "inithome"]
@@ -1072,8 +1069,7 @@ async def test_standard_inithome(
     await asyncio.sleep(0)
 
     pod = await mock_kubernetes.read_namespaced_pod(
-        f"{user.username}-nb",
-        f"{config.lab.namespace_prefix}-{user.username}",
+        f"{user.username}-nb", f"{config.lab.namespace_prefix}-{user.username}"
     )
     ic = pod.spec.init_containers[0]
     assert ic.name == "nublado-std-inithome"
@@ -1102,8 +1098,7 @@ async def test_landingpage(
     await asyncio.sleep(0)
 
     pod = await mock_kubernetes.read_namespaced_pod(
-        f"{user.username}-nb",
-        f"{config.lab.namespace_prefix}-{user.username}",
+        f"{user.username}-nb", f"{config.lab.namespace_prefix}-{user.username}"
     )
     icnames = [x.name for x in pod.spec.init_containers]
     assert icnames == [
@@ -1136,8 +1131,7 @@ async def test_alternative_home_volume(
     await asyncio.sleep(0)
 
     pod = await mock_kubernetes.read_namespaced_pod(
-        f"{user.username}-nb",
-        f"{config.lab.namespace_prefix}-{user.username}",
+        f"{user.username}-nb", f"{config.lab.namespace_prefix}-{user.username}"
     )
     icnames = [x.name for x in pod.spec.init_containers]
     assert icnames == [

--- a/tests/controller/models/v1/lab_test.py
+++ b/tests/controller/models/v1/lab_test.py
@@ -203,8 +203,7 @@ def test_cpu_resource_validation() -> None:
 
 def test_memory_resource_validation() -> None:
     with pytest.raises(
-        ValueError,
-        match=r"requests\.memory must be less than",
+        ValueError, match=r"requests\.memory must be less than"
     ):
         # Ignore type checking here because even though the
         # ResourceQuantity.memory field must eventually get parsed into an int,

--- a/tests/controller/services/prepuller_test.py
+++ b/tests/controller/services/prepuller_test.py
@@ -274,7 +274,7 @@ async def test_kubernetes_error(
                 },
                 {"type": "divider"},
             ]
-        },
+        }
     ]
 
 

--- a/tests/inithome/provisioner_test.py
+++ b/tests/inithome/provisioner_test.py
@@ -68,8 +68,7 @@ async def test_bad_ids() -> None:
 
 @pytest.mark.asyncio
 async def test_existing_dir(
-    privileged_fs: FakeFilesystem,
-    caplog: pytest.LogCaptureFixture,
+    privileged_fs: FakeFilesystem, caplog: pytest.LogCaptureFixture
 ) -> None:
     uid = 2000
     gid = 200
@@ -94,8 +93,7 @@ async def test_existing_dir(
 
 @pytest.mark.asyncio
 async def test_bad_ownership(
-    privileged_fs: FakeFilesystem,
-    caplog: pytest.LogCaptureFixture,
+    privileged_fs: FakeFilesystem, caplog: pytest.LogCaptureFixture
 ) -> None:
     uid = 9942
     gid = 500
@@ -137,8 +135,7 @@ async def test_bad_ownership(
 
 @pytest.mark.asyncio
 async def test_not_directory(
-    privileged_fs: FakeFilesystem,
-    caplog: pytest.LogCaptureFixture,
+    privileged_fs: FakeFilesystem, caplog: pytest.LogCaptureFixture
 ) -> None:
     uid = 4346
     gid = 4346
@@ -157,8 +154,7 @@ async def test_not_directory(
 
 @pytest.mark.asyncio
 async def test_wrong_permissions(
-    privileged_fs: FakeFilesystem,
-    caplog: pytest.LogCaptureFixture,
+    privileged_fs: FakeFilesystem, caplog: pytest.LogCaptureFixture
 ) -> None:
     uid = 7304
     gid = 7304

--- a/tests/support/data.py
+++ b/tests/support/data.py
@@ -24,9 +24,7 @@ class NubladoData(Data):
     """Test data management wrapper class."""
 
     def assert_kubernetes_matches(
-        self,
-        objects_raw: Iterable[dict | KubernetesModel],
-        path: str,
+        self, objects_raw: Iterable[dict | KubernetesModel], path: str
     ) -> None:
         """Serialize a list of Kubernetes objects and compare them.
 

--- a/tests/support/fileserver.py
+++ b/tests/support/fileserver.py
@@ -55,9 +55,7 @@ async def create_working_ingress_for_user(
 
 
 async def delete_ingress_for_user(
-    mock_kubernetes: MockKubernetesApi,
-    username: str,
-    namespace: str,
+    mock_kubernetes: MockKubernetesApi, username: str, namespace: str
 ) -> None:
     await mock_kubernetes.delete_namespaced_ingress(
         name=f"{username}-fs", namespace=namespace

--- a/tests/support/gafaelfawr.py
+++ b/tests/support/gafaelfawr.py
@@ -6,10 +6,7 @@ from nublado.controller.models.domain.gafaelfawr import GafaelfawrUser
 
 from .data import NubladoData
 
-__all__ = [
-    "GafaelfawrTestUser",
-    "create_gafaelfawr_user",
-]
+__all__ = ["GafaelfawrTestUser", "create_gafaelfawr_user"]
 
 
 class GafaelfawrTestUser(GafaelfawrUser):

--- a/tests/support/gar.py
+++ b/tests/support/gar.py
@@ -13,10 +13,7 @@ from google.cloud.artifactregistry_v1 import (
     ListDockerImagesRequest,
 )
 
-__all__ = [
-    "MockArtifactRegistry",
-    "patch_artifact_registry",
-]
+__all__ = ["MockArtifactRegistry", "patch_artifact_registry"]
 
 
 class MockArtifactRegistry(Mock):
@@ -48,8 +45,7 @@ class MockArtifactRegistry(Mock):
         self._fail = True
 
     async def list_docker_images(
-        self,
-        request: ListDockerImagesRequest,
+        self, request: ListDockerImagesRequest
     ) -> AsyncIterator[DockerImage]:
         """Retrieve the known list of images matching the request.
 


### PR DESCRIPTION
Stop forcing arguments onto multiple lines if there is a trailing comma. That trailing comma is added when arguments are too long to fit on one line, but under the previous setting they aren't moved back to one line if the become shorter. This setting provides more consistent formatting, where line breaks are determined solely by the length of the arguments.