### PR TITLE
DM-54523: Refactor how Docker credentials are managed

### DIFF
--- a/src/nublado/cli.py
+++ b/src/nublado/cli.py
@@ -115,6 +115,13 @@ def images() -> None:
 
 @images.command("list")
 @click.option(
+    "-a",
+    "--credentials",
+    "docker_credentials_path",
+    type=click.Path(path_type=Path),
+    help="Path to Docker API credentials.",
+)
+@click.option(
     "-c",
     "--config",
     "config_path",
@@ -126,9 +133,18 @@ def images() -> None:
     "--debug", "-d", is_flag=True, envvar="DEBUG", help="Enable debug logging"
 )
 @run_with_asyncio
-async def images_list(*, config_path: Path, debug: bool) -> None:
+async def images_list(
+    *,
+    docker_credentials_path: Path | None = None,
+    config_path: Path,
+    debug: bool,
+) -> None:
     """List the available images."""
-    config = ImagesConfig.from_file(config_path, debug=debug)
+    config = ImagesConfig.from_file(
+        config_path,
+        docker_credentials_path=docker_credentials_path,
+        debug=debug,
+    )
     config.configure_logging()
     async with ImagesFactory.standalone(config) as factory:
         manager = factory.create_images_manager()

--- a/src/nublado/config/images.py
+++ b/src/nublado/config/images.py
@@ -8,7 +8,7 @@ from pydantic import ConfigDict, Field
 from pydantic.alias_generators import to_camel
 from safir.logging import LogLevel, Profile, configure_logging
 
-from ..constants import ROOT_LOGGER
+from ..constants import DOCKER_CREDENTIALS_PATH, ROOT_LOGGER
 from ..models.images import DockerSource, GARSource
 from .base import CamelEnvFirstSettings
 
@@ -54,6 +54,20 @@ type ImageSourceConfig = Annotated[
 class ImagesConfig(CamelEnvFirstSettings):
     """Configuration for Nublado image management."""
 
+    docker_credentials_path: Annotated[
+        Path | None,
+        Field(
+            title="Path to Docker API credentials",
+            description=(
+                "Path to a file containing a JSON-encoded dictionary of Docker"
+                " credentials for various registries, in the same format as"
+                " the Docker configuration file and the value of a Kubernetes"
+                " pull secret"
+            ),
+            exclude=True,
+        ),
+    ] = None
+
     log_level: Annotated[LogLevel, Field(title="Log level")] = LogLevel.INFO
 
     log_profile: Annotated[Profile, Field(title="Logging profile")] = (
@@ -66,16 +80,30 @@ class ImagesConfig(CamelEnvFirstSettings):
     ]
 
     @classmethod
-    def from_file(cls, path: Path, *, debug: bool | None = None) -> Self:
+    def from_file(
+        cls,
+        path: Path,
+        *,
+        debug: bool | None = None,
+        docker_credentials_path: Path | None = None,
+    ) -> Self:
         """Load the images configuration from a YAML file.
 
         Parameters
         ----------
         path
             Path to the configuration file.
+        debug
+            Whether to force debug logging.
+        docker_credentials_path
+            Path to the Docker API credentials file.
         """
+        if not docker_credentials_path and DOCKER_CREDENTIALS_PATH.is_file():
+            docker_credentials_path = DOCKER_CREDENTIALS_PATH
         with path.open("r") as f:
             config = cls.model_validate(yaml.safe_load(f))
+        if docker_credentials_path:
+            config.docker_credentials_path = docker_credentials_path
         if debug:
             config.log_level = LogLevel.DEBUG
         return config

--- a/src/nublado/controller/config.py
+++ b/src/nublado/controller/config.py
@@ -29,6 +29,7 @@ from safir.pydantic import HumanTimedelta
 from ..config.images import ImageSourceConfig
 from ..models.images import ImageFilterPolicy
 from .constants import (
+    DOCKER_CREDENTIALS_PATH,
     KUBERNETES_NAME_PATTERN,
     METADATA_PATH,
     RESERVED_ENV,
@@ -629,12 +630,27 @@ class PrepullerConfig(PrepullerOptions):
     """Configuration for the prepuller.
 
     This is identical to the API model used to return the prepuller
-    configuration to an API client except that camel-case aliases are enabled.
+    configuration to an API client except that camel-case aliases are enabled
+    and it adds the path to the Docker credentials, if any.
     """
 
     model_config = ConfigDict(
         alias_generator=to_camel, extra="forbid", populate_by_name=True
     )
+
+    docker_credentials_path: Annotated[
+        Path | None,
+        Field(
+            title="Path to Docker API credentials",
+            description=(
+                "Path to a file containing a JSON-encoded dictionary of Docker"
+                " credentials for various registries, in the same format as"
+                " the Docker configuration file and the value of a Kubernetes"
+                " pull secret"
+            ),
+            exclude=True,
+        ),
+    ] = DOCKER_CREDENTIALS_PATH
 
     source: Annotated[ImageSourceConfig, Field(title="Source of images")]
 

--- a/src/nublado/controller/factory.py
+++ b/src/nublado/controller/factory.py
@@ -127,7 +127,7 @@ class ProcessContext:
         match config.images.source:
             case DockerSource():
                 docker_client = DockerStorageClient(
-                    credentials_path=config.images.source.credentials_path,
+                    credentials_path=config.images.docker_credentials_path,
                     http_client=http_client,
                     logger=logger,
                 )
@@ -371,7 +371,7 @@ class Factory:
         """
         if self._context.config.images.source.type != "docker":
             raise NotConfiguredError("Docker image source not configured")
-        credentials_path = self._context.config.images.source.credentials_path
+        credentials_path = self._context.config.images.docker_credentials_path
         return DockerStorageClient(
             credentials_path=credentials_path,
             http_client=self._context.http_client,

--- a/src/nublado/factory.py
+++ b/src/nublado/factory.py
@@ -76,7 +76,7 @@ class ImagesFactory:
         match self._config.source:
             case DockerSource():
                 docker_client = DockerStorageClient(
-                    self._config.source.credentials_path,
+                    self._config.docker_credentials_path,
                     self._http_client,
                     self._logger,
                 )

--- a/src/nublado/models/docker.py
+++ b/src/nublado/models/docker.py
@@ -66,7 +66,14 @@ class DockerCredentials:
 
 
 class DockerCredentialStore:
-    """Read and write the ``.dockerconfigjson`` syntax used by Kubernetes."""
+    """Read and write the ``.dockerconfigjson`` syntax used by Kubernetes.
+
+    Parameters
+    ----------
+    credentials
+        Mapping of registry hosts to credentials, or `None` to create an
+        empty credential store.
+    """
 
     @classmethod
     def from_path(cls, path: Path) -> Self:
@@ -89,8 +96,10 @@ class DockerCredentialStore:
             credentials[host] = DockerCredentials.from_config(config)
         return cls(credentials)
 
-    def __init__(self, credentials: dict[str, DockerCredentials]) -> None:
-        self._credentials = credentials
+    def __init__(
+        self, credentials: dict[str, DockerCredentials] | None = None
+    ) -> None:
+        self._credentials = credentials or {}
 
     def get(self, host: str) -> DockerCredentials | None:
         """Get credentials for a given host.

--- a/src/nublado/models/images/_sources.py
+++ b/src/nublado/models/images/_sources.py
@@ -1,12 +1,8 @@
 """Models for specifying the sources of images."""
 
-from pathlib import Path
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
-
-from ...constants import DOCKER_CREDENTIALS_PATH
-from ..docker import DockerCredentialStore
 
 __all__ = ["DockerSource", "GARSource", "ImageSource"]
 
@@ -39,36 +35,6 @@ class DockerSource(BaseModel):
             examples=["library/sketchbook"],
         ),
     ]
-
-    credentials_path: Annotated[
-        Path,
-        Field(
-            title="Path to Docker API credentials",
-            description=(
-                "Path to a file containing a JSON-encoded dictionary of Docker"
-                " credentials for various registries, in the same format as"
-                " the Docker configuration file and the value of a Kubernetes"
-                " pull secret"
-            ),
-            exclude=True,
-        ),
-    ] = DOCKER_CREDENTIALS_PATH
-
-    def read_credentials(self) -> DockerCredentialStore:
-        """Load the credentials store.
-
-        Returns
-        -------
-        DockerCredentialStore
-            Object representing the contents of the credentials store.
-
-        Raises
-        ------
-        FileNotFoundError
-            Raised if the file pointed to by ``credentials_path`` does not
-            exist.
-        """
-        return DockerCredentialStore.from_path(self.credentials_path)
 
     def to_logging_context(self) -> dict[str, str]:
         """Build key/value pairs suitable for passing to structlog.

--- a/src/nublado/storage/docker.py
+++ b/src/nublado/storage/docker.py
@@ -29,7 +29,8 @@ class DockerStorageClient:
     Parameters
     ----------
     credentials_path
-        Path to a Docker credentials store.
+        Path to a Docker credentials store, or `None` if no authentication
+        will be required.
     http_client
         Client to use to make requests.
     logger
@@ -38,11 +39,15 @@ class DockerStorageClient:
 
     def __init__(
         self,
-        credentials_path: Path,
+        credentials_path: Path | None,
         http_client: AsyncClient,
         logger: BoundLogger,
     ) -> None:
-        self._credentials = DockerCredentialStore.from_path(credentials_path)
+        if credentials_path:
+            credentials = DockerCredentialStore.from_path(credentials_path)
+        else:
+            credentials = DockerCredentialStore()
+        self._credentials = credentials
         self._client = http_client
         self._logger = logger
 

--- a/tests/controller/conftest.py
+++ b/tests/controller/conftest.py
@@ -21,6 +21,7 @@ from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 from nublado.controller.config import Config
 from nublado.controller.factory import Factory
 from nublado.controller.main import create_app
+from nublado.models.docker import DockerCredentialStore
 from nublado.models.images import DockerSource
 
 from ..support.config import configure
@@ -105,9 +106,13 @@ def mock_docker(
     config: Config, data: NubladoData, respx_mock: respx.Router
 ) -> MockDockerRegistry:
     assert isinstance(config.images.source, DockerSource)
+    credentials_path = config.images.docker_credentials_path
+    assert credentials_path
+    credentials_store = DockerCredentialStore.from_path(credentials_path)
     return register_mock_docker(
         respx_mock,
         config.images.source,
+        credentials_store,
         tags=data.read_json("registry/docker"),
         require_bearer=True,
     )

--- a/tests/storage/docker_test.py
+++ b/tests/storage/docker_test.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 from structlog import get_logger
 
 from nublado.exceptions import DockerInvalidUrlError
+from nublado.models.docker import DockerCredentialStore
 from nublado.models.images import DockerSource
 from nublado.storage.docker import DockerStorageClient
 
@@ -16,22 +17,30 @@ from ..support.docker import register_mock_docker
 
 
 @pytest.fixture
-def docker_client(source: DockerSource) -> DockerStorageClient:
-    return DockerStorageClient(
-        source.credentials_path, AsyncClient(), get_logger(__name__)
-    )
+def credential_store(data: NubladoData) -> DockerCredentialStore:
+    path = data.path("registry/docker-creds.json")
+    return DockerCredentialStore.from_path(path)
+
+
+@pytest.fixture
+def docker_client(
+    data: NubladoData, source: DockerSource
+) -> DockerStorageClient:
+    credential_path = data.path("registry/docker-creds.json")
+    logger = get_logger(__name__)
+    return DockerStorageClient(credential_path, AsyncClient(), logger)
 
 
 @pytest.fixture
 def source(data: NubladoData) -> DockerSource:
-    source = data.read_pydantic(DockerSource, "storage/docker-source")
-    source.credentials_path = data.path("registry/docker-creds.json")
-    return source
+    return data.read_pydantic(DockerSource, "storage/docker-source")
 
 
 @pytest.mark.asyncio
 async def test_api(
+    *,
     source: DockerSource,
+    credential_store: DockerCredentialStore,
     docker_client: DockerStorageClient,
     respx_mock: respx.Router,
 ) -> None:
@@ -45,7 +54,9 @@ async def test_api(
         "d_2021_06_15",
     }
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
-    register_mock_docker(respx_mock, source, tags, paginate=True)
+    register_mock_docker(
+        respx_mock, source, credential_store, tags=tags, paginate=True
+    )
     assert await docker_client.list_tags(source) == tag_names
     digest = await docker_client.get_image_digest(source, "w_2021_21")
     assert digest == tags["w_2021_21"]
@@ -55,13 +66,17 @@ async def test_api(
 
 @pytest.mark.asyncio
 async def test_api_nonpaginated(
+    *,
     source: DockerSource,
+    credential_store: DockerCredentialStore,
     docker_client: DockerStorageClient,
     respx_mock: respx.Router,
 ) -> None:
     tag_names = {"w_2021_21", "w_2021_22", "d_2021_06_14", "d_2021_06_15"}
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
-    register_mock_docker(respx_mock, source, tags, paginate=False)
+    register_mock_docker(
+        respx_mock, source, credential_store, tags=tags, paginate=False
+    )
     assert await docker_client.list_tags(source) == tag_names
     digest = await docker_client.get_image_digest(source, "w_2021_21")
     assert digest == tags["w_2021_21"]
@@ -71,12 +86,16 @@ async def test_api_nonpaginated(
 
 @pytest.mark.asyncio
 async def test_bearer_auth(
+    *,
     source: DockerSource,
+    credential_store: DockerCredentialStore,
     docker_client: DockerStorageClient,
     respx_mock: respx.Router,
 ) -> None:
     tags = {"r23_0_4": "sha256:" + os.urandom(32).hex()}
-    register_mock_docker(respx_mock, source, tags, require_bearer=True)
+    register_mock_docker(
+        respx_mock, source, credential_store, tags=tags, require_bearer=True
+    )
     assert await docker_client.list_tags(source) == {"r23_0_4"}
     digest = await docker_client.get_image_digest(source, "r23_0_4")
     assert digest == tags["r23_0_4"]
@@ -84,14 +103,21 @@ async def test_bearer_auth(
 
 @pytest.mark.asyncio
 async def test_duplicate_url(
+    *,
     source: DockerSource,
+    credential_store: DockerCredentialStore,
     docker_client: DockerStorageClient,
     respx_mock: respx.Router,
 ) -> None:
     tag_names = {"w_2021_21", "w_2021_22", "d_2021_06_14", "d_2021_06_15"}
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
     register_mock_docker(
-        respx_mock, source, tags, paginate=True, duplicate_url=True
+        respx_mock,
+        source,
+        credential_store,
+        tags=tags,
+        paginate=True,
+        duplicate_url=True,
     )
     with pytest.raises(DockerInvalidUrlError):
         await docker_client.list_tags(source)

--- a/tests/support/config.py
+++ b/tests/support/config.py
@@ -49,7 +49,7 @@ async def configure(
     config.metadata_path = data.path("controller/metadata")
     if isinstance(config.images.source, DockerSource):
         credentials_path = data.path("registry/docker-creds.json")
-        config.images.source.credentials_path = credentials_path
+        config.images.docker_credentials_path = credentials_path
 
     # If the new configuration enables fileservers, create the namespace for
     # the fileserver pods. Existence of the fileserver namespace is checked

--- a/tests/support/docker.py
+++ b/tests/support/docker.py
@@ -237,8 +237,9 @@ class MockDockerRegistry:
 def register_mock_docker(
     respx_mock: respx.Router,
     config: DockerSource,
-    tags: dict[str, str],
+    credential_store: DockerCredentialStore,
     *,
+    tags: dict[str, str],
     require_bearer: bool = False,
     paginate: bool = True,
     duplicate_url: bool = False,
@@ -252,6 +253,8 @@ def register_mock_docker(
         Mock router.
     config
         Configuration for the Docker image source.
+    credential_store
+        Store of Docker credentials to expect.
     tags
         A mapping of tags to image digests that should appear on that
         registry.
@@ -278,8 +281,7 @@ def register_mock_docker(
     tags_url = f"{base_url}/v2/{config.repository}/tags/list"
     digest_url = f"{base_url}/v2/{config.repository}/manifests/(?P<tag>.*)"
 
-    store = DockerCredentialStore.from_path(config.credentials_path)
-    credentials = store.get(config.registry)
+    credentials = credential_store.get(config.registry)
     assert credentials
     mock = MockDockerRegistry(
         tags,


### PR DESCRIPTION
The path to the Docker credentials store is independent of any given Docker image source. Remove the credentials path from the source configuration, in anticipation of a future world where we will have multiple sources, and instead configure it separately at the next level up in the configuration.