### PR TITLE
DM-54523: Retry GAR requests on internal server errors

### DIFF
--- a/changelog.d/20260410_164147_rra_DM_54523_queue.md
+++ b/changelog.d/20260410_164147_rra_DM_54523_queue.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Retry Google Artifact Registry requests on internal service errors as well as service unavailable errors. These errors also seem to be transitory problems with the Google API.

--- a/src/nublado/controller/storage/gar.py
+++ b/src/nublado/controller/storage/gar.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from google.api_core.exceptions import ServiceUnavailable
+from google.api_core.exceptions import InternalServerError, ServiceUnavailable
 from google.cloud import artifactregistry_v1
 from google.cloud.artifactregistry_v1 import ListDockerImagesRequest
 from structlog.stdlib import BoundLogger
@@ -63,7 +63,7 @@ class GARStorageClient:
         for attempt in range(GAR_RETRY_LIMIT):
             try:
                 images = await self._fetch_image_list(config)
-            except ServiceUnavailable as e:
+            except (InternalServerError, ServiceUnavailable) as e:
                 msg = "Error listing images from GAR, retrying"
                 error = f"{type(e).__name__}: {e!s}"
                 logger.warning(msg, error=error, attempt=attempt)


### PR DESCRIPTION
Retry Google Artifact Registry requests on internal service errors as well as service unavailable errors. These errors also seem to be transitory problems with the Google API.