### PR TITLE
DM-54523: Add support for inverted filters

### DIFF
--- a/src/nublado/models/images/_image.py
+++ b/src/nublado/models/images/_image.py
@@ -272,6 +272,7 @@ class RSPImageCollection:
         policy: ImageFilterPolicy,
         age_basis: datetime,
         *,
+        invert: bool = False,
         remove_arch_specific: bool = True,
     ) -> Iterator[RSPImage]:
         """Apply a filter policy and return the remaining images.
@@ -282,9 +283,12 @@ class RSPImageCollection:
             Policy governing tag filtering.
         age_basis
             Timestamp to use as basis for image age calculation.
+        invert
+            Invert the filtering: Return only images that are not accepted by
+            the filter.
         remove_arch_specific
-            If `True`, remove images for a specific architecture and only
-            include images for all supported architectures.
+            If `True`, remove all images for a specific architecture from the
+            results and return only architecture-independent images.
 
         Yields
         ------
@@ -473,11 +477,11 @@ class RSPImageCollection:
         images = [i for i in images if cycle is None or i.cycle == cycle]
         self._collection = RSPImageTagCollection(images)
 
-        # First pass: Store all images other than unresolved images by digest.
-        # Accumulate a list of unresolved images. If there is a conflict
-        # between two non-alias images, the first one added wins on the theory
-        # that hopefully the Docker image source API returns the newest images
-        # first.
+        # First pass: Store all images other than unresolved aliases by
+        # digest. Accumulate a list of unresolved images. If there is a
+        # conflict between two non-alias images, the first one added wins on
+        # the theory that hopefully the Docker image source API returns the
+        # newest images first.
         unresolved = []
         for image in images:
             if image.is_possible_alias:
@@ -488,7 +492,7 @@ class RSPImageCollection:
             else:
                 self._by_digest[image.digest] = image
 
-        # Second pass: add the unresolved images now that any images they
+        # Second pass: Add the unresolved images now that any images they
         # alias should have been found. This is when we discover the targets
         # of alias images so that we can resolve them. Do not try to resolve
         # one alias or unknown tag with another; that adds no value. Keep
@@ -503,8 +507,8 @@ class RSPImageCollection:
                 self._by_digest[image.digest] = image
 
         # Now, all images have been resolved where possible. Rebuild the tag
-        # collection. This has to be done again since the type of the image
-        # may change, which affects the indexing.
+        # collection. The rebuild is required since the type of images may
+        # have changed during alias resolution, which affects the indexing.
         self._collection = RSPImageTagCollection(images)
 
     def _resolve_duplicate(self, new: RSPImage, old: RSPImage) -> None:
@@ -513,7 +517,7 @@ class RSPImageCollection:
         Implements the following logic:
 
         #. If both images are possible aliases, mark them as aliases of each
-           other and add ``new`` to the list of possible aliases.
+           other and add ``new`` to the list of unresolved aliases.
         #. If ``new`` is a possible alias and ``old`` is not, resolve ``new``
            as an alias of ``old`` and add ``new`` as an alias of all of the
            aliases of ``old``.
@@ -525,8 +529,8 @@ class RSPImageCollection:
 
         The final case, where ``old`` is a possible alias and ``new`` is not,
         is not possible by construction so is ignored. (In `add`, this case is
-        handled by rebuilding the whole collection, and when building the
-        collection possible aliases are always added second.)
+        handled by rebuilding the whole collection. When building the
+        collection, possible aliases are always added second.)
 
         Parameters
         ----------

--- a/src/nublado/models/images/_tag.py
+++ b/src/nublado/models/images/_tag.py
@@ -3,7 +3,7 @@
 import contextlib
 import re
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import total_ordering
@@ -576,6 +576,7 @@ class RSPImageTagCollection[T: RSPImageTag]:
         policy: ImageFilterPolicy,
         age_basis: datetime,
         *,
+        invert: bool = False,
         remove_arch_specific: bool = True,
     ) -> Iterator[T]:
         """Apply a filter policy and return the remaining tags.
@@ -585,10 +586,13 @@ class RSPImageTagCollection[T: RSPImageTag]:
         policy
             Policy governing tag filtering.
         age_basis
-            Timestamp to use as basis for image age calculation.
+            Timestamp to use as basis for tag age calculation.
+        invert
+            Invert the filtering: Return only tags that are not accepted by
+            the filter.
         remove_arch_specific
-            If `True`, remove tags for a specific architecture and only
-            include tags for all supported architectures.
+            If `True`, remove all tags for a specific architecture from the
+            results and return only architecture-independent tags.
 
         Yields
         ------
@@ -600,6 +604,7 @@ class RSPImageTagCollection[T: RSPImageTag]:
                 self._by_type[image_type],
                 policy.for_image_type(image_type),
                 age_basis,
+                invert=invert,
                 remove_arch_specific=remove_arch_specific,
             )
 
@@ -680,12 +685,66 @@ class RSPImageTagCollection[T: RSPImageTag]:
         """
         return self._by_tag.get(tag_name)
 
+    def _build_filter(
+        self,
+        policy: ImageFilter,
+        age_basis: datetime,
+        *,
+        invert: bool = False,
+        remove_arch_specific: bool = False,
+    ) -> Callable[[Iterable[T]], Iterator[T]]:
+        """Construct a filter iterator from an image filter.
+
+        Parameters
+        ----------
+        policy
+            Image filter policy to apply, or `None` to do no filtering.
+        age_basis
+            Current time to use as a basis for age filters.
+        invert
+            Invert the filtering: Return only tags that are not accepted by
+            the filter.
+        remove_arch_specific
+            If `True`, remove all tags for a specific architecture from the
+            results and return only architecture-independent tags.
+
+        Returns
+        -------
+        typing.Callable
+            A function that takes an iterator of tags and returns the filtered
+            version of those tags.
+        """
+        date = (age_basis - policy.age) if policy.age else None
+        if policy.cutoff_date and (not date or date < policy.cutoff_date):
+            date = policy.cutoff_date
+        version = policy.cutoff_version
+
+        # Construct a closure that implements the filtering rules.
+        def tag_filter(tags: Iterable[T]) -> Iterator[T]:
+            count = 0
+            for tag in tags:
+                if remove_arch_specific and tag.architecture:
+                    continue
+                if tag.date and date and tag.date < date:
+                    continue
+                if tag.semantic:
+                    if tag.version and version and tag.version < version:
+                        continue
+                yield tag
+                count += 1
+                if policy.number and count >= policy.number:
+                    break
+
+        # Return the constructed filter.
+        return tag_filter
+
     def _filter_image_list(
         self,
         tags: list[T],
         policy: ImageFilter | None,
         age_basis: datetime,
         *,
+        invert: bool = False,
         remove_arch_specific: bool = True,
     ) -> Iterator[T]:
         """Filter a list of tags against a filter policy.
@@ -698,37 +757,33 @@ class RSPImageTagCollection[T: RSPImageTag]:
             Image filter policy to apply, or `None` to do no filtering.
         age_basis
             Current time to use as a basis for age filters.
+        invert
+            Invert the filtering: Return only tags that are not accepted by
+            the filter.
         remove_arch_specific
-            If `True`, remove tags for a specific architecture and only
-            include tags for all supported architectures.
+            If `True`, remove all tags for a specific architecture from the
+            results and return only architecture-independent tags.
         """
+        if remove_arch_specific:
+            candidate_tags = (t for t in tags if not t.architecture)
+        else:
+            candidate_tags = (t for t in tags)
+
+        # If there is no policy, return all tags (or, if inverted, no tags).
         if not policy:
-            if remove_arch_specific:
-                filtered_tags = (t for t in tags if not t.architecture)
-            else:
-                filtered_tags = (t for t in tags)
-            yield from filtered_tags
+            if invert:
+                return
+            yield from candidate_tags
             return
 
-        # Some filtering rule applies. Calculate the cutoffs and apply the
-        # filtering.
-        date = (age_basis - policy.age) if policy.age else None
-        if policy.cutoff_date and (not date or date < policy.cutoff_date):
-            date = policy.cutoff_date
-        version = policy.cutoff_version
-        count = 0
-        for tag in tags:
-            if remove_arch_specific and tag.architecture:
-                continue
-            if tag.date and date and tag.date < date:
-                continue
-            if tag.semantic:
-                if tag.version and version and tag.version < version:
-                    continue
-            yield tag
-            count += 1
-            if policy.number and count >= policy.number:
-                break
+        # Otherwise, do the filtering, and then invert it if requested.
+        tag_filter = self._build_filter(policy, age_basis)
+        if invert:
+            all_tags = list(candidate_tags)
+            remove_tags = set(tag_filter(all_tags))
+            yield from (t for t in all_tags if t not in remove_tags)
+        else:
+            yield from tag_filter(candidate_tags)
 
     def _first_tags(
         self,

--- a/tests/models/images/filter_test.py
+++ b/tests/models/images/filter_test.py
@@ -81,6 +81,15 @@ def test_filter() -> None:
         "unknown",
     ]
 
+    # If this filtering is inverted, the combination of the two lists should
+    # be exactly the original list of tags except for ones with architecture
+    # qualifiers.
+    remaining_tags = [
+        x.tag for x in collection.filter(policy, age_basis, invert=True)
+    ]
+    non_arch = sorted(t for t in tags if not t.endswith(("-amd64", "-arm64")))
+    assert sorted(filtered_tags + remaining_tags) == sorted(non_arch)
+
     # Redo the filtering without excluding arch-specific images (the
     # non-default mode). Version- and date-based filtering should just include
     # the new images. Count-based filtering will push a different image off.
@@ -106,6 +115,15 @@ def test_filter() -> None:
         "exp_w_2025_07",
         "unknown",
     ]
+
+    # If this filtering is inverted, we should get exactly the excluded tags.
+    remaining_tags = [
+        x.tag
+        for x in collection.filter(
+            policy, age_basis, invert=True, remove_arch_specific=False
+        )
+    ]
+    assert sorted(filtered_tags + remaining_tags) == sorted(tags)
 
 
 def test_filter_semver() -> None:


### PR DESCRIPTION
In preparation for supporting image pruning, add the ability to invert an RSP tag or image filter to return only the tags or images that are not accepted by the filter.