### PR TITLE
DM-54523: Add build number filtering

### DIFF
--- a/changelog.d/20260424_162623_rra_DM_54523.md
+++ b/changelog.d/20260424_162623_rra_DM_54523.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a new `cutoffBuild` attribute for dropdown menu filtering, used to restrict display of images with build numbers to only those with larger or equal build numbers. Images without build numbers are ignored.

--- a/src/nublado/models/images/_filter.py
+++ b/src/nublado/models/images/_filter.py
@@ -63,6 +63,18 @@ class ImageFilter(BaseModel):
         ),
     ] = None
 
+    cutoff_build: Annotated[
+        int | None,
+        Field(
+            title="Cutoff build number",
+            description=(
+                "Minimum build number for images containing a build number."
+                " If the image tag has no build number, this constraint is"
+                " ignored."
+            ),
+        ),
+    ] = None
+
     cutoff_date: Annotated[
         UtcDatetime | None,
         Field(

--- a/src/nublado/models/images/_tag.py
+++ b/src/nublado/models/images/_tag.py
@@ -720,6 +720,7 @@ class RSPImageTagCollection[T: RSPImageTag]:
             version of those tags.
         """
         date = (age_basis - policy.age) if policy.age else None
+        build = policy.cutoff_build
         if policy.cutoff_date and (not date or date < policy.cutoff_date):
             date = policy.cutoff_date
         version = policy.cutoff_version
@@ -729,6 +730,8 @@ class RSPImageTagCollection[T: RSPImageTag]:
             count = 0
             for tag in tags:
                 if remove_arch_specific and tag.architecture:
+                    continue
+                if tag.rsp_build and build and tag.rsp_build < build:
                     continue
                 if tag.date and date and tag.date < date:
                     continue

--- a/tests/models/images/filter_test.py
+++ b/tests/models/images/filter_test.py
@@ -17,6 +17,8 @@ def test_filter() -> None:
     tags = [
         "recommended",
         "recommended-amd64",
+        "r29_2_1_rsp2742",
+        "r29_2_1_rsp2332",
         "r28_0_1",
         "r28_0_1-amd64",
         "r28_0_0",
@@ -48,13 +50,15 @@ def test_filter() -> None:
     recommended = {"recommended", "recommended-amd64"}
     collection = RSPImageTagCollection.from_tag_names(tags, recommended)
 
-    # Create image policy. This should return three releases, two weeklies,
-    # two dailies (due to the age policy; the number policy will have no
-    # effect), one release candidate (from the number policy, version will
-    # have no effect), and one experimental.
+    # Create image policy. This should return four releases (dropping one due
+    # to the RSP build restriction and another due to the version
+    # restriction), two weeklies, two dailies (due to the age policy; the
+    # number policy will have no effect), one release candidate (from the
+    # number policy, version will have no effect), and one experimental.
     policy = ImageFilterPolicy(
         release=ImageFilter(
-            cutoff_version=Version(major=27, minor=0, patch=0)
+            cutoff_build=2600,
+            cutoff_version=Version(major=27, minor=0, patch=0),
         ),
         weekly=ImageFilter(age=timedelta(weeks=2)),
         daily=ImageFilter(age=timedelta(days=2), number=4),
@@ -69,6 +73,7 @@ def test_filter() -> None:
     filtered_tags = [x.tag for x in collection.filter(policy, age_basis)]
     assert filtered_tags == [
         "recommended",
+        "r29_2_1_rsp2742",
         "r28_0_1",
         "r28_0_0",
         "r27_0_0",
@@ -102,6 +107,7 @@ def test_filter() -> None:
     assert filtered_tags == [
         "recommended",
         "recommended-amd64",
+        "r29_2_1_rsp2742",
         "r28_0_1",
         "r28_0_1-amd64",
         "r28_0_0",


### PR DESCRIPTION
Add a new `cutoffBuild` attribute for dropdown menu filtering and image pruning, used to prune or restrict display of images with build numbers to only those with larger or equal build numbers. Images without build numbers are ignored.