### PR TITLE
DM-54523: Allow creating a tag collection without aliases

### DIFF
--- a/src/nublado/models/images/_tag.py
+++ b/src/nublado/models/images/_tag.py
@@ -501,7 +501,7 @@ class RSPImageTagCollection[T: RSPImageTag]:
     def from_tag_names(
         cls,
         tag_names: Iterable[str],
-        aliases: set[str],
+        aliases: set[str] | None = None,
         cycle: int | None = None,
     ) -> RSPImageTagCollection[RSPImageTag]:
         """Create a collection from tag strings.
@@ -520,6 +520,8 @@ class RSPImageTagCollection[T: RSPImageTag]:
         RSPImageTagCollection
             The resulting collection of tags.
         """
+        if aliases is None:
+            aliases = set()
         tags = []
         for name in tag_names:
             if name in aliases:

--- a/tests/models/images/filter_test.py
+++ b/tests/models/images/filter_test.py
@@ -138,7 +138,7 @@ def test_filter_semver() -> None:
         "exp_r28_0_1_exp",
         "exp_r28_0_0_exp",
     ]
-    collection = RSPImageTagCollection.from_tag_names(tags, set())
+    collection = RSPImageTagCollection.from_tag_names(tags)
 
     # Construct a filter that uses 28.0.1 as a semantic version cutoff. This
     # should have no effect on the weeklies but should affect the experimental

--- a/tests/models/images/tag_test.py
+++ b/tests/models/images/tag_test.py
@@ -170,7 +170,7 @@ def test_collection() -> None:
     shuffled_tags = list(tags)
     SystemRandom().shuffle(shuffled_tags)
 
-    collection = RSPImageTagCollection.from_tag_names(shuffled_tags, set())
+    collection = RSPImageTagCollection.from_tag_names(shuffled_tags)
     all_tags = [t.tag for t in collection.all_tags(hide_arch_specific=False)]
     assert all_tags == tags
     assert [t.tag for t in collection.all_tags()] == [
@@ -182,9 +182,7 @@ def test_collection() -> None:
     assert collection.tag_for_tag_name("w_2080_01") is None
 
     # Filter by cycle.
-    collection = RSPImageTagCollection.from_tag_names(
-        shuffled_tags, set(), cycle=27
-    )
+    collection = RSPImageTagCollection.from_tag_names(shuffled_tags, cycle=27)
     assert [t.tag for t in collection.all_tags()] == [
         "r20_0_1_c0027.001",
         "w_2077_40_c0027.001",


### PR DESCRIPTION
Make the aliases argument to the class method to construct an image tag collection optional. When doing tag analysis for pruning, we don't care what tags are aliases.