### PR TITLE
DM-54523: Rename rsp_build in tags to build

### DIFF
--- a/src/nublado/models/images/_tag.py
+++ b/src/nublado/models/images/_tag.py
@@ -42,7 +42,7 @@ _UNKNOWN_WITH_CYCLE = r"(?P<tag>.*?)_c(?P<cycle>\d+)"
 # c0020.002
 _CYCLE = r"(?:_c(?P<cycle>\d+)\.(?P<cbuild>\d+))?"
 # rsp19
-_RSP = r"(?:_rsp(?P<rspbuild>\d+))?"
+_RSP = r"(?:_rsp(?P<build>\d+))?"
 # _whatever_your_heart_desires (non-greedy since architecture may follow)
 _REST = r"(?:_(?P<rest>.+?))?"
 # -amd64 or -arm64
@@ -121,7 +121,7 @@ class RSPImageTag:
     cycle_build: int | None = None
     """XML schema build number (only for T&S builds)."""
 
-    rsp_build: int | None = None
+    build: int | None = None
     """Version number of the RSP build machinery."""
 
     architecture: str | None = None
@@ -237,7 +237,7 @@ class RSPImageTag:
             "base": self.base,
             "cycle": self.cycle,
             "cycle_build": self.cycle_build,
-            "rsp_build": self.rsp_build,
+            "build": self.build,
             "architecture": self.architecture,
             "extra": self.extra,
             "date": format_datetime_for_logging(self.date),
@@ -267,7 +267,7 @@ class RSPImageTag:
         base = None
         cycle = data.get("cycle")
         cycle_build = data.get("cbuild")
-        rsp_build = data.get("rspbuild")
+        build = data.get("build")
         extra = data.get("rest")
         architecture = data.get("arch")
 
@@ -305,8 +305,8 @@ class RSPImageTag:
                 display_name += f" (SAL Cycle {cycle}, Build {cycle_build})"
             else:
                 display_name += f" (SAL Cycle {cycle})"
-        if rsp_build is not None:
-            display_name += f" (RSP Build {rsp_build})"
+        if build is not None:
+            display_name += f" (RSP Build {build})"
         if extra:
             display_name += f" [{extra}]"
         if architecture:
@@ -322,7 +322,7 @@ class RSPImageTag:
             base=base,
             cycle=int(cycle) if cycle else None,
             cycle_build=int(cycle_build) if cycle_build else None,
-            rsp_build=int(rsp_build) if rsp_build else None,
+            build=int(build) if build else None,
             architecture=architecture,
             extra=extra,
             date=cls._calculate_date(data),
@@ -448,7 +448,7 @@ class RSPImageTag:
             return rank
         if rank := self._compare_int(self.cycle_build, other.cycle_build):
             return rank
-        if rank := self._compare_int(self.rsp_build, other.rsp_build):
+        if rank := self._compare_int(self.build, other.build):
             return rank
         if rank := self._compare_str(self.extra, other.extra):
             return rank
@@ -731,7 +731,7 @@ class RSPImageTagCollection[T: RSPImageTag]:
             for tag in tags:
                 if remove_arch_specific and tag.architecture:
                     continue
-                if tag.rsp_build and build and tag.rsp_build < build:
+                if tag.build and build and tag.build < build:
                     continue
                 if tag.date and date and tag.date < date:
                     continue

--- a/tests/data/controller/rspimagetag/d_2021_05_27.json
+++ b/tests/data/controller/rspimagetag/d_2021_05_27.json
@@ -7,7 +7,7 @@
   "display_name": "Daily 2021_05_27",
   "extra": null,
   "image_type": "Daily",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "d_2021_05_27",
   "version": {

--- a/tests/data/controller/rspimagetag/exp_random.json
+++ b/tests/data/controller/rspimagetag/exp_random.json
@@ -7,7 +7,7 @@
   "display_name": "Experimental random",
   "extra": null,
   "image_type": "Experimental",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "exp_random",
   "version": null

--- a/tests/data/controller/rspimagetag/exp_random_c0027-amd64.json
+++ b/tests/data/controller/rspimagetag/exp_random_c0027-amd64.json
@@ -7,7 +7,7 @@
   "display_name": "Experimental random (SAL Cycle 0027) [amd64]",
   "extra": null,
   "image_type": "Experimental",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "exp_random_c0027-amd64",
   "version": null

--- a/tests/data/controller/rspimagetag/exp_w_2021_22_c0020.001_rsp19_foo-amd64.json
+++ b/tests/data/controller/rspimagetag/exp_w_2021_22_c0020.001_rsp19_foo-amd64.json
@@ -7,7 +7,7 @@
   "display_name": "Experimental Weekly 2021_22 (SAL Cycle 0020, Build 001) (RSP Build 19) [foo] [amd64]",
   "extra": "foo",
   "image_type": "Experimental",
-  "rsp_build": 19,
+  "build": 19,
   "semantic": false,
   "tag": "exp_w_2021_22_c0020.001_rsp19_foo-amd64",
   "version": {

--- a/tests/data/controller/rspimagetag/latest-amd64.json
+++ b/tests/data/controller/rspimagetag/latest-amd64.json
@@ -7,7 +7,7 @@
   "display_name": "latest [amd64]",
   "extra": null,
   "image_type": "Unknown",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "latest-amd64",
   "version": null

--- a/tests/data/controller/rspimagetag/latest_c0027-amd64.json
+++ b/tests/data/controller/rspimagetag/latest_c0027-amd64.json
@@ -7,7 +7,7 @@
   "display_name": "latest (SAL Cycle 0027) [amd64]",
   "extra": null,
   "image_type": "Unknown",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "latest_c0027-amd64",
   "version": null

--- a/tests/data/controller/rspimagetag/not_a_normal_format.json
+++ b/tests/data/controller/rspimagetag/not_a_normal_format.json
@@ -7,7 +7,7 @@
   "display_name": "not_a_normal_format",
   "extra": null,
   "image_type": "Unknown",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "not_a_normal_format",
   "version": null

--- a/tests/data/controller/rspimagetag/r21_0_1.json
+++ b/tests/data/controller/rspimagetag/r21_0_1.json
@@ -7,7 +7,7 @@
   "display_name": "Release r21.0.1",
   "extra": null,
   "image_type": "Release",
-  "rsp_build": null,
+  "build": null,
   "semantic": true,
   "tag": "r21_0_1",
   "version": {

--- a/tests/data/controller/rspimagetag/r22_0_0_rc1.json
+++ b/tests/data/controller/rspimagetag/r22_0_0_rc1.json
@@ -7,7 +7,7 @@
   "display_name": "Release Candidate r22.0.0-rc1",
   "extra": null,
   "image_type": "Release Candidate",
-  "rsp_build": null,
+  "build": null,
   "semantic": true,
   "tag": "r22_0_0_rc1",
   "version": {

--- a/tests/data/controller/rspimagetag/recommended.json
+++ b/tests/data/controller/rspimagetag/recommended.json
@@ -7,7 +7,7 @@
   "display_name": "recommended",
   "extra": null,
   "image_type": "Unknown",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "recommended",
   "version": null

--- a/tests/data/controller/rspimagetag/recommended_c0027-arm64.json
+++ b/tests/data/controller/rspimagetag/recommended_c0027-arm64.json
@@ -7,7 +7,7 @@
   "display_name": "recommended (SAL Cycle 0027) [arm64]",
   "extra": null,
   "image_type": "Unknown",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "recommended_c0027-arm64",
   "version": null

--- a/tests/data/controller/rspimagetag/recommended_c0027.json
+++ b/tests/data/controller/rspimagetag/recommended_c0027.json
@@ -7,7 +7,7 @@
   "display_name": "recommended (SAL Cycle 0027)",
   "extra": null,
   "image_type": "Unknown",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "recommended_c0027",
   "version": null

--- a/tests/data/controller/rspimagetag/w_2021_22.json
+++ b/tests/data/controller/rspimagetag/w_2021_22.json
@@ -7,7 +7,7 @@
   "display_name": "Weekly 2021_22",
   "extra": null,
   "image_type": "Weekly",
-  "rsp_build": null,
+  "build": null,
   "semantic": false,
   "tag": "w_2021_22",
   "version": {

--- a/tests/data/controller/rspimagetag/w_2021_22_rsp19-arm64.json
+++ b/tests/data/controller/rspimagetag/w_2021_22_rsp19-arm64.json
@@ -7,7 +7,7 @@
   "display_name": "Weekly 2021_22 (RSP Build 19) [arm64]",
   "extra": null,
   "image_type": "Weekly",
-  "rsp_build": 19,
+  "build": 19,
   "semantic": false,
   "tag": "w_2021_22_rsp19-arm64",
   "version": {

--- a/tests/models/images/image_test.py
+++ b/tests/models/images/image_test.py
@@ -45,7 +45,7 @@ def test_image() -> None:
         "base": None,
         "cycle": None,
         "cycle_build": None,
-        "rsp_build": None,
+        "build": None,
         "architecture": None,
         "extra": None,
         "date": datetime(2077, 10, 23, tzinfo=UTC),
@@ -143,7 +143,7 @@ def test_resolve_alias_arch() -> None:
         tag=RSPImageTag.from_str("r21_0_2_rsp64_stuff-amd64"),
         digest="sha256:1234",
     )
-    assert image.rsp_build == 64
+    assert image.build == 64
     assert image.architecture == "amd64"
 
     latest = RSPImage.from_tag(

--- a/tests/models/images/tag_test.py
+++ b/tests/models/images/tag_test.py
@@ -86,7 +86,7 @@ def test_alias() -> None:
         "semantic": False,
         "cycle": None,
         "cycle_build": None,
-        "rsp_build": None,
+        "build": None,
         "architecture": None,
         "extra": None,
         "date": None,
@@ -103,7 +103,7 @@ def test_alias() -> None:
         "semantic": False,
         "cycle": 46,
         "cycle_build": None,
-        "rsp_build": None,
+        "build": None,
         "architecture": None,
         "extra": None,
         "date": None,
@@ -120,7 +120,7 @@ def test_alias() -> None:
         "semantic": False,
         "cycle": None,
         "cycle_build": None,
-        "rsp_build": None,
+        "build": None,
         "architecture": "amd64",
         "extra": None,
         "date": None,
@@ -135,7 +135,7 @@ def test_alias() -> None:
         "semantic": False,
         "cycle": 46,
         "cycle_build": None,
-        "rsp_build": None,
+        "build": None,
         "architecture": "arm64",
         "extra": None,
         "date": None,
@@ -264,7 +264,7 @@ def test_from_str(data: NubladoData) -> None:
         "semantic": False,
         "cycle": None,
         "cycle_build": None,
-        "rsp_build": None,
+        "build": None,
         "architecture": None,
         "extra": None,
         "date": None,
@@ -278,7 +278,7 @@ def test_from_str(data: NubladoData) -> None:
         "semantic": False,
         "cycle": None,
         "cycle_build": None,
-        "rsp_build": None,
+        "build": None,
         "architecture": None,
         "extra": None,
         "date": None,
@@ -290,7 +290,7 @@ def test_from_str(data: NubladoData) -> None:
 )
 @pytest.mark.parametrize("experimental", [True, False])
 @pytest.mark.parametrize("cycle", [None, ("0020", "001")])
-@pytest.mark.parametrize("rsp_build", [None, 19])
+@pytest.mark.parametrize("build", [None, 19])
 @pytest.mark.parametrize("extra", [None, "20210527", "random"])
 @pytest.mark.parametrize("architecture", [None, "amd64"])
 def test_from_str_varient(
@@ -300,7 +300,7 @@ def test_from_str_varient(
     experimental: bool,
     cycle: tuple[str, str] | None,
     extra: str | None,
-    rsp_build: int | None,
+    build: int | None,
     architecture: str | None,
 ) -> None:
     """Test all the variations of each tag.
@@ -322,10 +322,10 @@ def test_from_str_varient(
         expected["cycle_build"] = int(cycle[1])
         extra_display = f" (SAL Cycle {cycle[0]}, Build {cycle[1]})"
         expected["display_name"] += extra_display
-    if rsp_build:
-        tag += f"_rsp{rsp_build}"
-        expected["display_name"] += f" (RSP Build {rsp_build})"
-        expected["rsp_build"] = rsp_build
+    if build:
+        tag += f"_rsp{build}"
+        expected["display_name"] += f" (RSP Build {build})"
+        expected["build"] = build
     if extra:
         tag += f"_{extra}"
         expected["display_name"] += f" [{extra}]"


### PR DESCRIPTION
Rename the `rsp_build` field to `build`. The class is already called `RSPImageTag`, so the RSP part is implicit, and this is the build number of the image, so the extra `rsp_` was redundant.