### PR TITLE
DM-54523: Add nublado images delete command

### DIFF
--- a/changelog.d/20260424_155320_rra_DM_54523.md
+++ b/changelog.d/20260424_155320_rra_DM_54523.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a new command, `nublado images delete`, to delete specific images by tag.

--- a/src/nublado/cli.py
+++ b/src/nublado/cli.py
@@ -114,6 +114,46 @@ def images() -> None:
     """Commands to manage Docker images."""
 
 
+@images.command("delete")
+@click.argument("tags", nargs=-1)
+@click.option(
+    "-a",
+    "--credentials",
+    "docker_credentials_path",
+    type=click.Path(path_type=Path),
+    help="Path to Docker API credentials.",
+)
+@click.option(
+    "-c",
+    "--config",
+    "config_path",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Path to images configuration.",
+)
+@click.option(
+    "--debug", "-d", is_flag=True, envvar="DEBUG", help="Enable debug logging"
+)
+@run_with_asyncio
+async def images_delete(
+    tags: tuple[str],
+    *,
+    docker_credentials_path: Path | None = None,
+    config_path: Path,
+    debug: bool,
+) -> None:
+    """List the available images."""
+    config = ImagesConfig.from_file(
+        config_path,
+        docker_credentials_path=docker_credentials_path,
+        debug=debug,
+    )
+    config.configure_logging()
+    async with ImagesFactory.standalone(config) as factory:
+        manager = factory.create_images_manager()
+        await manager.delete_tags(config.source, tags)
+
+
 @images.command("list")
 @click.option(
     "-a",

--- a/src/nublado/services/images/_base.py
+++ b/src/nublado/services/images/_base.py
@@ -1,6 +1,7 @@
 """Shared API for images managers."""
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterable
 
 from ...models.images import ImageFilterPolicy, ImageSource
 
@@ -13,6 +14,23 @@ class ImagesManager[T: ImageSource](metaclass=ABCMeta):
     There are separate implementations of the images manager API for each
     image source. This class provides the common API.
     """
+
+    @abstractmethod
+    async def delete_tags(self, config: T, tags: Iterable[str]) -> None:
+        """Delete the given tags.
+
+        The underlying image will be deleted, even if the image also has other
+        tags, so this will also delete other tags attached to the same image.
+        Use with caution for images that may be tagged with ``recommended`` or
+        other alias tags.
+
+        Parameters
+        ----------
+        config
+            Configuration for the repository.
+        tags
+            Tags to delete.
+        """
 
     @abstractmethod
     async def list_tags(self, config: T) -> set[str]:

--- a/src/nublado/services/images/_docker.py
+++ b/src/nublado/services/images/_docker.py
@@ -1,5 +1,6 @@
 """Image manager implementation for the Docker API."""
 
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import override
 
@@ -32,6 +33,14 @@ class DockerImagesManager(ImagesManager[DockerSource]):
     ) -> None:
         self._client = docker_client
         self._logger = logger
+
+    @override
+    async def delete_tags(
+        self, config: DockerSource, tags: Iterable[str]
+    ) -> None:
+        for tag in tags:
+            digest = await self._client.get_image_digest(config, tag)
+            await self._client.delete_image(config, digest)
 
     @override
     async def list_tags(self, config: DockerSource) -> set[str]:

--- a/src/nublado/services/images/_gar.py
+++ b/src/nublado/services/images/_gar.py
@@ -1,5 +1,6 @@
 """Image manager implementation for the Google Artifact Registry API."""
 
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import override
 
@@ -28,6 +29,18 @@ class GARImagesManager(ImagesManager[GARSource]):
     ) -> None:
         self._client = gar_client
         self._logger = logger
+
+    @override
+    async def delete_tags(
+        self, config: GARSource, tags: Iterable[str]
+    ) -> None:
+        images = await self._client.list_images(config)
+        digests = []
+        for tag in tags:
+            image = images.image_for_tag_name(tag)
+            if image:
+                digests.append(image.digest)
+        await self._client.delete_images(config, digests)
 
     @override
     async def list_tags(self, config: GARSource) -> set[str]:

--- a/src/nublado/storage/docker.py
+++ b/src/nublado/storage/docker.py
@@ -111,7 +111,8 @@ class DockerStorageClient:
         try:
             r = await self._client.head(url, headers=headers)
             if r.status_code == 401:
-                headers = await self._authenticate(config.registry, r, logger)
+                await self._authenticate(config.registry, r, logger)
+                headers = self._build_headers(config.registry, manifest=True)
                 r = await self._client.head(url, headers=headers)
             r.raise_for_status()
             digest = r.headers["Docker-Content-Digest"]

--- a/tests/images/cli_test.py
+++ b/tests/images/cli_test.py
@@ -13,24 +13,26 @@ from nublado.models.docker import DockerCredentialStore
 from nublado.models.images import DockerSource, RSPImageTagCollection
 
 from ..support.data import NubladoData
-from ..support.docker import register_mock_docker
+from ..support.docker import MockDockerRegistry, register_mock_docker
 from ..support.gar import MockArtifactRegistry
 
 
 @pytest.fixture
-def mock_gar_images(
-    data: NubladoData, mock_gar: MockArtifactRegistry
-) -> list[dict[str, Any]]:
-    known_images = data.read_json("registry/gar")
-    mock_gar.add_images_for_test(DockerImage(**i) for i in known_images)
-    return known_images
-
-
-def test_list_docker(data: NubladoData, respx_mock: respx.Router) -> None:
-    config_path = data.path("images/docker.yaml")
+def mock_docker(
+    data: NubladoData,
+    mock_docker_images: dict[str, str],
+    respx_mock: respx.Router,
+) -> MockDockerRegistry:
     credential_path = data.path("registry/docker-creds.json")
     credential_store = DockerCredentialStore.from_path(credential_path)
     source = data.read_pydantic(DockerSource, "storage/docker-source")
+    return register_mock_docker(
+        respx_mock, source, credential_store, tags=mock_docker_images
+    )
+
+
+@pytest.fixture
+def mock_docker_images() -> dict[str, str]:
     tag_names = [
         "w_2021_22",
         "w_2021_22-amd64",
@@ -42,8 +44,25 @@ def test_list_docker(data: NubladoData, respx_mock: respx.Router) -> None:
     ]
     tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
     tag_names.append("recommended")
-    tags["recommended"] = tags["w_2021_21"]
-    register_mock_docker(respx_mock, source, credential_store, tags=tags)
+    tags["recommended"] = tags["w_2021_22"]
+    return tags
+
+
+@pytest.fixture
+def mock_gar_images(
+    data: NubladoData, mock_gar: MockArtifactRegistry
+) -> list[dict[str, Any]]:
+    known_images = data.read_json("registry/gar")
+    mock_gar.add_images_for_test(DockerImage(**i) for i in known_images)
+    return known_images
+
+
+@pytest.mark.usefixtures("mock_docker")
+def test_delete_docker(
+    mock_docker_images: dict[str, str], data: NubladoData
+) -> None:
+    config_path = data.path("images/docker.yaml")
+    credential_path = data.path("registry/docker-creds.json")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -51,7 +70,77 @@ def test_list_docker(data: NubladoData, respx_mock: respx.Router) -> None:
         ["images", "list", "-c", str(config_path), "-a", str(credential_path)],
         catch_exceptions=False,
     )
-    assert result.output == "\n".join(tag_names) + "\n"
+    assert result.exit_code == 0
+    assert "w_2021_22" in result.output
+
+    result = runner.invoke(
+        main,
+        [
+            "images",
+            "delete",
+            "-c",
+            str(config_path),
+            "-a",
+            str(credential_path),
+            *[i for i in mock_docker_images if i.startswith("w_2021_22")],
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path), "-a", str(credential_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "w_2021_22" not in result.output
+
+
+def test_delete_gar(
+    data: NubladoData, mock_gar_images: list[dict[str, Any]]
+) -> None:
+    config_path = data.path("images/gar.yaml")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "w_2077_42" in result.output
+
+    result = runner.invoke(
+        main,
+        ["images", "delete", "-c", str(config_path), "w_2077_42"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "w_2077_42" not in result.output
+
+
+@pytest.mark.usefixtures("mock_docker")
+def test_list_docker(
+    mock_docker_images: dict[str, str], data: NubladoData
+) -> None:
+    config_path = data.path("images/docker.yaml")
+    credential_path = data.path("registry/docker-creds.json")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["images", "list", "-c", str(config_path), "-a", str(credential_path)],
+        catch_exceptions=False,
+    )
+    assert result.output == "\n".join(mock_docker_images.keys()) + "\n"
     assert result.exit_code == 0
 
 
@@ -81,19 +170,14 @@ def test_list_gar(
     assert result.exit_code == 0
 
 
-def test_prune_docker(data: NubladoData, respx_mock: respx.Router) -> None:
+@pytest.mark.usefixtures("mock_docker")
+def test_prune_docker(
+    data: NubladoData,
+    mock_docker_images: dict[str, str],
+    respx_mock: respx.Router,
+) -> None:
     config_path = data.path("images/docker.yaml")
     credential_path = data.path("registry/docker-creds.json")
-    credential_store = DockerCredentialStore.from_path(credential_path)
-    source = data.read_pydantic(DockerSource, "storage/docker-source")
-    tag_names = [
-        "w_2021_22",
-        "w_2021_22-amd64",
-        "w_2021_21",
-        "w_2021_21-arm64",
-    ]
-    tags = {t: "sha256:" + os.urandom(32).hex() for t in tag_names}
-    register_mock_docker(respx_mock, source, credential_store, tags=tags)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -109,7 +193,8 @@ def test_prune_docker(data: NubladoData, respx_mock: respx.Router) -> None:
         ],
         catch_exceptions=False,
     )
-    expected = "Would delete images:\n  w_2021_21\n  w_2021_21-arm64\n"
+    to_delete = [i for i in mock_docker_images if i.startswith("w_2021_21")]
+    expected = "Would delete images:\n  " + "\n  ".join(to_delete) + "\n"
     assert result.output == expected
     assert result.exit_code == 0
 
@@ -133,7 +218,8 @@ def test_prune_docker(data: NubladoData, respx_mock: respx.Router) -> None:
         ],
         catch_exceptions=False,
     )
-    assert result.output == "Deleted images:\n  w_2021_21\n  w_2021_21-arm64\n"
+    expected = "Deleted images:\n  " + "\n  ".join(to_delete) + "\n"
+    assert result.output == expected
     assert result.exit_code == 0
 
     result = runner.invoke(


### PR DESCRIPTION
Add support for deleting specific images from the command line. This is rather inefficient, but this sort of manual operation should be rare.