### PR TITLE
DM-54523: Provide a default for the filtering age basis

### DIFF
--- a/src/nublado/controller/services/source/docker.py
+++ b/src/nublado/controller/services/source/docker.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from collections.abc import Mapping
-from datetime import UTC, datetime
 from typing import override
 
 from structlog.stdlib import BoundLogger
@@ -210,7 +209,7 @@ class DockerImageSource(ImageSource):
         registry = self._config.registry
         repository = self._config.repository
         menu_images = []
-        for tag in self._tags.filter(self._image_filter, datetime.now(tz=UTC)):
+        for tag in self._tags.filter(self._image_filter):
             image = self._images.image_for_tag_name(tag.tag)
             if image:
                 menu_image = MenuImage.from_rsp_image(image)

--- a/src/nublado/controller/services/source/gar.py
+++ b/src/nublado/controller/services/source/gar.py
@@ -1,7 +1,6 @@
 """Image source using a Google Artifact Registry."""
 
 from collections.abc import Mapping
-from datetime import UTC, datetime
 from typing import override
 
 from structlog.stdlib import BoundLogger
@@ -153,8 +152,7 @@ class GARImageSource(ImageSource):
             f"Constructing menu from {len(list(self._images.all_images()))}"
             " images"
         )
-        now = datetime.now(tz=UTC)
-        filtered = self._images.filter(self._image_filter, now)
+        filtered = self._images.filter(self._image_filter)
         menu_images = [MenuImage.from_rsp_image(i) for i in filtered]
         self._logger.debug(f"Filtered menu contains {len(menu_images)} images")
         return menu_images

--- a/src/nublado/models/images/_image.py
+++ b/src/nublado/models/images/_image.py
@@ -270,7 +270,7 @@ class RSPImageCollection:
     def filter(
         self,
         policy: ImageFilterPolicy,
-        age_basis: datetime,
+        age_basis: datetime | None = None,
         *,
         invert: bool = False,
         remove_arch_specific: bool = True,
@@ -282,7 +282,8 @@ class RSPImageCollection:
         policy
             Policy governing tag filtering.
         age_basis
-            Timestamp to use as basis for image age calculation.
+            Timestamp to use as basis for image age calculation. If `None` or
+            not given, use the current time.
         invert
             Invert the filtering: Return only images that are not accepted by
             the filter.

--- a/src/nublado/models/images/_tag.py
+++ b/src/nublado/models/images/_tag.py
@@ -576,7 +576,7 @@ class RSPImageTagCollection[T: RSPImageTag]:
     def filter(
         self,
         policy: ImageFilterPolicy,
-        age_basis: datetime,
+        age_basis: datetime | None = None,
         *,
         invert: bool = False,
         remove_arch_specific: bool = True,
@@ -588,7 +588,8 @@ class RSPImageTagCollection[T: RSPImageTag]:
         policy
             Policy governing tag filtering.
         age_basis
-            Timestamp to use as basis for tag age calculation.
+            Timestamp to use as basis for tag age calculation. If `None` or
+            not given, use the current time.
         invert
             Invert the filtering: Return only tags that are not accepted by
             the filter.
@@ -601,6 +602,8 @@ class RSPImageTagCollection[T: RSPImageTag]:
         RSPImageTag
             Next tag allowed under the policy.
         """
+        if not age_basis:
+            age_basis = datetime.now(tz=UTC)
         for image_type in RSPImageType:
             yield from self._filter_image_list(
                 self._by_type[image_type],

--- a/tests/models/images/filter_test.py
+++ b/tests/models/images/filter_test.py
@@ -152,8 +152,7 @@ def test_filter_semver() -> None:
     )
 
     # Run the filter and check the results. The age basis shouldn't matter.
-    now = datetime.now(tz=UTC)
-    filtered_tags = [x.tag for x in collection.filter(policy, now)]
+    filtered_tags = [x.tag for x in collection.filter(policy)]
     assert filtered_tags == [
         "r28_0_1",
         "w_2025_07",


### PR DESCRIPTION
When filtering tags or images, default the age basis to the current time if it's not given. This simplifies the code for single-pass filtering.