### PR TITLE
DM-54797: Restore pre-commit hooks repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
-  - repo: builtin
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 ### Other changes
 
 - Relax the dependency on Safir in rubin.nublado.client to allow Safir 15.0.0.
+- Switch to [prek](https://prek.j178.dev/) for pre-commit checks during development.
 
 <a id='changelog-12.1.0'></a>
 ## 12.1.0 (2026-03-27)


### PR DESCRIPTION
Change the pre-commit hooks repository back to the standard pre-commit repository and rely on prek magic to use the built-ins instead of using the builtin repository explicitly. This provides backwards compatibility with pre-commit.

Add a retroactive changelog entry about prek to 13.0.0.