### PR TITLE
DM-54523: Merge purger config handling with top level

### DIFF
--- a/changelog.d/20260424_085937_rra_DM_54523.md
+++ b/changelog.d/20260424_085937_rra_DM_54523.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Use `NUBLADO_` as the prefix for environment variables to configure the `nublado purger` command-line tool instead of `RSP_SCRATCHPURGER_`. This brings it in line with the rest of Nublado.

--- a/src/nublado/purger/config.py
+++ b/src/nublado/purger/config.py
@@ -1,71 +1,25 @@
 """Application configuration for the purger."""
 
 from pathlib import Path
-from typing import Annotated, Self, override
+from typing import Annotated, Self
 
 import yaml
-from pydantic import AliasChoices, Field, SecretStr
-from pydantic_settings import (
-    BaseSettings,
-    PydanticBaseSettingsSource,
-    SettingsConfigDict,
-)
+from pydantic import Field, SecretStr
 from safir.logging import LogLevel, Profile, configure_logging
 from safir.pydantic import HumanTimedelta
 
-from .constants import ENV_PREFIX, POLICY_FILE, ROOT_LOGGER
+from ..config.base import CamelEnvFirstSettings
+from .constants import POLICY_FILE, ROOT_LOGGER
 
-__all__ = ["Config", "EnvFirstSettings"]
-
-
-class EnvFirstSettings(BaseSettings):
-    """Base class for Pydantic settings with environment overrides.
-
-    Classes that inherit from this base class will prioritize environment
-    variables over arguments to the class constructor.
-    """
-
-    model_config = SettingsConfigDict(
-        env_prefix=ENV_PREFIX, extra="forbid", validate_by_name=True
-    )
-
-    @override
-    @classmethod
-    def settings_customise_sources(
-        cls,
-        settings_cls: type[BaseSettings],
-        init_settings: PydanticBaseSettingsSource,
-        env_settings: PydanticBaseSettingsSource,
-        dotenv_settings: PydanticBaseSettingsSource,
-        file_secret_settings: PydanticBaseSettingsSource,
-    ) -> tuple[PydanticBaseSettingsSource, ...]:
-        """Override the sources of settings.
-
-        Deactivate :file:`.env` and secret file support, since Phalanx doesn't
-        use them. Allow environment variables to override init parameters,
-        since init parameters come from the YAML configuration file and we
-        want environment variables to take precedent.
-
-        Ideally, this code would use Pydantic's ``YamlConfigSettingsSource``,
-        but unfortunately it currently doesn't support overriding the path to
-        the configuration file dynamically, which is required by the test
-        suite.
-        """
-        return (env_settings, init_settings)
+__all__ = ["Config"]
 
 
-class Config(EnvFirstSettings):
+class Config(CamelEnvFirstSettings):
     """Configuration for the purger."""
 
-    policy_file: Annotated[
-        Path,
-        Field(
-            title="Policy file location",
-            validation_alias=AliasChoices(
-                ENV_PREFIX + "POLICY_FILE", "policyFile"
-            ),
-        ),
-    ] = POLICY_FILE
+    policy_file: Annotated[Path, Field(title="Policy file location")] = (
+        POLICY_FILE
+    )
 
     debug: Annotated[
         bool,
@@ -79,51 +33,22 @@ class Config(EnvFirstSettings):
     ] = False
 
     dry_run: Annotated[
-        bool,
-        Field(
-            title="Report rather than execute plan",
-            validation_alias=AliasChoices(ENV_PREFIX + "DRY_RUN", "dryRun"),
-        ),
+        bool, Field(title="Report rather than execute plan")
     ] = False
 
     future_duration: Annotated[
         HumanTimedelta | None,
-        Field(
-            title="Duration into the future to use for planning purposes",
-            validation_alias=AliasChoices(
-                ENV_PREFIX + "FUTURE_DURATION", "futureDuration"
-            ),
-        ),
+        Field(title="Duration into the future to use for planning purposes"),
     ] = None
 
-    log_profile: Annotated[
-        Profile,
-        Field(
-            title="Logging profile",
-            validation_alias=AliasChoices(
-                ENV_PREFIX + "LOG_PROFILE", "logProfile"
-            ),
-        ),
-    ] = Profile.production
+    log_profile: Annotated[Profile, Field(title="Logging profile")] = (
+        Profile.production
+    )
 
-    log_level: Annotated[
-        LogLevel,
-        Field(
-            title="Log level",
-            validation_alias=AliasChoices(
-                ENV_PREFIX + "LOG_LEVEL", "logLevel"
-            ),
-        ),
-    ] = LogLevel.INFO
+    log_level: Annotated[LogLevel, Field(title="Log level")] = LogLevel.INFO
 
     add_timestamp: Annotated[
-        bool,
-        Field(
-            title="Add timestamp to log lines",
-            validation_alias=AliasChoices(
-                ENV_PREFIX + "ADD_TIMESTAMP", "addTimestamp"
-            ),
-        ),
+        bool, Field(title="Add timestamp to log lines")
     ] = False
 
     alert_hook: Annotated[
@@ -133,9 +58,6 @@ class Config(EnvFirstSettings):
             description=(
                 "An https URL, which should be considered secret."
                 " If not set or set to `None`, this feature will be disabled."
-            ),
-            validation_alias=AliasChoices(
-                ENV_PREFIX + "ALERT_HOOK", "alertHook"
             ),
         ),
     ] = None

--- a/src/nublado/purger/constants.py
+++ b/src/nublado/purger/constants.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 __all__ = [
-    "ALERT_HOOK_ENV_VAR",
     "CONFIG_FILE",
     "CONFIG_FILE_ENV_VAR",
     "ENV_PREFIX",
@@ -13,7 +12,6 @@ __all__ = [
 
 CONFIG_FILE = Path("/etc/purger/config.yaml")
 ENV_PREFIX = "RSP_SCRATCHPURGER_"
-ALERT_HOOK_ENV_VAR = f"{ENV_PREFIX}ALERT_HOOK"
 CONFIG_FILE_ENV_VAR = f"{ENV_PREFIX}CONFIG_FILE"
 POLICY_FILE = Path("/etc/purger/policy.yaml")
 ROOT_LOGGER = "rsp_scratchpurger"

--- a/tests/purger/config_test.py
+++ b/tests/purger/config_test.py
@@ -1,20 +1,22 @@
 """Tests for purger configuration."""
 
-from pathlib import Path
-
 import pytest
 
 from nublado.purger.config import Config
 
+from ..support.data import NubladoData
 
-def test_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("RSP_SCRATCHPURGER_DRY_RUN", "true")
-    monkeypatch.setenv("RSP_SCRATCHPURGER_DEBUG", "true")
 
-    config_file = (
-        Path(__file__).parent.parent / "data" / "purger" / "config.yaml"
-    )
-    config = Config.from_file(config_file)
+def test_env_override(
+    data: NubladoData, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = Config.from_file(data.path("purger/config.yaml"))
+    assert not config.debug
+    assert not config.dry_run
 
+    monkeypatch.setenv("NUBLADO_DRY_RUN", "true")
+    monkeypatch.setenv("NUBLADO_DEBUG", "true")
+
+    config = Config.from_file(data.path("purger/config.yaml"))
     assert config.debug
     assert config.dry_run

--- a/tests/purger/import_test.py
+++ b/tests/purger/import_test.py
@@ -1,9 +1,0 @@
-"""Test basic module functionality."""
-
-from nublado.purger.config import Config
-from nublado.purger.purger import Purger
-
-
-def test_import(purger_config: Config) -> None:
-    p = Purger(config=purger_config)
-    assert p is not None


### PR DESCRIPTION
Use the base `CamelEnvFirstSettings` instead of a separate version for the purger and use the same environment variable prefix as the rest of Nublado. This does not (yet) change the environment variable used to override the location of the configuration file, but all other settings now use `NUBLADO_` as the prefix.