### PR TITLE
DM-54523: Prepare 13.0.0 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ repos:
     rev: 1.20.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==25.9.0]
+        additional_dependencies: [black==26.3.1]
         args: [-l, '79', -t, py313]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-13.0.0'></a>
+## 13.0.0 (2026-04-27)
+
+### Backwards-incompatible changes
+
+- Rename the `Rubin` menu to `Jobs` in the standard extensions installed in the JupyterLab base image. Beneath that, rename `Query` to `TAP Query`. This menu now separates jobs by dataset, although jobs may be listed under multiple datasets if the extension cannot determine what dataset that job was querying.
+- Change the default runtime mount location to `/etc/nublado` from `/opt/lsst/software/jupyterlab`. This change should be invisible to users since all code that relies on its location should be using the `NUBLADO_RUNTIME_MOUNTS_DIR` environment variable to find it.
+- Stop creating an `.access_token` symlink in the user's home directory to the injected Gafaelfawr access token. The lsst.rsp library, which should be used by most payloads, knows how to find the access token, and other languages should use the `NUBLADO_TOKEN` environment variable.
+- Semantic version filters in the dropdown menu are no longer supported for weekly and daily images. Switching between calendar versions and semantic versions for `cutoffVersion` was potentially confusing.
+- Use `NUBLADO_` as the prefix for environment variables to configure the `nublado purger` command-line tool instead of `RSP_SCRATCHPURGER_`. This brings it in line with the rest of Nublado.
+
+### New features
+
+- Add a new command, `nublado images list`, to list the available Nublado image tags given an image source configuration.
+- Add a new command, `nublado images prune`, to delete some Nublado images from a repository based on a pruning policy.
+- Add a new command, `nublado images delete`, to delete specific images by tag.
+- Provide the lab's Gafaelfawr token in the `NUBLADO_TOKEN` environment variable as well as the `ACCESS_TOKEN` environment variable. The latter will eventually be deprecated.
+- Add a new `cutoffDate` attribute for dropdown menu filtering, used to restrict display of daily and weekly images to only those after a given date. Filtering of experimental images can now be done with both `cutoffVersion` and `cutoffDate`, with the former applying to the semantic version of experimental builds based on releases and release candidates and the latter applying to builds based on weeklies and dailies.
+- Add a new `cutoffBuild` attribute for dropdown menu filtering, used to restrict display of images with build numbers to only those with larger or equal build numbers. Images without build numbers are ignored.
+
+### Bug fixes
+
+- Restore lab startup code to increase log output limits. This was accidentally dropped as part of the init container changes.
+- Retry Google Artifact Registry requests on internal service errors as well as service unavailable errors. These errors also seem to be transitory problems with the Google API.
+
+### Other changes
+
+- Relax the dependency on Safir in rubin.nublado.client to allow Safir 15.0.0.
+
 <a id='changelog-12.1.0'></a>
 ## 12.1.0 (2026-03-27)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.14.3-slim-trixie AS base-image
+FROM python:3.14.4-slim-trixie AS base-image
 
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /bin/uv

--- a/Dockerfile.jupyterlab-base
+++ b/Dockerfile.jupyterlab-base
@@ -1,4 +1,4 @@
-FROM python:3.14.3-slim-trixie AS base-image
+FROM python:3.14.4-slim-trixie AS base-image
 
 USER root
 SHELL ["/bin/bash", "-lc"]

--- a/changelog.d/20260327_101637_rra_DM_54440.md
+++ b/changelog.d/20260327_101637_rra_DM_54440.md
@@ -1,7 +1,0 @@
-### Backwards-incompatible changes
-
-- Change the default runtime mount location to `/etc/nublado` from `/opt/lsst/software/jupyterlab`. This change should be invisible to users since all code that relies on its location should be using the `NUBLADO_RUNTIME_MOUNTS_DIR` environment variable to find it.
-
-### New features
-
-- Provide the lab's Gafaelfawr token in the `NUBLADO_TOKEN` environment variable as well as the `ACCESS_TOKEN` environment variable. The latter will eventually be deprecated.

--- a/changelog.d/20260327_160336_rra_DM_54440.md
+++ b/changelog.d/20260327_160336_rra_DM_54440.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Restore lab startup code to create a symlink to the user's token and increase log output limits. This was accidentally dropped as part of the init container changes.

--- a/changelog.d/20260408_163342_rra_DM_54523_queue.md
+++ b/changelog.d/20260408_163342_rra_DM_54523_queue.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add a new command, `nublado images list`, to list the available Nublado image tags given an image source configuration.

--- a/changelog.d/20260410_161057_rra_DM_54523.md
+++ b/changelog.d/20260410_161057_rra_DM_54523.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Relax the dependency on Safir in rubin.nublado.client to allow Safir 15.0.0.

--- a/changelog.d/20260410_164147_rra_DM_54523_queue.md
+++ b/changelog.d/20260410_164147_rra_DM_54523_queue.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Retry Google Artifact Registry requests on internal service errors as well as service unavailable errors. These errors also seem to be transitory problems with the Google API.

--- a/changelog.d/20260420_145215_rra_DM_54523.md
+++ b/changelog.d/20260420_145215_rra_DM_54523.md
@@ -1,3 +1,0 @@
-### Backwards-incompatible changes
-
-- Stop creating an `.access_token` symlink in the user's home directory to the injected Gafaelfawr access token. The lsst.rsp library, which should be used by most payloads, knows how to find the access token, and other languages should use the `NUBLADO_TOKEN` environment variable.

--- a/changelog.d/20260421_142359_rra_DM_54523.md
+++ b/changelog.d/20260421_142359_rra_DM_54523.md
@@ -1,7 +1,0 @@
-### Backwards-incompatible changes
-
-- Semantic version filters in the dropdown menu are no longer supported for weekly and daily images. Switching between calendar versions and semantic versions for `cutoffVersion` was potentially confusing.
-
-### New features
-
-- Add a new `cutoffDate` attribute for dropdown menu filtering, used to restrict display of daily and weekly images to only those after a given date. Filtering of experimental images can now be done with both `cutoffVersion` and `cutoffDate`, with the former applying to the semantic version of experimental builds based on releases and release candidates and the latter applying to builds based on weeklies and dailies.

--- a/changelog.d/20260423_160022_rra_DM_54523.md
+++ b/changelog.d/20260423_160022_rra_DM_54523.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add a new command, `nublado images prune`, to delete some Nublado images from a repository based on a pruning policy.

--- a/changelog.d/20260424_085937_rra_DM_54523.md
+++ b/changelog.d/20260424_085937_rra_DM_54523.md
@@ -1,3 +1,0 @@
-### Backwards-incompatible changes
-
-- Use `NUBLADO_` as the prefix for environment variables to configure the `nublado purger` command-line tool instead of `RSP_SCRATCHPURGER_`. This brings it in line with the rest of Nublado.

--- a/changelog.d/20260424_155320_rra_DM_54523.md
+++ b/changelog.d/20260424_155320_rra_DM_54523.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add a new command, `nublado images delete`, to delete specific images by tag.

--- a/changelog.d/20260424_162623_rra_DM_54523.md
+++ b/changelog.d/20260424_162623_rra_DM_54523.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add a new `cutoffBuild` attribute for dropdown menu filtering, used to restrict display of images with build numbers to only those with larger or equal build numbers. Images without build numbers are ignored.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -38,6 +38,8 @@ nitpick_ignore = [
     ["py:class", "pathlib._local.Path"],
     # Bug in Sphinx with type declarations
     ["py:class", "safir.pydantic._types.TypeAliasType"],
+    # Bug in Sphinx with Python 3.14
+    ["py:data", "typing.Union"]
 ]
 nitpick_ignore_regex = [
     ["py:class", "kubernetes_asyncio\\.client\\.models\\..*"],
@@ -49,7 +51,7 @@ python_api_dir = "dev/api/contents"
 
 [sphinx.intersphinx.projects]
 jupyerhub = "https://jupyterhub.readthedocs.io/en/stable"
-python = "https://docs.python.org/3.13"  # Union gets weird in 3.14
+python = "https://docs.python.org/3.14"
 rubin-gafaelfawr = "https://gafaelfawr.lsst.io"
 rubin-repertoire = "https://repertoire.lsst.io"
 safir = "https://safir.lsst.io"


### PR DESCRIPTION
Collect the change log for the 13.0.0 release. Update the base version for the Docker images to Python 3.14.4. Update the version of blacken-docs. Point to the Python 3.14 documentation for generated documentation links.