### PR TITLE
DM-54523: Add support for pruning images

### DIFF
--- a/changelog.d/20260423_160022_rra_DM_54523.md
+++ b/changelog.d/20260423_160022_rra_DM_54523.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a new command, `nublado images prune`, to delete some Nublado images from a repository based on a pruning policy.

--- a/src/nublado/cli.py
+++ b/src/nublado/cli.py
@@ -22,6 +22,7 @@ from .constants import ALERT_HOOK_ENV_VAR, ROOT_LOGGER
 from .factory import ImagesFactory
 from .inithome.provisioner import Provisioner
 from .landingpage.provisioner import Provisioner as LandingPageProvisioner
+from .models.images import RSPImageTagCollection
 from .purger.config import Config as PurgerConfig
 from .purger.constants import CONFIG_FILE as PURGER_CONFIG_FILE
 from .purger.constants import CONFIG_FILE_ENV_VAR as PURGER_CONFIG_FILE_ENV_VAR
@@ -148,8 +149,63 @@ async def images_list(
     config.configure_logging()
     async with ImagesFactory.standalone(config) as factory:
         manager = factory.create_images_manager()
-        images = await manager.list_tags(config.source)
-    sys.stdout.write("\n".join(sorted(images)))
+        unsorted_tags = await manager.list_tags(config.source)
+        collection = RSPImageTagCollection.from_tag_names(unsorted_tags)
+        tags = [t.tag for t in collection.all_tags(hide_arch_specific=False)]
+    sys.stdout.write("\n".join(tags))
+    sys.stdout.write("\n")
+
+
+@images.command("prune")
+@click.option(
+    "-a",
+    "--credentials",
+    "docker_credentials_path",
+    type=click.Path(path_type=Path),
+    help="Path to Docker API credentials.",
+)
+@click.option(
+    "-c",
+    "--config",
+    "config_path",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Path to images configuration.",
+)
+@click.option(
+    "--debug", "-d", is_flag=True, envvar="DEBUG", help="Enable debug logging"
+)
+@click.option(
+    "-n",
+    "--dry-run",
+    is_flag=True,
+    help="Do not act, but report what would be done",
+)
+@run_with_asyncio
+async def images_prune(
+    *,
+    docker_credentials_path: Path | None = None,
+    config_path: Path,
+    debug: bool,
+    dry_run: bool,
+) -> None:
+    """List the available images."""
+    config = ImagesConfig.from_file(
+        config_path,
+        docker_credentials_path=docker_credentials_path,
+        debug=debug,
+    )
+    if not config.prune:
+        raise click.UsageError("No image prune filter defined in config")
+    config.configure_logging()
+    async with ImagesFactory.standalone(config) as factory:
+        manager = factory.create_images_manager()
+        images = await manager.prune_images(
+            config.source, config.prune, dry_run=dry_run
+        )
+    sys.stdout.write("Would delete images" if dry_run else "Deleted images")
+    sys.stdout.write(":\n  ")
+    sys.stdout.write("\n  ".join(images))
     sys.stdout.write("\n")
 
 

--- a/src/nublado/config/images.py
+++ b/src/nublado/config/images.py
@@ -9,7 +9,7 @@ from pydantic.alias_generators import to_camel
 from safir.logging import LogLevel, Profile, configure_logging
 
 from ..constants import DOCKER_CREDENTIALS_PATH, ROOT_LOGGER
-from ..models.images import DockerSource, GARSource
+from ..models.images import DockerSource, GARSource, ImageFilterPolicy
 from .base import CamelEnvFirstSettings
 
 __all__ = [
@@ -73,6 +73,17 @@ class ImagesConfig(CamelEnvFirstSettings):
     log_profile: Annotated[Profile, Field(title="Logging profile")] = (
         Profile.production
     )
+
+    prune: Annotated[
+        ImageFilterPolicy | None,
+        Field(
+            title="Prune policy",
+            description=(
+                "Policy describing which images to retain. All others will be"
+                " pruned."
+            ),
+        ),
+    ] = None
 
     source: Annotated[
         ImageSourceConfig,

--- a/src/nublado/constants.py
+++ b/src/nublado/constants.py
@@ -7,6 +7,7 @@ __all__ = [
     "ALERT_HOOK_ENV_VAR",
     "DOCKER_CREDENTIALS_PATH",
     "ENV_PREFIX",
+    "GAR_DELETE_BATCH_SIZE",
     "GAR_RETRY_DELAY",
     "GAR_RETRY_LIMIT",
     "ROOT_LOGGER",
@@ -20,6 +21,9 @@ ALERT_HOOK_ENV_VAR = f"{ENV_PREFIX}_ALERT_HOOK"
 
 DOCKER_CREDENTIALS_PATH = Path("/etc/secrets/.dockerconfigjson")
 """Default path to the Docker API secrets."""
+
+GAR_DELETE_BATCH_SIZE = 50
+"""Number of images to delete from Google Artifact Registry at a time."""
 
 GAR_RETRY_DELAY = timedelta(seconds=10)
 """How long to wait between Google Artifact Registry retries."""

--- a/src/nublado/models/images/_filter.py
+++ b/src/nublado/models/images/_filter.py
@@ -1,6 +1,5 @@
 """Policy for selecting images based on filter criteria."""
 
-from datetime import datetime
 from typing import Annotated
 
 from pydantic import (
@@ -11,7 +10,7 @@ from pydantic import (
     PlainSerializer,
 )
 from pydantic.alias_generators import to_camel
-from safir.pydantic import HumanTimedelta
+from safir.pydantic import HumanTimedelta, UtcDatetime
 from semver import Version
 
 from ._type import RSPImageType
@@ -65,7 +64,7 @@ class ImageFilter(BaseModel):
     ] = None
 
     cutoff_date: Annotated[
-        datetime | None,
+        UtcDatetime | None,
         Field(
             title="Cutoff date",
             description=(

--- a/src/nublado/models/images/_image.py
+++ b/src/nublado/models/images/_image.py
@@ -297,7 +297,10 @@ class RSPImageCollection:
             Next image matching the criteria.
         """
         yield from self._collection.filter(
-            policy, age_basis, remove_arch_specific=remove_arch_specific
+            policy,
+            age_basis,
+            invert=invert,
+            remove_arch_specific=remove_arch_specific,
         )
 
     def image_for_digest(self, digest: str) -> RSPImage | None:

--- a/src/nublado/models/images/_tag.py
+++ b/src/nublado/models/images/_tag.py
@@ -785,8 +785,8 @@ class RSPImageTagCollection[T: RSPImageTag]:
         tag_filter = self._build_filter(policy, age_basis)
         if invert:
             all_tags = list(candidate_tags)
-            remove_tags = set(tag_filter(all_tags))
-            yield from (t for t in all_tags if t not in remove_tags)
+            remove_tags = {t.tag for t in tag_filter(all_tags)}
+            yield from (t for t in all_tags if t.tag not in remove_tags)
         else:
             yield from tag_filter(candidate_tags)
 

--- a/src/nublado/services/images/_base.py
+++ b/src/nublado/services/images/_base.py
@@ -2,7 +2,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-from ...models.images import ImageSource
+from ...models.images import ImageFilterPolicy, ImageSource
 
 __all__ = ["ImagesManager"]
 
@@ -26,5 +26,31 @@ class ImagesManager[T: ImageSource](metaclass=ABCMeta):
         Returns
         -------
         set of str
-            List of image tags.
+            Set of image tags.
+        """
+
+    @abstractmethod
+    async def prune_images(
+        self, config: T, policy: ImageFilterPolicy, *, dry_run: bool = True
+    ) -> list[str]:
+        """Prune the images excluded by a filter policy.
+
+        The images that are not accepted by the filter policy will be deleted,
+        at least to the extent that is possible in the target image registry.
+
+        Parameters
+        ----------
+        config
+            Configuration for the repository.
+        policy
+            Image filter policy describing what images to retain.
+        dry_run
+            If `True`, do not delete the images, only return which images
+            would be deleted.
+
+        Returns
+        -------
+        list of str
+            Tags of deleted images, or images that would be deleted if
+            ``dry_run`` is `True`, in standard sorted order.
         """

--- a/src/nublado/services/images/_docker.py
+++ b/src/nublado/services/images/_docker.py
@@ -1,10 +1,15 @@
 """Image manager implementation for the Docker API."""
 
+from datetime import UTC, datetime
 from typing import override
 
 from structlog.stdlib import BoundLogger
 
-from ...models.images import DockerSource
+from ...models.images import (
+    DockerSource,
+    ImageFilterPolicy,
+    RSPImageTagCollection,
+)
 from ...storage.docker import DockerStorageClient
 from ._base import ImagesManager
 
@@ -31,3 +36,41 @@ class DockerImagesManager(ImagesManager[DockerSource]):
     @override
     async def list_tags(self, config: DockerSource) -> set[str]:
         return await self._client.list_tags(config)
+
+    @override
+    async def prune_images(
+        self,
+        config: DockerSource,
+        policy: ImageFilterPolicy,
+        *,
+        dry_run: bool = True,
+    ) -> list[str]:
+        all_tags = await self._client.list_tags(config)
+        collection = RSPImageTagCollection.from_tag_names(all_tags)
+        to_delete = collection.filter(
+            policy,
+            datetime.now(tz=UTC),
+            invert=True,
+            remove_arch_specific=False,
+        )
+
+        # Do the deletion if desired, and build the list of images that would
+        # be deleted by tag. Deletion has to be done by digest, so we have to
+        # retrieve the digest for each tag. Do this one image at a time, since
+        # deletions don't have to be fast and that reduces the chance of being
+        # rate-limited.
+        #
+        # Some tags may be aliases, so to avoid deleting the same digest
+        # twice, keep a record of the ones that have already been processed.
+        tags = [t.tag for t in to_delete]
+        deleted = set()
+        if not dry_run:
+            for tag in tags:
+                digest = await self._client.get_image_digest(config, tag)
+                if digest in deleted:
+                    continue
+                await self._client.delete_image(config, digest)
+                deleted.add(digest)
+
+        # Return the tags that were or would have been deleted.
+        return tags

--- a/src/nublado/services/images/_gar.py
+++ b/src/nublado/services/images/_gar.py
@@ -1,10 +1,11 @@
 """Image manager implementation for the Google Artifact Registry API."""
 
+from datetime import UTC, datetime
 from typing import override
 
 from structlog.stdlib import BoundLogger
 
-from ...models.images import GARSource
+from ...models.images import GARSource, ImageFilterPolicy
 from ...storage.gar import GARStorageClient
 from ._base import ImagesManager
 
@@ -32,3 +33,32 @@ class GARImagesManager(ImagesManager[GARSource]):
     async def list_tags(self, config: GARSource) -> set[str]:
         images = await self._client.list_images(config)
         return {i.tag for i in images.all_images(hide_arch_specific=False)}
+
+    @override
+    async def prune_images(
+        self,
+        config: GARSource,
+        policy: ImageFilterPolicy,
+        *,
+        dry_run: bool = True,
+    ) -> list[str]:
+        collection = await self._client.list_images(config)
+        to_delete = collection.filter(
+            policy,
+            datetime.now(tz=UTC),
+            invert=True,
+            remove_arch_specific=False,
+        )
+
+        # Do the deletion if desired, and build the list of images that would
+        # be deleted by tag.
+        tags = []
+        digests = []
+        for image in to_delete:
+            tags.append(image.tag)
+            digests.append(image.digest)
+        if not dry_run:
+            await self._client.delete_images(config, digests)
+
+        # Return the tags that were or would have been deleted.
+        return tags

--- a/src/nublado/storage/docker.py
+++ b/src/nublado/storage/docker.py
@@ -57,6 +57,34 @@ class DockerStorageClient:
         # obtained via API calls.
         self._authorization: dict[str, str] = {}
 
+    async def delete_image(self, config: DockerSource, digest: str) -> None:
+        """Delete an image by digest.
+
+        Parameters
+        ----------
+        config
+            Configuration for the repository.
+        digest
+            Digest of image to delete.
+
+        Raises
+        ------
+        DockerError
+            Raised if unable to delete the image from the Docker registry.
+        """
+        logger = self._logger.bind(**config.to_logging_context())
+        url = config.url_for(f"manifests/{digest}")
+        headers = self._build_headers(config.registry)
+        logger.debug("Deleting image", image=digest)
+        try:
+            r = await self._client.delete(url, headers=headers)
+            if r.status_code == 401:
+                headers = await self._authenticate(config.registry, r, logger)
+                r = await self._client.delete(url, headers=headers)
+            r.raise_for_status()
+        except HTTPError as e:
+            raise DockerError.from_exception(e) from e
+
     async def get_image_digest(self, config: DockerSource, tag: str) -> str:
         """Get the digest associated with an image tag.
 
@@ -75,9 +103,9 @@ class DockerStorageClient:
         Raises
         ------
         DockerError
-            Unable to retrieve the digest from the Docker Registry.
+            Raised if unable to retrieve the digest from the Docker registry.
         """
-        logger = self._logger.bind(**config.to_logging_context())
+        logger = self._logger.bind(**config.to_logging_context(), tag=tag)
         url = config.url_for(f"manifests/{tag}")
         headers = self._build_headers(config.registry, manifest=True)
         try:
@@ -94,9 +122,7 @@ class DockerStorageClient:
             msg = f"Cannot get image digest from Docker registry: {error}"
             raise DockerError(msg, method="GET", url=url) from e
         else:
-            self._logger.debug(
-                "Retrieved image digest for tag", tag=tag, digest=digest
-            )
+            logger.debug("Retrieved image digest for tag", digest=digest)
             return digest
 
     async def list_tags(self, config: DockerSource) -> set[str]:
@@ -111,6 +137,11 @@ class DockerStorageClient:
         -------
         set of str
             All the non-platform-specific tags found for that repository.
+
+        Raises
+        ------
+        DockerError
+            Raised if unable to list tags from the Docker registry.
         """
         logger = self._logger.bind(**config.to_logging_context())
         url = config.url_for("tags/list")
@@ -182,7 +213,8 @@ class DockerStorageClient:
         Raises
         ------
         DockerError
-            Some failure in talking to the Docker registry API server.
+            Raised if there was some failure in talking to the Docker registry
+            API server.
         """
         if host in self._authorization:
             msg = f"Authentication credentials for {host} rejected"
@@ -202,7 +234,7 @@ class DockerStorageClient:
 
         if challenge_type == "basic":
             self._authorization[host] = credentials.authorization
-            logger.info(
+            logger.debug(
                 "Authenticated to Docker API with basic auth",
                 username=credentials.username,
             )
@@ -210,7 +242,7 @@ class DockerStorageClient:
             # Bearer is used by Docker's official registry.
             token = await self._get_bearer_token(host, params, logger)
             self._authorization[host] = f"Bearer {token}"
-            logger.info(
+            logger.debug(
                 "Authenticated to Docker API with bearer token",
                 username=credentials.username,
             )
@@ -272,7 +304,8 @@ class DockerStorageClient:
         Raises
         ------
         DockerError
-            Some failure in talking to the Docker registry API server.
+            Raised if there was some failure in talking to the Docker registry
+            API server.
         """
         credentials = self._credentials.get(host)
         if not credentials:
@@ -291,7 +324,7 @@ class DockerStorageClient:
         url = params["realm"]
 
         # Request a bearer token.
-        logger.info(
+        logger.debug(
             "Obtaining Docker API bearer token",
             url=url,
             username=credentials.username,

--- a/src/nublado/storage/gar.py
+++ b/src/nublado/storage/gar.py
@@ -1,13 +1,17 @@
 """Client for Google Artifact Registry."""
 
 import asyncio
+from itertools import batched
 
 from google.api_core.exceptions import InternalServerError, ServiceUnavailable
 from google.cloud import artifactregistry_v1
-from google.cloud.artifactregistry_v1 import ListDockerImagesRequest
+from google.cloud.artifactregistry_v1 import (
+    BatchDeleteVersionsRequest,
+    ListDockerImagesRequest,
+)
 from structlog.stdlib import BoundLogger
 
-from ..constants import GAR_RETRY_DELAY, GAR_RETRY_LIMIT
+from ..constants import GAR_DELETE_BATCH_SIZE, GAR_RETRY_DELAY, GAR_RETRY_LIMIT
 from ..models.images import (
     GARSource,
     RSPImage,
@@ -34,6 +38,29 @@ class GARStorageClient:
     def __init__(self, logger: BoundLogger) -> None:
         self._logger = logger
         self._client = artifactregistry_v1.ArtifactRegistryAsyncClient()
+
+    async def delete_images(
+        self, config: GARSource, digests: list[str]
+    ) -> None:
+        """Delete images by digest.
+
+        Deletion is done in batches since experimentally Google rejects
+        deletion of more than 50 images in a request.
+
+        Parameters
+        ----------
+        config
+            Configuration for the repository.
+        digests
+            List of image digests to delete.
+        """
+        logger = self._logger.bind(**config.to_logging_context())
+        parent = f"{config.parent}/packages/{config.image}"
+        names = (f"{parent}/versions/{d}" for d in digests)
+        for chunk in batched(names, GAR_DELETE_BATCH_SIZE, strict=False):
+            request = BatchDeleteVersionsRequest(parent=parent, names=chunk)
+            logger.debug("Deleting images", images=chunk)
+            await self._client.batch_delete_versions(request)
 
     async def list_images(
         self, config: GARSource, cycle: int | None = None

--- a/tests/data/images/docker.yaml
+++ b/tests/data/images/docker.yaml
@@ -1,0 +1,7 @@
+prune:
+  weekly:
+    cutoffDate: "2021-05-31"
+source:
+  type: "docker"
+  registry: "lighthouse.ceres"
+  repository: "library/sketchbook"

--- a/tests/data/images/gar.yaml
+++ b/tests/data/images/gar.yaml
@@ -1,0 +1,9 @@
+prune:
+  weekly:
+    cutoffDate: "2077-10-25"
+source:
+  type: "google"
+  location: "us-central1"
+  projectId: "rubin-shared-services-71ec"
+  repository: "sciplat"
+  image: "sciplat-lab"

--- a/tests/images/cli_test.py
+++ b/tests/images/cli_test.py
@@ -1,0 +1,182 @@
+"""Tests for the :command:`nublado images` CLI."""
+
+import os
+from typing import Any
+
+import pytest
+import respx
+from click.testing import CliRunner
+from google.cloud.artifactregistry_v1 import DockerImage
+
+from nublado.cli import main
+from nublado.models.docker import DockerCredentialStore
+from nublado.models.images import DockerSource, RSPImageTagCollection
+
+from ..support.data import NubladoData
+from ..support.docker import register_mock_docker
+from ..support.gar import MockArtifactRegistry
+
+
+@pytest.fixture
+def mock_gar_images(
+    data: NubladoData, mock_gar: MockArtifactRegistry
+) -> list[dict[str, Any]]:
+    known_images = data.read_json("registry/gar")
+    mock_gar.add_images_for_test(DockerImage(**i) for i in known_images)
+    return known_images
+
+
+def test_list_docker(data: NubladoData, respx_mock: respx.Router) -> None:
+    config_path = data.path("images/docker.yaml")
+    credential_path = data.path("registry/docker-creds.json")
+    credential_store = DockerCredentialStore.from_path(credential_path)
+    source = data.read_pydantic(DockerSource, "storage/docker-source")
+    tag_names = [
+        "w_2021_22",
+        "w_2021_22-amd64",
+        "w_2021_21",
+        "w_2021_21-arm64",
+        "w_2021_21-amd64",
+        "d_2021_06_15",
+        "d_2021_06_14-amd64",
+    ]
+    tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
+    tag_names.append("recommended")
+    tags["recommended"] = tags["w_2021_21"]
+    register_mock_docker(respx_mock, source, credential_store, tags=tags)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path), "-a", str(credential_path)],
+        catch_exceptions=False,
+    )
+    assert result.output == "\n".join(tag_names) + "\n"
+    assert result.exit_code == 0
+
+
+def test_list_gar(
+    data: NubladoData, mock_gar_images: list[dict[str, Any]]
+) -> None:
+    config_path = data.path("images/gar.yaml")
+
+    # Determine the expected tag list. Alias information is discarded by the
+    # current list implementation, so alias tags are treated as unknown and
+    # sorted last.
+    unsorted_tags = []
+    for image in mock_gar_images:
+        if "sciplat-lab" not in image["name"]:
+            continue
+        unsorted_tags.extend(image["tags"])
+    collection = RSPImageTagCollection.from_tag_names(unsorted_tags)
+    tags = [t.tag for t in collection.all_tags(hide_arch_specific=False)]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path)],
+        catch_exceptions=False,
+    )
+    assert result.output == "\n".join(tags) + "\n"
+    assert result.exit_code == 0
+
+
+def test_prune_docker(data: NubladoData, respx_mock: respx.Router) -> None:
+    config_path = data.path("images/docker.yaml")
+    credential_path = data.path("registry/docker-creds.json")
+    credential_store = DockerCredentialStore.from_path(credential_path)
+    source = data.read_pydantic(DockerSource, "storage/docker-source")
+    tag_names = [
+        "w_2021_22",
+        "w_2021_22-amd64",
+        "w_2021_21",
+        "w_2021_21-arm64",
+    ]
+    tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
+    register_mock_docker(respx_mock, source, credential_store, tags=tags)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "images",
+            "prune",
+            "-n",
+            "-c",
+            str(config_path),
+            "-a",
+            str(credential_path),
+        ],
+        catch_exceptions=False,
+    )
+    expected = "Would delete images:\n  w_2021_21\n  w_2021_21-arm64\n"
+    assert result.output == expected
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path), "-a", str(credential_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "w_2021_21" in result.output
+
+    result = runner.invoke(
+        main,
+        [
+            "images",
+            "prune",
+            "-c",
+            str(config_path),
+            "-a",
+            str(credential_path),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.output == "Deleted images:\n  w_2021_21\n  w_2021_21-arm64\n"
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path), "-a", str(credential_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "w_2021_21" not in result.output
+
+
+@pytest.mark.usefixtures("mock_gar_images")
+def test_prune_gar(data: NubladoData) -> None:
+    config_path = data.path("images/gar.yaml")
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["images", "prune", "-n", "-c", str(config_path)],
+        catch_exceptions=False,
+    )
+    assert result.output == "Would delete images:\n  w_2077_42\n  w_2077_41\n"
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "w_2077_42" in result.output
+
+    result = runner.invoke(
+        main,
+        ["images", "prune", "-c", str(config_path)],
+        catch_exceptions=False,
+    )
+    assert result.output == "Deleted images:\n  w_2077_42\n  w_2077_41\n"
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "w_2077_42" not in result.output

--- a/tests/support/docker.py
+++ b/tests/support/docker.py
@@ -97,6 +97,33 @@ class MockDockerRegistry:
         assert auth_data == auth_b64
         return Response(200, json={"token": self._token})
 
+    def delete(self, request: Request, digest: str) -> Response:
+        """Simulate the delete image route for a Docker Registry.
+
+        Parameters
+        ----------
+        request
+            Incoming request.
+        digest
+            Digest of image to delete.
+
+        Returns
+        -------
+        httpx.Response
+            Returns 202 if the request is successful.
+        """
+        if not self._check_auth(request):
+            return self._make_auth_challenge()
+        to_delete = None
+        for tag, tag_digest in self.tags.items():
+            if tag_digest == digest:
+                to_delete = tag
+                break
+        if not to_delete:
+            return Response(404)
+        del self.tags[to_delete]
+        return Response(202)
+
     def list_tags(self, request: Request) -> Response:
         """Simulate the list tags route for a Docker Registry.
 
@@ -120,61 +147,6 @@ class MockDockerRegistry:
             return self._return_paginated_response(request)
         else:
             return Response(200, json={"tags": list(self.tags.keys())})
-
-    def _return_paginated_response(self, request: Request) -> Response:
-        """Paginate the tags based on the request parameters.
-
-        Split the list of tags in half, and on first response, return the
-        first half (or slightly less, if there are an odd number of tags). and
-        when given a page parameter, return the rest.
-
-        Parameters
-        ----------
-        request
-            Incoming request.
-
-        Returns
-        -------
-            Returns 200 with the relevant portion of the tag list given the
-            request.
-
-        Notes
-        -----
-        Actual Docker registries behave differently. ghcr.io tells you the
-        last tag it gave you, you tell it that was the last one you saw on the
-        previous call, and it starts from just past there in its list when
-        giving you the next set of tags.
-
-        Docker Hub doesn't paginate tags at all, at least out to the
-        1500-ish tags range.
-
-        Nexus uses an opaque continuation token that presumably maps to a
-        checksum of some pointer into its list of tags.
-        """
-        tags = list(self.tags.keys())
-        midpoint = int(len(tags) / 2)
-
-        # The only parameter we should see is page, which must be 2 to get the
-        # second page. Any other value is incorrect.
-        if request.url.query:
-            query = parse_qs(request.url.query.decode())
-            assert query == {"page": ["2"]}
-            return Response(200, json={"tags": tags[midpoint:]})
-
-        # The request is for the first page. Do pagination. This will
-        # construct a next URL that matches the current URL plus ?page=2 and
-        # stick that in a link header.
-        url = request.url.path
-        if self._netloc_paginate:
-            if not url.startswith("/"):
-                url = "/" + url
-            url = f"https://{request.url.host}{url}"
-        if self._duplicate_url:
-            link_header = f'<{url}>; rel="next"'
-        else:
-            link_header = f'<{url}?page=2>; rel="next"'
-        result = {"tags": tags[:midpoint]}
-        return Response(200, json=result, headers={"Link": link_header})
 
     def get_digest(self, request: Request, tag: str) -> Response:
         """Simulate the image manifest route for a Docker Registry.
@@ -233,6 +205,61 @@ class MockDockerRegistry:
             challenge = f'Basic realm="{self._challenge["realm"]}"'
         return Response(401, headers={"WWW-Authenticate": challenge})
 
+    def _return_paginated_response(self, request: Request) -> Response:
+        """Paginate the tags based on the request parameters.
+
+        Split the list of tags in half, and on first response, return the
+        first half (or slightly less, if there are an odd number of tags). and
+        when given a page parameter, return the rest.
+
+        Parameters
+        ----------
+        request
+            Incoming request.
+
+        Returns
+        -------
+            Returns 200 with the relevant portion of the tag list given the
+            request.
+
+        Notes
+        -----
+        Actual Docker registries behave differently. ghcr.io tells you the
+        last tag it gave you, you tell it that was the last one you saw on the
+        previous call, and it starts from just past there in its list when
+        giving you the next set of tags.
+
+        Docker Hub doesn't paginate tags at all, at least out to the
+        1500-ish tags range.
+
+        Nexus uses an opaque continuation token that presumably maps to a
+        checksum of some pointer into its list of tags.
+        """
+        tags = list(self.tags.keys())
+        midpoint = int(len(tags) / 2)
+
+        # The only parameter we should see is page, which must be 2 to get the
+        # second page. Any other value is incorrect.
+        if request.url.query:
+            query = parse_qs(request.url.query.decode())
+            assert query == {"page": ["2"]}
+            return Response(200, json={"tags": tags[midpoint:]})
+
+        # The request is for the first page. Do pagination. This will
+        # construct a next URL that matches the current URL plus ?page=2 and
+        # stick that in a link header.
+        url = request.url.path
+        if self._netloc_paginate:
+            if not url.startswith("/"):
+                url = "/" + url
+            url = f"https://{request.url.host}{url}"
+        if self._duplicate_url:
+            link_header = f'<{url}>; rel="next"'
+        else:
+            link_header = f'<{url}?page=2>; rel="next"'
+        result = {"tags": tags[:midpoint]}
+        return Response(200, json=result, headers={"Link": link_header})
+
 
 def register_mock_docker(
     respx_mock: respx.Router,
@@ -280,6 +307,7 @@ def register_mock_docker(
     auth_url = f"{base_url}/auth"
     tags_url = f"{base_url}/v2/{config.repository}/tags/list"
     digest_url = f"{base_url}/v2/{config.repository}/manifests/(?P<tag>.*)"
+    delete_url = f"{base_url}/v2/{config.repository}/manifests/(?P<digest>.*)"
 
     credentials = credential_store.get(config.registry)
     assert credentials
@@ -296,4 +324,5 @@ def register_mock_docker(
     respx_mock.get(base_url + "/auth").mock(side_effect=mock.authenticate)
     respx_mock.get(tags_url).mock(side_effect=mock.list_tags)
     respx_mock.head(url__regex=digest_url).mock(side_effect=mock.get_digest)
+    respx_mock.delete(url__regex=delete_url).mock(side_effect=mock.delete)
     return mock

--- a/tests/support/gar.py
+++ b/tests/support/gar.py
@@ -10,6 +10,7 @@ from google.api_core.exceptions import ServiceUnavailable
 from google.cloud import artifactregistry_v1
 from google.cloud.artifactregistry_v1 import (
     ArtifactRegistryAsyncClient,
+    BatchDeleteVersionsRequest,
     DockerImage,
     ListDockerImagesRequest,
 )
@@ -44,6 +45,26 @@ class MockArtifactRegistry(Mock):
         again.
         """
         self._fail = True
+
+    async def batch_delete_versions(
+        self, request: BatchDeleteVersionsRequest
+    ) -> None:
+        """Delete images by digest.
+
+        Parameters
+        ----------
+        request
+            Image list request. Only the ``parent`` field is used.
+        """
+        parent = "/".join(request.parent.split("/")[:-2])
+        images = self._images[parent]
+        to_remove = set()
+        for name in request.names:
+            mangled_name = name.replace("packages", "dockerImages")
+            mangled_name = mangled_name.replace("/versions/", "@")
+            to_remove.add(mangled_name)
+        assert to_remove <= {i.name for i in images}
+        self._images[parent] = [i for i in images if i.name not in to_remove]
 
     async def list_docker_images(
         self, request: ListDockerImagesRequest


### PR DESCRIPTION
Add a new command-line tool, `nublado images prune`, that uses a configuration file to determine what images to prune. It supports a dry-run mode that just prints what would be deleted.

Add tests for all the `nublado images` command-line commands.