### PR TITLE
DM-54523: Refactor how Docker credentials are managed

### DIFF
--- a/src/nublado/config/images.py
+++ b/src/nublado/config/images.py
@@ -106,6 +106,8 @@ class ImagesConfig(CamelEnvFirstSettings):
             config.docker_credentials_path = docker_credentials_path
         if debug:
             config.log_level = LogLevel.DEBUG
+        if docker_credentials_path:
+            config.docker_credentials_path = docker_credentials_path
         return config
 
     def configure_logging(self) -> None:


### PR DESCRIPTION
The path to the Docker credentials store is independent of any given Docker image source. Remove the credentials path from the source configuration, in anticipation of a future world where we will have multiple sources, and instead configure it separately at the next level up in the configuration.